### PR TITLE
fix: assert title+agent on set-merged, fetch from GitHub if absent (#60)

### DIFF
--- a/hooks/update-state.sh
+++ b/hooks/update-state.sh
@@ -147,11 +147,32 @@ if [[ -z "$CURRENT" ]]; then
     "$STATE_FILE" > "$TMP" && mv "$TMP" "$STATE_FILE"
 fi
 
-# Update state and timestamp
-TMP=$(make_tmp)
-jq --arg id "$ISSUE_ID" --arg state "$NEW_STATE" --arg now "$NOW" \
-  '.issues[$id].state = $state | .updated_at = $now' \
-  "$STATE_FILE" > "$TMP" && mv "$TMP" "$STATE_FILE"
+# For set-merged: assert title and agent are present (enrich from GitHub if absent)
+if [[ "$ACTION" == "set-merged" ]]; then
+  ISSUE_NUMBER=$(echo "$ISSUE_ID" | grep -o '[0-9]*')
+
+  TITLE=$(jq -r --arg k "$ISSUE_ID" '.issues[$k].title // ""' "$STATE_FILE")
+  AGENT=$(jq -r --arg k "$ISSUE_ID" '.issues[$k].agent // ""' "$STATE_FILE")
+
+  if [[ -z "$TITLE" ]]; then
+    TITLE=$(gh issue view "$ISSUE_NUMBER" --json title --jq '.title' 2>/dev/null || echo '(unknown)')
+  fi
+  if [[ -z "$AGENT" ]]; then
+    AGENT="direct"
+  fi
+
+  # Update state with title and agent
+  TMP=$(make_tmp)
+  jq --arg id "$ISSUE_ID" --arg state "$NEW_STATE" --arg now "$NOW" --arg title "$TITLE" --arg agent "$AGENT" \
+    '.issues[$id].state = $state | .updated_at = $now | .issues[$id].title = $title | .issues[$id].agent = $agent' \
+    "$STATE_FILE" > "$TMP" && mv "$TMP" "$STATE_FILE"
+else
+  # Standard state update
+  TMP=$(make_tmp)
+  jq --arg id "$ISSUE_ID" --arg state "$NEW_STATE" --arg now "$NOW" \
+    '.issues[$id].state = $state | .updated_at = $now' \
+    "$STATE_FILE" > "$TMP" && mv "$TMP" "$STATE_FILE"
+fi
 
 # Increment stat counter if applicable
 if [[ -n "$STAT_KEY" ]]; then


### PR DESCRIPTION
## Summary

Fixes 34% of merged issues having no title or agent in state.json (batch-merge path only wrote state+pr_number).

- In `set-merged`: check title and agent before writing
- Fetch title from `gh issue view` if missing; fallback to `(unknown)`
- Set agent to `direct` sentinel for operator-merged issues
- Include title+agent in the merged state jq update

## Test plan

- [ ] Every `set-merged` call results in non-empty title and agent in state.json
- [ ] `(unknown)` used when GitHub fetch fails
- [ ] `direct` used when agent field was empty

Fixes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)