### PR TITLE
feat: add Grok CLI detection + Symphony shim (#44)

### DIFF
--- a/hooks/detect-tools.sh
+++ b/hooks/detect-tools.sh
@@ -145,6 +145,16 @@ detect_gemini() {
   fi
 }
 
+detect_grok() {
+  if command -v grok >/dev/null 2>&1; then
+    ver=$(grok --version 2>/dev/null | head -1) || ver="unknown"
+    qpct=$(_read_quota "grok")
+    printf '"grok": {"available": true, "version": "%s", "quota_pct": %s}' "$ver" "$qpct"
+  else
+    printf '"grok": {"available": false, "quota_pct": -1}'
+  fi
+}
+
 # ---------------------------------------------------------------------------
 # Build JSON output
 # ---------------------------------------------------------------------------
@@ -155,6 +165,8 @@ echo -n ", "
 detect_codex
 echo -n ", "
 detect_gemini
+echo -n ", "
+detect_grok
 echo "}"
 
 exit 0

--- a/hooks/shims/grok-appserver.sh
+++ b/hooks/shims/grok-appserver.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# grok-appserver.sh — Thin Symphony shim for the Grok CLI.
+#
+# Usage:
+#   echo '{"type":"turn/start","prompt":"..."}' | grok-appserver.sh
+#   grok-appserver.sh /path/to/prompt-file.json
+#
+# Reads a turn/start JSON from stdin or a prompt file path passed as $1.
+# Extracts the prompt text, runs `grok --prompt-file`, streams output,
+# and emits synthetic Symphony JSON-RPC events on completion.
+#
+# Final line is always COMPLETE or STUCK.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Guard: grok must be installed
+# ---------------------------------------------------------------------------
+if ! command -v grok >/dev/null 2>&1; then
+  printf '{"type":"turn/error","threadId":"grok-shim","error":"grok: command not found — install the Grok CLI"}\n' >&2
+  echo "STUCK"
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Read input: $1 (file path) or stdin
+# ---------------------------------------------------------------------------
+INPUT_JSON=""
+if [[ -n "${1:-}" && -f "$1" ]]; then
+  INPUT_JSON=$(cat "$1")
+else
+  INPUT_JSON=$(cat)
+fi
+
+# ---------------------------------------------------------------------------
+# Extract prompt text from turn/start JSON
+# ---------------------------------------------------------------------------
+PROMPT_TEXT=""
+if command -v jq >/dev/null 2>&1; then
+  PROMPT_TEXT=$(printf '%s' "$INPUT_JSON" | jq -r '.prompt // .content // .text // empty' 2>/dev/null || true)
+fi
+
+# Fallback: strip JSON, use raw input as prompt
+if [[ -z "$PROMPT_TEXT" ]]; then
+  PROMPT_TEXT="$INPUT_JSON"
+fi
+
+if [[ -z "$PROMPT_TEXT" ]]; then
+  printf '{"type":"turn/error","threadId":"grok-shim","error":"No prompt text found in input"}\n' >&2
+  echo "STUCK"
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Extract thread ID (optional; default to timestamp-based ID)
+# ---------------------------------------------------------------------------
+THREAD_ID=""
+if command -v jq >/dev/null 2>&1; then
+  THREAD_ID=$(printf '%s' "$INPUT_JSON" | jq -r '.threadId // empty' 2>/dev/null || true)
+fi
+if [[ -z "$THREAD_ID" ]]; then
+  THREAD_ID="grok-$(date +%s)"
+fi
+
+# ---------------------------------------------------------------------------
+# Write prompt to temp file
+# ---------------------------------------------------------------------------
+TMPFILE=$(mktemp /tmp/grok-prompt-XXXXXX.txt)
+trap 'rm -f "$TMPFILE"' EXIT
+
+printf '%s' "$PROMPT_TEXT" > "$TMPFILE"
+
+# ---------------------------------------------------------------------------
+# Run grok CLI and stream output
+# ---------------------------------------------------------------------------
+EXIT_CODE=0
+grok --prompt-file "$TMPFILE" || EXIT_CODE=$?
+
+# ---------------------------------------------------------------------------
+# Emit synthetic Symphony JSON-RPC completion events
+# ---------------------------------------------------------------------------
+if [[ $EXIT_CODE -eq 0 ]]; then
+  printf '{"type":"turn/completed","threadId":"%s","status":"success"}\n' "$THREAD_ID"
+  printf '{"type":"thread/tokenUsage/updated","threadId":"%s","totalTokens":0}\n' "$THREAD_ID"
+  echo "COMPLETE"
+else
+  printf '{"type":"turn/error","threadId":"%s","status":"error","exitCode":%d}\n' \
+    "$THREAD_ID" "$EXIT_CODE" >&2
+  echo "STUCK"
+  exit 1
+fi


### PR DESCRIPTION
Closes #44

## Changes
- `hooks/detect-tools.sh`: Added `detect_grok()` function — detects `grok` CLI, reads version and quota, outputs JSON entry alongside other tools
- `hooks/shims/grok-appserver.sh`: New executable shim — translates `grok` CLI stdout into Symphony JSON-RPC events (`turn/completed`, `thread/tokenUsage/updated`); handles missing Grok CLI gracefully with STUCK output

## Test
`grep -c 'grok' hooks/detect-tools.sh && test -x hooks/shims/grok-appserver.sh && echo PASS` → PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)