### PR TITLE
fix: validate PR→issue assignment before writing pr_number (#57)

### DIFF
--- a/hooks/update-state.sh
+++ b/hooks/update-state.sh
@@ -170,6 +170,18 @@ fi
 for pair in "$@"; do
   KEY="${pair%%=*}"
   VALUE="${pair#*=}"
+
+  # Validate PR→issue assignment before writing pr_number
+  if [[ "$KEY" == "pr_number" ]]; then
+    ISSUE_NUMBER=$(echo "$ISSUE_ID" | grep -o '[0-9]*')
+    if command -v gh >/dev/null 2>&1; then
+      PR_ISSUE=$(gh pr view "$VALUE" --json body --jq '.body' 2>/dev/null | grep -o '#[0-9]*' | head -1 | tr -d '#')
+      if [[ -n "$PR_ISSUE" && "$PR_ISSUE" != "$ISSUE_NUMBER" ]]; then
+        echo "WARN: PR #$VALUE body references #$PR_ISSUE but expected #$ISSUE_NUMBER — possible transposition" >> "$REPO_ROOT/.beacon/poll.log"
+      fi
+    fi
+  fi
+
   TMP=$(make_tmp)
   # Try to parse as JSON (for numbers/booleans), fall back to string
   if echo "$VALUE" | jq -e '.' >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

Detects PR number transposition from concurrent update-state.sh writes.

- Before writing `pr_number`, fetch PR body and extract referenced issue number
- Log `WARN: PR #N body references #M but expected #K — possible transposition` to `.beacon/poll.log`
- Non-blocking: write proceeds even on mismatch (informational only)

## Test plan

- [ ] `grep -n 'transposition\|PR_ISSUE' hooks/update-state.sh` → found
- [ ] WARN line appears in poll.log when PR body references wrong issue
- [ ] pr_number still written even when mismatch detected

Fixes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)