### PR TITLE
issue-25: Add jq dependency check to beacon-init.sh

### DIFF
--- a/BEACON_RESULT.md
+++ b/BEACON_RESULT.md
@@ -1,0 +1,24 @@
+# Result: #25 — Add jq dependency check to beacon-init.sh
+
+## Status: DONE
+
+## Changes Made
+
+- `hooks/beacon-init.sh`: Added jq dependency check after git repository detection. The check prints a clear warning message if jq is not found: "Warning: jq not found. Install with: brew install jq". The script continues to execute successfully (jq is needed later in other hook scripts, not during init).
+
+- `CLAUDE.md`: Added a new "Prerequisites" section documenting that jq is required for state updates and completion tracking. Includes installation instructions for macOS via Homebrew.
+
+## Tests
+
+- Test command: `none (markdown/bash plugin)`
+- Result: N/A
+- New tests added: no
+
+## Notes
+
+The jq check is non-blocking — beacon-init.sh will still succeed even if jq is missing. This is appropriate because:
+1. The init script itself doesn't use jq (it writes the initial JSON directly)
+2. jq is only required by downstream hooks like update-state.sh and optionally by check-completion.sh
+3. An early warning at init time helps users catch the missing dependency before running beacon commands that depend on it
+
+The check uses `command -v jq >/dev/null 2>&1` which is a portable way to detect if jq is available in the PATH.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,11 @@ Autonomous multi-agent orchestration plugin for Claude Code.
 - **Reviewer**: Sonnet agent — verifies all work against acceptance criteria
 - **Monitor**: Sonnet agent — watches CI, PR comments, merge status
 
+## Prerequisites
+
+- `jq` — JSON query tool, required for state updates and completion tracking
+  - Install: `brew install jq`
+
 ## Plugin Structure
 
 - `commands/beacon.md` — `/beacon start|status|stop|plan` entry point

--- a/hooks/beacon-init.sh
+++ b/hooks/beacon-init.sh
@@ -15,6 +15,11 @@ REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
 }
 cd "$REPO_ROOT"
 
+# Check for jq dependency
+if ! command -v jq >/dev/null 2>&1; then
+  echo "Warning: jq not found. Install with: brew install jq" >&2
+fi
+
 # Derive owner/repo from git remote
 REPO_SLUG=""
 REMOTE_URL=$(git remote get-url origin 2>/dev/null) || true


### PR DESCRIPTION
## Summary

- Add non-blocking jq check to `beacon-init.sh` — warns if missing, doesn't block init
- Add `Prerequisites` section to `CLAUDE.md` documenting jq requirement

## Verification

- Reviewer: PASS (HIGH confidence)
- Tests: SKIPPED (markdown/bash plugin, no test suite)
- Simplified: no (change too small)

Closes #25

Dispatched by [Beacon](https://github.com/Maleick/beacon). Agent: Claude Haiku.