### PR TITLE
issue-15: CronCreate polling — 10-minute GitHub issue sync

### DIFF
--- a/BEACON_RESULT.md
+++ b/BEACON_RESULT.md
@@ -1,114 +1,29 @@
-# Issue #5: GitHub Labels Lifecycle Implementation
+# Result: #15 — CronCreate polling: 10-minute GitHub issue sync
 
-## Summary
+## Status: DONE
 
-Successfully implemented GitHub labels lifecycle management for Beacon orchestration. Labels now serve as durable state for recovery across session restarts.
+## Changes Made
 
-## What Was Done
+- `skills/beacon-poll/SKILL.md`: New skill implementing the full 10-minute GitHub issue polling protocol. Covers all 7 steps: load known state, fetch live issues, diff for new/closed/changed, handle each category, update state, and log results.
+- `skills/beacon/SKILL.md` (Step 6): Updated CronCreate call to delegate to the new `beacon-poll` skill instead of embedding inline logic. Added bullet summary of what the skill covers and a note about re-establishing the cron after context compaction.
 
-### 1. Enhanced `hooks/update-state.sh`
+## Tests
 
-Added a new `manage_labels()` function that:
+- Test command: none (skill files are markdown protocols, not executable code)
+- Result: N/A — verified by reading protocol against all 6 acceptance criteria
 
-- Integrates with GitHub CLI (`gh`) for label management
-- Gracefully degrades if `gh` is unavailable (returns silently)
-- Verifies labels exist before operations
-- Is fully bash 3.2 compatible (macOS native, no associative arrays)
+## Acceptance Criteria Verification
 
-Updated action handlers with label lifecycle:
+- [x] CronCreate fires every 10 minutes — `schedule: "*/10 * * * *"` in Step 6 of beacon/SKILL.md
+- [x] Fetch open issues and diff against known state — Steps 2 & 3 of beacon-poll/SKILL.md
+- [x] New issues: run UltraPlan to integrate into existing plan — Step 4 classifies complexity and appends to plan phases
+- [x] Closed issues: cancel running agents if applicable — Step 5 kills tmux panes and removes worktrees
+- [x] Changed issues: update local state — Step 6 handles label reconciliation and metadata sync
+- [x] Log poll results — Step 7 writes timestamped summary to `.beacon/poll.log` (bounded to 500 lines)
 
-| Action        | Label Applied        | Labels Removed               | Purpose                               |
-| ------------- | -------------------- | ---------------------------- | ------------------------------------- |
-| `set-running` | `beacon:in-progress` | blocked, paused, done        | Marks issue as actively being worked  |
-| `set-blocked` | `beacon:blocked`     | in-progress, paused, done    | Flags issues requiring human review   |
-| `set-merged`  | `beacon:done`        | in-progress, blocked, paused | Marks completion, cleanup removes all |
-| `set-paused`  | `beacon:paused`      | (none)                       | Marks orchestration halt state        |
-| `set-failed`  | `beacon:blocked`     | in-progress, paused, done    | Failed attempt → blocked state        |
+## Notes
 
-### 2. Updated `skills/beacon/SKILL.md`
-
-Enhanced documentation with:
-
-**GitHub Labels Section** — Added action references and clarification:
-
-- Each label now shows which action applies it
-- `beacon:paused` added to the label list
-- Clear description of lifecycle and cleanup behavior
-
-**Recovery Section** — Expanded label-based recovery logic:
-
-- Issues with `beacon:in-progress` → restore to running or re-dispatch
-- Issues with `beacon:blocked` → restore to blocked, flag for human review
-- Issues with `beacon:done` → restore to merged, remove all lifecycle labels
-- Issues with `beacon:paused` → restore to paused, awaiting resume
-
-### 3. Label Design
-
-Four labels created by `beacon-init.sh` (issue #26):
-
-- **beacon:in-progress** (yellow #FFEB3B) — Agent actively working
-- **beacon:blocked** (red #F44336) — All agents failed, needs human intervention
-- **beacon:paused** (orange #FF9800) — Orchestration paused, awaiting resume
-- **beacon:done** (green #4CAF50) — Completed and merged
-
-## Acceptance Criteria Met
-
-✅ Apply `beacon:in-progress` when dispatching an agent (set-running)  
-✅ Replace with `beacon:blocked` when agents fail (set-blocked, set-failed)  
-✅ Replace with `beacon:done` on successful merge (set-merged with cleanup)  
-✅ Apply `beacon:paused` on stop (new set-paused action)  
-✅ Remove labels on cleanup (set-merged removes all lifecycle labels)  
-✅ Use labels for state recovery on restart (documented in recovery section)
-
-## Key Implementation Details
-
-### macOS Compatibility
-
-- Bash 3.2 compatible (no `declare -A`, uses simple arrays)
-- Uses `gh` CLI for all GitHub operations
-- Graceful degradation if `gh` unavailable (non-fatal)
-
-### Idempotent Operations
-
-- Label existence verified before add/remove
-- Multiple calls to same action safely idempotent
-- Failed label ops don't block state updates
-
-### State Recovery Flow
-
-On restart, Beacon:
-
-1. Reads `.beacon/state.json`
-2. Polls GitHub for current issue states and labels
-3. Maps labels back to internal states
-4. Reconciles local state with GitHub as source of truth
-5. Resumes from checkpoint without re-planning
-
-## Testing Notes
-
-- Verified bash syntax with `bash -n`
-- All label operations wrapped in error handling
-- Tested with macOS bash 3.2 compatibility
-- Graceful fallback when gh CLI unavailable
-
-## Files Modified
-
-- `hooks/update-state.sh` — Label management implementation
-- `skills/beacon/SKILL.md` — Documentation updates
-
-## Commit
-
-```
-feat(#5): implement GitHub labels lifecycle management
-
-- Add manage_labels() function to apply/remove labels via gh CLI
-- Apply beacon:in-progress on set-running action
-- Apply beacon:blocked on set-blocked and set-failed actions
-- Apply beacon:done on set-merged action (removes other labels)
-- Add set-paused action for orchestration halt state
-- Enhance recovery documentation in beacon skill
-- Update GitHub Labels section with action references
-- All changes are bash 3.2 compatible (macOS native)
-```
-
-Commit: `62d2906`
+- The CronCreate prompt now references `skills/beacon-poll/SKILL.md` directly so the protocol can evolve independently of the orchestrator
+- Step 5 (closed issues) reports cancellations via stdout; Opus reads the poll output and can take additional action if needed
+- The `beacon:in-progress` label is removed from cancelled issues to keep GitHub labels as the durable source of truth
+- Context compaction note added to Step 6 and already present in the Recovery section (line 398) — both now mention re-establishing the cron after compaction

--- a/skills/beacon-poll/SKILL.md
+++ b/skills/beacon-poll/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: beacon-poll
+description: 10-minute GitHub issue sync — diffs live issue state against .beacon/state.json, integrates new issues into the plan, cancels agents for closed issues, and updates changed issue metadata
+tools: ["Bash", "Read", "Write"]
+---
+
+# Beacon Poll Protocol
+
+You are the Beacon polling safety net. You run every 10 minutes via CronCreate. Your job is to diff live GitHub issue state against `.beacon/state.json` and reconcile any drift.
+
+## Step 1: Load Known State
+
+```bash
+cat .beacon/state.json
+```
+
+Extract the `issues` map: each key is an issue number (as string), with `state`, `complexity`, `agent`, `pane_id`, and `worktree` fields.
+
+Also note the `repo` field — you'll need it for `gh` calls.
+
+## Step 2: Fetch Live Issues from GitHub
+
+```bash
+gh issue list --state open --json number,title,body,labels,updatedAt --limit 200
+```
+
+This returns all currently **open** issues. Store the result as `live_issues`.
+
+Also fetch recently closed issues (closed in the past 30 minutes) to catch external closures:
+
+```bash
+gh issue list --state closed --json number,title,labels,updatedAt --limit 50 \
+  | jq '[.[] | select(.updatedAt > (now - 1800 | todate))]'
+```
+
+## Step 3: Diff Against Known State
+
+Build three lists by comparing `live_issues` against the `issues` map in `.beacon/state.json`:
+
+### New Issues
+
+Issues in `live_issues` that are **not** present in `.beacon/state.json`.
+
+```bash
+# Pseudocode — implement with jq
+known_numbers=$(jq -r '.issues | keys[]' .beacon/state.json)
+live_numbers=$(echo "$live_issues" | jq -r '.[].number')
+new_issues=$(comm -13 <(echo "$known_numbers" | sort) <(echo "$live_numbers" | sort))
+```
+
+### Closed Issues
+
+Issues present in `.beacon/state.json` with `state` != `merged` or `blocked`, but **absent** from `live_issues` (i.e., closed externally).
+
+```bash
+jq -r '.issues | to_entries[] | select(.value.state | test("running|claimed|unclaimed|verifying|approved")) | .key' \
+  .beacon/state.json
+# Cross-reference against live open issue numbers
+```
+
+### Changed Issues
+
+Issues in both `live_issues` and `.beacon/state.json` where `updatedAt` in GitHub is **newer** than the timestamp stored in local state (if tracked), or where labels have changed.
+
+Compare label sets — look for additions or removals of `beacon:*` labels that would indicate out-of-band state changes.
+
+## Step 4: Handle New Issues
+
+For each new issue:
+
+### 4a. Classify Complexity
+
+Use the same classification table as the main orchestrator:
+
+| Signal           | Simple                          | Medium                        | Complex                              |
+| ---------------- | ------------------------------- | ----------------------------- | ------------------------------------ |
+| Scope            | Single file, < 50 lines changed | 2–5 files, < 200 lines        | 5+ files, architectural changes      |
+| Test coverage    | Existing tests cover the change | Needs new test cases          | Needs new test infrastructure        |
+| Dependencies     | None                            | Touches shared utilities      | Cross-cutting concerns               |
+| Domain knowledge | Obvious fix/feature             | Requires reading related code | Requires understanding system design |
+| Description      | Clear steps to implement        | Partial spec, needs inference | Ambiguous, needs decomposition       |
+
+When ambiguous, classify **up** (prefer medium over simple, complex over medium).
+
+### 4b. Check Dependencies
+
+Scan the issue body for:
+- Explicit: `blocks: #N`, `depends-on: #N`, `blocked by #N`, `after #N`
+- Implicit: references to the same files or components as in-flight issues
+
+### 4c. Add to Plan
+
+Append the new issue to `.beacon/state.json`:
+
+```bash
+jq --arg num "<number>" \
+   --arg title "<title>" \
+   --arg complexity "<simple|medium|complex>" \
+   '.issues[$num] = {
+     state: "unclaimed",
+     complexity: $complexity,
+     title: $title,
+     agent: null,
+     attempt: 0,
+     worktree: null,
+     pane_id: null,
+     discovered_by: "poll",
+     started_at: null,
+     attempts_history: []
+   }' .beacon/state.json > .beacon/state.tmp && mv .beacon/state.tmp .beacon/state.json
+```
+
+Determine which phase the issue belongs to (Phase 1 if no unresolved dependencies, otherwise after its blockers). Append to the appropriate phase in `plan.phases`.
+
+## Step 5: Handle Closed Issues
+
+For each issue that was closed externally:
+
+### 5a. Check for Running Agent
+
+Read `.beacon/state.json` to get `pane_id` and `worktree` for the issue.
+
+```bash
+pane_id=$(jq -r --arg num "<number>" '.issues[$num].pane_id // empty' .beacon/state.json)
+worktree=$(jq -r --arg num "<number>" '.issues[$num].worktree // empty' .beacon/state.json)
+```
+
+### 5b. Kill Running Pane (if any)
+
+If `pane_id` is set and the tmux pane is still alive:
+
+```bash
+if tmux list-panes -a -F '#{pane_id}' | grep -q "^${pane_id}$"; then
+  tmux kill-pane -t "$pane_id"
+  echo "Killed pane $pane_id for closed issue #<number>"
+fi
+```
+
+### 5c. Remove Worktree (if any)
+
+If `worktree` path exists:
+
+```bash
+if [ -d "$worktree" ]; then
+  git worktree remove "$worktree" --force
+  echo "Removed worktree $worktree for closed issue #<number>"
+fi
+```
+
+### 5d. Update Local State
+
+```bash
+jq --arg num "<number>" \
+   '.issues[$num].state = "cancelled" |
+    .issues[$num].cancelled_reason = "closed-externally"' \
+  .beacon/state.json > .beacon/state.tmp && mv .beacon/state.tmp .beacon/state.json
+```
+
+Remove the `beacon:in-progress` label from the issue if present:
+
+```bash
+gh issue edit <number> --remove-label "beacon:in-progress" 2>/dev/null || true
+```
+
+## Step 6: Handle Changed Issues
+
+For each changed issue (label changes or body updates):
+
+### Label Reconciliation
+
+If a `beacon:*` label was **added** externally:
+- `beacon:blocked` → update local state to `blocked`
+- `beacon:in-progress` → log discrepancy (we should already know about it)
+
+If a `beacon:*` label was **removed** externally:
+- `beacon:in-progress` removed → treat as cancellation signal, proceed as Step 5
+
+### Metadata Update
+
+Update title, body, and labels in `.beacon/state.json`:
+
+```bash
+jq --arg num "<number>" \
+   --arg title "<new_title>" \
+   --argjson labels '<labels_array>' \
+   '.issues[$num].title = $title |
+    .issues[$num].labels = $labels |
+    .issues[$num].last_synced = now | todate' \
+  .beacon/state.json > .beacon/state.tmp && mv .beacon/state.tmp .beacon/state.json
+```
+
+## Step 7: Update Poll Timestamp and Write Log
+
+Update `updated_at` and `last_poll` in state:
+
+```bash
+jq --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+   '.updated_at = $ts | .last_poll = $ts' \
+  .beacon/state.json > .beacon/state.tmp && mv .beacon/state.tmp .beacon/state.json
+```
+
+Write a summary to `.beacon/poll.log`:
+
+```bash
+cat >> .beacon/poll.log <<EOF
+[$(date -u +%Y-%m-%dT%H:%M:%SZ)] Poll complete
+  New issues:    <count> (<numbers>)
+  Closed issues: <count> (<numbers>)
+  Changed issues: <count> (<numbers>)
+  Active agents:  <count>
+  State file:     .beacon/state.json
+EOF
+```
+
+Keep the log bounded — trim to the last 500 lines:
+
+```bash
+tail -500 .beacon/poll.log > .beacon/poll.log.tmp && mv .beacon/poll.log.tmp .beacon/poll.log
+```
+
+## Output
+
+After completing all steps, print a brief summary:
+
+```
+Beacon Poll [<timestamp>]
+  New:     <N> issues added to plan
+  Closed:  <N> agents cancelled
+  Changed: <N> state updates
+  No action needed for <N> issues
+```
+
+If nothing changed, print:
+
+```
+Beacon Poll [<timestamp>] — no changes detected
+```

--- a/skills/beacon/SKILL.md
+++ b/skills/beacon/SKILL.md
@@ -143,17 +143,27 @@ Display the plan and begin execution.
 
 ### Step 6: Start Orchestration Loop
 
-Use CronCreate to schedule the 10-minute polling safety net:
+Use CronCreate to schedule the 10-minute polling safety net. The poll skill handles all diffing, agent cancellation, and state updates:
 
 ```
 CronCreate({
   schedule: "*/10 * * * *",
-  prompt: "Beacon poll: run `gh issue list --state open --json number,title,labels,updatedAt --limit 200`. Diff against .beacon/state.json known issues. For new issues: classify complexity and integrate into the current UltraPlan. For issues closed externally: cancel any running agents (kill tmux pane, remove worktree). For issues with updated labels: reconcile state. Update .beacon/state.json with poll timestamp.",
+  prompt: "Run the beacon-poll skill: fetch open GitHub issues, diff against .beacon/state.json, integrate new issues into the plan, cancel agents for externally-closed issues, and update changed issue metadata. Use the protocol in skills/beacon-poll/SKILL.md.",
   description: "Beacon GitHub poll safety net"
 })
 ```
 
+The full polling protocol is defined in `skills/beacon-poll/SKILL.md`. It covers:
+
+- Fetching live issue state via `gh issue list`
+- Classifying and inserting new issues into the active plan
+- Killing tmux panes and removing worktrees for externally-closed issues
+- Reconciling label changes and metadata updates
+- Writing a timestamped summary to `.beacon/poll.log`
+
 This fires even if the Discord webhook is active — it catches anything the webhook misses (e.g., issues created via API, label changes, external closures).
+
+> **Note:** CronCreate jobs do not survive context compaction. After any compaction event, re-issue the CronCreate call above to restore the polling loop. See the Recovery section for details.
 
 ### Step 7: Start Discord Listener
 


### PR DESCRIPTION
## Summary

- New skill: `skills/beacon-poll/SKILL.md` (237 lines) — full 7-step polling protocol
- Diffs live GitHub issues against `.beacon/state.json` known state
- New issues → classify complexity, add to plan phases
- Closed issues → kill agent pane, remove worktree, update state
- Changed issues → reconcile labels and metadata
- Bounded poll log (`.beacon/poll.log`, 500 lines max)
- Updated `skills/beacon/SKILL.md` Step 6 to delegate CronCreate to poll skill

## Verification

- Reviewer: PASS
- New skill has correct frontmatter, tools, and self-contained protocol

Closes #15

Dispatched by [Beacon](https://github.com/Maleick/beacon). Agent: Claude Sonnet.