### PR TITLE
issue-26: Add beacon:paused label to spec and label management

### DIFF
--- a/BEACON_SPEC.md
+++ b/BEACON_SPEC.md
@@ -221,11 +221,12 @@ Step 6: CLEANUP
 
 ### 7.2 GitHub Labels (Durable Recovery)
 
-- `beacon:in-progress` — agent working on it
-- `beacon:blocked` — all agents failed, needs human review
-- `beacon:done` — completed and merged
+- `beacon:in-progress` — agent working on it (color: yellow)
+- `beacon:blocked` — all agents failed, needs human review (color: red)
+- `beacon:paused` — orchestration halted, awaiting resume (color: orange)
+- `beacon:done` — completed and merged (color: green)
 
-On restart: reconcile local state with GitHub labels + PR status.
+Labels are created automatically on first run. On restart: reconcile local state with GitHub labels + PR status.
 
 ---
 

--- a/hooks/beacon-init.sh
+++ b/hooks/beacon-init.sh
@@ -79,19 +79,12 @@ create_github_labels() {
     return 0
   fi
 
-  # Define labels with their colors
-  declare -A labels=(
-    ["beacon:in-progress"]="FFEB3B"  # yellow
-    ["beacon:blocked"]="F44336"      # red
-    ["beacon:paused"]="FF9800"       # orange
-    ["beacon:done"]="4CAF50"         # green
-  )
-
-  # Create each label if it doesn't exist
-  for label in "${!labels[@]}"; do
-    color="${labels[$label]}"
-    # Check if label exists
-    if ! gh label list --repo "$REPO_SLUG" --json name --query ".[].name" 2>/dev/null | grep -q "^$label$"; then
+  # Create each label if it doesn't exist (bash 3.2 compatible — no associative arrays)
+  local pairs="beacon:in-progress=FFEB3B beacon:blocked=F44336 beacon:paused=FF9800 beacon:done=4CAF50"
+  for pair in $pairs; do
+    label="${pair%%=*}"
+    color="${pair#*=}"
+    if ! gh label list --repo "$REPO_SLUG" --json name --jq ".[].name" 2>/dev/null | grep -q "^${label}$"; then
       echo "Creating label: $label (color: $color)"
       gh label create "$label" --repo "$REPO_SLUG" --color "$color" --description "Beacon orchestration label" 2>/dev/null || true
     fi

--- a/hooks/beacon-init.sh
+++ b/hooks/beacon-init.sh
@@ -67,4 +67,38 @@ if [[ ! -f "$CONFIG_FILE" ]]; then
   echo "Initialized $CONFIG_FILE (add test_command, etc. for overrides)"
 fi
 
+# Create GitHub labels if the repo is on GitHub and gh CLI is available
+create_github_labels() {
+  # Check if gh CLI is available
+  if ! command -v gh &> /dev/null; then
+    return 0
+  fi
+
+  # Check if we're in a GitHub repo (REPO_SLUG will be set)
+  if [[ -z "$REPO_SLUG" ]]; then
+    return 0
+  fi
+
+  # Define labels with their colors
+  declare -A labels=(
+    ["beacon:in-progress"]="FFEB3B"  # yellow
+    ["beacon:blocked"]="F44336"      # red
+    ["beacon:paused"]="FF9800"       # orange
+    ["beacon:done"]="4CAF50"         # green
+  )
+
+  # Create each label if it doesn't exist
+  for label in "${!labels[@]}"; do
+    color="${labels[$label]}"
+    # Check if label exists
+    if ! gh label list --repo "$REPO_SLUG" --json name --query ".[].name" 2>/dev/null | grep -q "^$label$"; then
+      echo "Creating label: $label (color: $color)"
+      gh label create "$label" --repo "$REPO_SLUG" --color "$color" --description "Beacon orchestration label" 2>/dev/null || true
+    fi
+  done
+}
+
+# Attempt to create labels (non-fatal if it fails)
+create_github_labels || true
+
 echo "Beacon workspace ready at $BEACON_DIR"


### PR DESCRIPTION
## Summary

- Add `beacon:paused` label to BEACON_SPEC.md Section 7.2 with color definitions
- Add `create_github_labels()` to `beacon-init.sh` — auto-creates all 4 beacon labels on first run
- Labels: in-progress (yellow), blocked (red), paused (orange), done (green)

## Verification

- Reviewer: FAIL → fixed → PASS
- Issue found: `declare -A` (bash 4+) not portable to macOS stock bash 3.2
- Fix: replaced with bash 3.2-compatible string pairs
- Also fixed: `--query` → `--jq` for gh CLI flag
- Tests: SKIPPED (no test suite)

Closes #26

Dispatched by [Beacon](https://github.com/Maleick/beacon). Agent: Claude Haiku. Reviewer fix: Opus.