### PR TITLE
fix: sweep-stale thrashing — add swept sentinel (#51)

### DIFF
--- a/hooks/sweep-stale.sh
+++ b/hooks/sweep-stale.sh
@@ -67,6 +67,10 @@ for worktree_dir in "$WORKSPACES_DIR"/*/; do
   # Extract issue key from directory name (e.g., ".beacon/workspaces/issue-16" → "issue-16")
   ISSUE_KEY=$(basename "$worktree_dir")
 
+  # Check if this issue was already swept in this cycle; skip if so
+  swept=$(jq -r --arg key "$ISSUE_KEY" '.issues[$key].swept // false' "$STATE_FILE" 2>/dev/null) || swept="false"
+  [[ "$swept" == "true" ]] && continue
+
   # Look up the issue state in state.json
   ISSUE_STATE=$(jq -r --arg id "$ISSUE_KEY" '.issues[$id].state // "unknown"' "$STATE_FILE" 2>/dev/null) || ISSUE_STATE="unknown"
 
@@ -87,6 +91,9 @@ for worktree_dir in "$WORKSPACES_DIR"/*/; do
     bash "$SCRIPT_DIR/cleanup-worktree.sh" "$ISSUE_KEY" 2>/dev/null || {
       echo "Warning: failed to clean up $ISSUE_KEY"
     }
+
+    # Write swept sentinel to prevent re-processing
+    jq --arg key "$ISSUE_KEY" '.issues[$key].swept = true' "$STATE_FILE" > "$STATE_FILE.tmp" && mv "$STATE_FILE.tmp" "$STATE_FILE" 2>/dev/null || true
 
     CLEANED_COUNT=$((CLEANED_COUNT + 1))
     continue
@@ -111,6 +118,10 @@ for worktree_dir in "$WORKSPACES_DIR"/*/; do
       bash "$SCRIPT_DIR/cleanup-worktree.sh" "$ISSUE_KEY" 2>/dev/null || {
         echo "Warning: failed to clean up orphaned worktree $ISSUE_KEY"
       }
+
+      # Write swept sentinel to prevent re-processing
+      jq --arg key "$ISSUE_KEY" '.issues[$key].swept = true' "$STATE_FILE" > "$STATE_FILE.tmp" && mv "$STATE_FILE.tmp" "$STATE_FILE" 2>/dev/null || true
+
       CLEANED_COUNT=$((CLEANED_COUNT + 1))
     fi
   fi


### PR DESCRIPTION
## Summary

Fixes repeated removal of the same worktree in a single sweep cycle (issue-834 removed 6× in poll.log).

- Add `swept` check at top of loop: skip issue if `state.json` already has `swept=true`
- Write `swept=true` sentinel after successful worktree removal (both terminal and orphaned paths)

## Test plan

- [ ] `grep -c 'swept' hooks/sweep-stale.sh` → ≥ 3 occurrences (check + 2 sentinel writes)
- [ ] Same worktree path never appears twice in poll.log for one sweep cycle
- [ ] `poll.log` line count per issue ≤ 2

Fixes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)