### PR TITLE
issue-27: Implement quota parsing for Codex and Gemini CLIs

### DIFF
--- a/BEACON_RESULT.md
+++ b/BEACON_RESULT.md
@@ -1,24 +1,25 @@
-# Result: #25 — Add jq dependency check to beacon-init.sh
+# Result: #27 — Implement quota parsing for Codex and Gemini CLIs
 
 ## Status: DONE
 
 ## Changes Made
 
-- `hooks/beacon-init.sh`: Added jq dependency check after git repository detection. The check prints a clear warning message if jq is not found: "Warning: jq not found. Install with: brew install jq". The script continues to execute successfully (jq is needed later in other hook scripts, not during init).
+- `hooks/detect-tools.sh`: Rewrote to output `quota_pct` for every tool. Claude is hardcoded to 100. Codex is split into two separate entries (`codex-spark`, `codex-gpt`) each with `quota_pct: -1` (unknown). Gemini gets `quota_pct: -1` (unknown). Quota helpers (`quota_codex_spark`, `quota_codex_gpt`, `quota_gemini`) are isolated functions — easy to update if the CLIs ever expose a machine-readable quota command.
 
-- `CLAUDE.md`: Added a new "Prerequisites" section documenting that jq is required for state updates and completion tracking. Includes installation instructions for macOS via Homebrew.
+- `hooks/beacon-init.sh`: Added `SCRIPT_DIR` resolution and calls `detect-tools.sh` at init time. Transforms detect-tools output (uses `available: bool`) to state.json format (`status: "available"|"unavailable"`) via jq. Uses `jq -n` to write the full state.json (replaces heredoc) so tools data is embedded cleanly. On re-run (state.json already exists), refreshes only the `tools` section without touching other state (`issues`, `stats`, etc.) and updates `updated_at`.
 
 ## Tests
 
-- Test command: `none (markdown/bash plugin)`
-- Result: N/A
+- Test command: `bash hooks/detect-tools.sh` (smoke test)
+- Result: PASS — outputs valid JSON with `quota_pct` for all four tool keys
+- Test command: `bash hooks/beacon-init.sh` (init + refresh)
+- Result: PASS — creates state.json on first run, refreshes tools section on re-run
 - New tests added: no
 
 ## Notes
 
-The jq check is non-blocking — beacon-init.sh will still succeed even if jq is missing. This is appropriate because:
-1. The init script itself doesn't use jq (it writes the initial JSON directly)
-2. jq is only required by downstream hooks like update-state.sh and optionally by check-completion.sh
-3. An early warning at init time helps users catch the missing dependency before running beacon commands that depend on it
-
-The check uses `command -v jq >/dev/null 2>&1` which is a portable way to detect if jq is available in the PATH.
+- Neither `codex` (v0.120.0) nor `gemini` (v0.37.1) expose a quota or status command that outputs machine-readable quota data. Both default to `quota_pct: -1` (unknown).
+- `codex` has a `cloud` subcommand that could theoretically surface task/quota info, but it requires interactive stdin and has no structured quota output.
+- `gemini` has no quota-related subcommands in its help output.
+- The quota helper functions (`quota_codex_spark`, etc.) are intentionally separated — when the CLIs add quota commands, only those functions need updating.
+- jq is required (available at /opt/homebrew/bin/jq on macOS). If jq is absent, beacon-init.sh falls back to a hardcoded tools JSON with conservative defaults (claude: available/100, others: unavailable/-1).

--- a/hooks/beacon-init.sh
+++ b/hooks/beacon-init.sh
@@ -8,6 +8,9 @@ BEACON_DIR=".beacon"
 STATE_FILE="$BEACON_DIR/state.json"
 WORKSPACES_DIR="$BEACON_DIR/workspaces"
 
+# Resolve the directory this script lives in so we can call sibling scripts.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
 # Detect repo
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
   echo "Error: not inside a git repository" >&2
@@ -31,38 +34,62 @@ fi
 # Create directory structure
 mkdir -p "$WORKSPACES_DIR"
 
+# Detect tools and parse quotas.
+# detect-tools.sh outputs: {"claude": {"available": bool, "quota_pct": N}, ...}
+# Transform to state.json format:  {"claude": {"status": "available"|"unavailable", "quota_pct": N}, ...}
+TOOLS_RAW=$(bash "$SCRIPT_DIR/detect-tools.sh" 2>/dev/null) || TOOLS_RAW='{}'
+TOOLS_JSON=$(printf '%s' "$TOOLS_RAW" | jq '
+  to_entries
+  | map({
+      key: .key,
+      value: {
+        status: (if .value.available then "available" else "unavailable" end),
+        quota_pct: .value.quota_pct
+      }
+    })
+  | from_entries
+' 2>/dev/null) || TOOLS_JSON='{
+    "claude":     {"status": "available",   "quota_pct": 100},
+    "codex-spark":{"status": "unavailable", "quota_pct": -1},
+    "codex-gpt":  {"status": "unavailable", "quota_pct": -1},
+    "gemini":     {"status": "unavailable", "quota_pct": -1}
+  }'
+
 # Initialize state.json only if it doesn't exist
 if [[ ! -f "$STATE_FILE" ]]; then
   NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-  cat > "$STATE_FILE" <<EOF
-{
-  "version": 1,
-  "repo": "${REPO_SLUG}",
-  "started_at": "${NOW}",
-  "updated_at": "${NOW}",
-  "plan": {
-    "phases": [],
-    "current_phase": 0,
-    "checkpoint_pending": false
-  },
-  "issues": {},
-  "tools": {
-    "claude": { "status": "available", "quota_pct": 100 },
-    "codex-spark": { "status": "available", "quota_pct": 100 },
-    "codex-gpt": { "status": "available", "quota_pct": 100 },
-    "gemini": { "status": "available", "quota_pct": 100 }
-  },
-  "stats": {
-    "dispatched": 0,
-    "completed": 0,
-    "failed": 0,
-    "blocked": 0
-  }
-}
-EOF
+  # Use jq to produce well-formed JSON, embedding the detected tools.
+  jq -n \
+    --arg repo "$REPO_SLUG" \
+    --arg now "$NOW" \
+    --argjson tools "$TOOLS_JSON" \
+    '{
+      version: 1,
+      repo: $repo,
+      started_at: $now,
+      updated_at: $now,
+      plan: {
+        phases: [],
+        current_phase: 0,
+        checkpoint_pending: false
+      },
+      issues: {},
+      tools: $tools,
+      stats: {
+        dispatched: 0,
+        completed: 0,
+        failed: 0,
+        blocked: 0
+      }
+    }' > "$STATE_FILE"
   echo "Initialized $STATE_FILE"
 else
-  echo "$STATE_FILE already exists, skipping"
+  # Refresh tools section with current quota data without touching other state.
+  NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  UPDATED=$(jq --argjson tools "$TOOLS_JSON" --arg now "$NOW" \
+    '.tools = $tools | .updated_at = $now' "$STATE_FILE") && \
+    printf '%s\n' "$UPDATED" > "$STATE_FILE"
+  echo "Refreshed tools quota in $STATE_FILE"
 fi
 
 # Create config.json for operator overrides (if not present)

--- a/hooks/detect-tools.sh
+++ b/hooks/detect-tools.sh
@@ -2,31 +2,90 @@
 set -euo pipefail
 
 # detect-tools.sh — Detect available AI CLI tools and output JSON report.
+# Outputs quota_pct for each tool: 100 if known-full, -1 if unknown, 0-100 if parseable.
 # Always exits 0; missing tools are reported as unavailable, not errors.
 
-detect_tool() {
-  local name="$1"
-  local cmd="$2"
-  local version_flag="${3:---version}"
+# ---------------------------------------------------------------------------
+# Quota helpers — return integer 0-100 or -1 (unknown)
+# ---------------------------------------------------------------------------
 
-  if command -v "$cmd" >/dev/null 2>&1; then
-    local ver
-    ver=$("$cmd" "$version_flag" 2>/dev/null | head -1) || ver="unknown"
-    # Escape version string for safe JSON embedding
+# Claude uses a Max subscription — treat as always full.
+quota_claude() {
+  echo "100"
+}
+
+# Codex CLI: no public quota/status command as of 2025. Default to -1.
+# If a future `codex quota --model spark` or similar command exists, parse it here.
+quota_codex_spark() {
+  # Attempt: codex features may expose quota info in the future.
+  # For now there is no machine-readable quota output — return unknown.
+  echo "-1"
+}
+
+quota_codex_gpt() {
+  echo "-1"
+}
+
+# Gemini CLI: no --quota or status subcommand as of 2025. Default to -1.
+quota_gemini() {
+  echo "-1"
+}
+
+# ---------------------------------------------------------------------------
+# Per-tool detection
+# ---------------------------------------------------------------------------
+
+detect_claude() {
+  if command -v claude >/dev/null 2>&1; then
+    local ver qpct
+    ver=$(claude --version 2>/dev/null | head -1) || ver="unknown"
     ver=$(printf '%s' "$ver" | sed 's/\\/\\\\/g; s/"/\\"/g' | tr -d '\n')
-    printf '"%s": {"available": true, "version": "%s"}' "$name" "$ver"
+    qpct=$(quota_claude)
+    printf '"claude": {"available": true, "version": "%s", "quota_pct": %s}' "$ver" "$qpct"
   else
-    printf '"%s": {"available": false}' "$name"
+    printf '"claude": {"available": false, "quota_pct": -1}'
   fi
 }
 
+detect_codex() {
+  if command -v codex >/dev/null 2>&1; then
+    local ver spark_q gpt_q
+    ver=$(codex --version 2>/dev/null | head -1) || ver="unknown"
+    ver=$(printf '%s' "$ver" | sed 's/\\/\\\\/g; s/"/\\"/g' | tr -d '\n')
+    spark_q=$(quota_codex_spark)
+    gpt_q=$(quota_codex_gpt)
+    printf '"codex-spark": {"available": true, "version": "%s", "quota_pct": %s}, ' \
+      "$ver" "$spark_q"
+    printf '"codex-gpt": {"available": true, "version": "%s", "quota_pct": %s}' \
+      "$ver" "$gpt_q"
+  else
+    printf '"codex-spark": {"available": false, "quota_pct": -1}, '
+    printf '"codex-gpt": {"available": false, "quota_pct": -1}'
+  fi
+}
+
+detect_gemini() {
+  if command -v gemini >/dev/null 2>&1; then
+    local ver qpct
+    ver=$(gemini --version 2>/dev/null | head -1) || ver="unknown"
+    ver=$(printf '%s' "$ver" | sed 's/\\/\\\\/g; s/"/\\"/g' | tr -d '\n')
+    qpct=$(quota_gemini)
+    printf '"gemini": {"available": true, "version": "%s", "quota_pct": %s}' "$ver" "$qpct"
+  else
+    printf '"gemini": {"available": false, "quota_pct": -1}'
+  fi
+}
+
+# ---------------------------------------------------------------------------
 # Build JSON output
+# ---------------------------------------------------------------------------
+
 echo -n "{"
-detect_tool "claude" "claude" "--version"
+detect_claude
 echo -n ", "
-detect_tool "codex" "codex" "--version"
+detect_codex
 echo -n ", "
-detect_tool "gemini" "gemini" "--version"
+detect_gemini
 echo "}"
 
 exit 0


### PR DESCRIPTION
## Summary

- Refactor `detect-tools.sh` to output `quota_pct` per tool (100 for Claude, -1 for unknown)
- Split Codex into separate `codex-spark` and `codex-gpt` keys with independent quotas
- Integrate tool detection into `beacon-init.sh` — populates `state.json` tools on fresh init, refreshes on re-run
- Quota helper stubs ready for future CLI commands (currently neither Codex nor Gemini expose machine-readable quota)

## Verification

- Reviewer: PASS (HIGH confidence)
- Smoke test: `bash hooks/detect-tools.sh` → valid JSON with all 4 keys and correct quota_pct values
- bash 3.2 compatible (no associative arrays)

Closes #27

Dispatched by [Beacon](https://github.com/Maleick/beacon). Agent: Claude Sonnet. Attempt: 1.