### PR TITLE
fix: rename stats counters to session/all-time scopes (#58)

### DIFF
--- a/hooks/beacon-init.sh
+++ b/hooks/beacon-init.sh
@@ -115,8 +115,10 @@ if [[ ! -f "$STATE_FILE" ]]; then
       issues: {},
       tools: $tools,
       stats: {
-        dispatched: 0,
-        completed: 0,
+        session_dispatched: 0,
+        session_completed: 0,
+        total_dispatched_all_time: 0,
+        total_completed_all_time: 0,
         failed: 0,
         blocked: 0
       }
@@ -130,11 +132,25 @@ else
   fi
 
   # Refresh tools section with current quota data without touching other state.
+  # Also reset session-scoped counters on each startup, and migrate old key names if present.
   NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-  UPDATED=$(jq --argjson tools "$TOOLS_JSON" --arg now "$NOW" \
-    '.tools = $tools | .updated_at = $now' "$STATE_FILE") && \
+  UPDATED=$(jq --argjson tools "$TOOLS_JSON" --arg now "$NOW" '
+    .tools = $tools |
+    .updated_at = $now |
+    # Migrate old "dispatched"/"completed" keys to new schema (keep totals, reset session)
+    if (.stats | has("dispatched")) then
+      .stats.total_dispatched_all_time = (.stats.total_dispatched_all_time // .stats.dispatched) |
+      .stats.total_completed_all_time  = (.stats.total_completed_all_time  // .stats.completed) |
+      del(.stats.dispatched) | del(.stats.completed)
+    else . end |
+    # Ensure all four keys exist
+    .stats.session_dispatched        = 0 |
+    .stats.session_completed         = 0 |
+    .stats.total_dispatched_all_time = (.stats.total_dispatched_all_time // 0) |
+    .stats.total_completed_all_time  = (.stats.total_completed_all_time  // 0)
+  ' "$STATE_FILE") && \
     printf '%s\n' "$UPDATED" > "$STATE_FILE"
-  echo "Refreshed tools quota in $STATE_FILE"
+  echo "Refreshed tools quota and reset session counters in $STATE_FILE"
 fi
 
 # Create config.json for operator overrides (if not present)
@@ -263,7 +279,7 @@ check_available_never_dispatched() {
   fi
 
   local total_dispatches
-  total_dispatches=$(jq -r '.stats.dispatched // 0' "$STATE_FILE" 2>/dev/null) || total_dispatches=0
+  total_dispatches=$(jq -r '.stats.total_dispatched_all_time // 0' "$STATE_FILE" 2>/dev/null) || total_dispatches=0
 
   # Only check if we've done 10+ dispatches
   if (( total_dispatches < 10 )); then

--- a/hooks/update-state.sh
+++ b/hooks/update-state.sh
@@ -92,7 +92,7 @@ NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 # Cleanup temp files on exit
 TMP_FILES=()
-cleanup() { for f in "${TMP_FILES[@]}"; do rm -f "$f"; done; }
+cleanup() { for f in "${TMP_FILES[@]+"${TMP_FILES[@]}"}"; do rm -f "$f"; done; }
 trap cleanup EXIT
 
 make_tmp() { local t; t=$(mktemp); TMP_FILES+=("$t"); echo "$t"; }

--- a/hooks/update-state.sh
+++ b/hooks/update-state.sh
@@ -107,7 +107,7 @@ case "$ACTION" in
     ;;
   set-running)
     NEW_STATE="running"
-    STAT_KEY="dispatched"
+    STAT_KEY="dispatched"  # signals: increment session_dispatched + total_dispatched_all_time
     ADD_LABEL="beacon:in-progress"
     REMOVE_LABELS=("beacon:blocked" "beacon:paused" "beacon:done")
     ;;
@@ -119,7 +119,7 @@ case "$ACTION" in
     ;;
   set-completed)
     NEW_STATE="approved"
-    STAT_KEY="completed"
+    STAT_KEY="completed"  # signals: increment session_completed + total_completed_all_time
     ADD_LABEL=""
     REMOVE_LABELS=()
     ;;
@@ -131,7 +131,7 @@ case "$ACTION" in
     ;;
   set-merged)
     NEW_STATE="merged"
-    STAT_KEY="completed"
+    STAT_KEY="completed"  # signals: increment session_completed + total_completed_all_time
     ADD_LABEL="beacon:done"
     REMOVE_LABELS=("beacon:in-progress" "beacon:blocked" "beacon:paused")
     ;;
@@ -213,12 +213,31 @@ else
     '.issues[$id].state = $state | .updated_at = $now' \
     "$STATE_FILE" > "$TMP" && mv "$TMP" "$STATE_FILE"
 fi
-# Increment stat counter if applicable
+# Increment stat counters if applicable.
+# "dispatched" → session_dispatched + total_dispatched_all_time
+# "completed"  → session_completed  + total_completed_all_time
+# other keys   → incremented directly (e.g. "blocked", "failed")
 if [[ -n "$STAT_KEY" ]]; then
   TMP=$(make_tmp)
-  jq --arg key "$STAT_KEY" \
-    '.stats[$key] += 1' \
-    "$STATE_FILE" > "$TMP" && mv "$TMP" "$STATE_FILE"
+  case "$STAT_KEY" in
+    dispatched)
+      jq '
+        .stats.session_dispatched        = ((.stats.session_dispatched        // 0) + 1) |
+        .stats.total_dispatched_all_time = ((.stats.total_dispatched_all_time // 0) + 1)
+      ' "$STATE_FILE" > "$TMP" && mv "$TMP" "$STATE_FILE"
+      ;;
+    completed)
+      jq '
+        .stats.session_completed        = ((.stats.session_completed        // 0) + 1) |
+        .stats.total_completed_all_time = ((.stats.total_completed_all_time // 0) + 1)
+      ' "$STATE_FILE" > "$TMP" && mv "$TMP" "$STATE_FILE"
+      ;;
+    *)
+      jq --arg key "$STAT_KEY" \
+        '.stats[$key] = ((.stats[$key] // 0) + 1)' \
+        "$STATE_FILE" > "$TMP" && mv "$TMP" "$STATE_FILE"
+      ;;
+  esac
 fi
 
 # Manage GitHub labels for lifecycle transitions

--- a/skills/beacon-status/SKILL.md
+++ b/skills/beacon-status/SKILL.md
@@ -46,7 +46,7 @@ For Claude's quota line: check if `quota.json` has a `claude` entry. If it does,
 Claude:      Claude Max — N dispatches (session)
 ```
 
-where N comes from `state.json` → `stats.claude_dispatches` (or `0` if not set). This accurately reflects session usage without fabricating a percentage.
+where N comes from `state.json` → `stats.session_dispatched` (or `0` if not set). This accurately reflects session usage without fabricating a percentage.
 
 **If file is corrupted** (invalid JSON): Display error and suggest recovery:
 
@@ -96,6 +96,19 @@ If `started_at` is missing, display `Uptime: unknown`.
 
 ### Step 5: Render Output
 
+**PROGRESS fields** — read from `state.json` → `stats`:
+
+| Display label          | JSON key                    |
+| ---------------------- | --------------------------- |
+| Session Dispatched     | `session_dispatched`        |
+| Session Completed      | `session_completed`         |
+| All-time Dispatched    | `total_dispatched_all_time` |
+| All-time Completed     | `total_completed_all_time`  |
+| Failed                 | `failed`                    |
+| Blocked                | `blocked`                   |
+
+`session_*` counters reset to 0 on each `/beacon:start`. `total_*` counters grow monotonically across sessions.
+
 ## Output Format
 
 ```
@@ -117,7 +130,8 @@ QUOTA
   Gemini:      ██████░░░░░░░░░░░░░░ ~30%  (5 dispatches, est.)
 
 PROGRESS
-  Dispatched: 12  Completed: 8  Failed: 1  Blocked: 0
+  Session:   Dispatched: 4   Completed: 3   Failed: 1  Blocked: 0
+  All-time:  Dispatched: 45  Completed: 40
   PRs open: 3  PRs merged: 5
 ```
 
@@ -156,7 +170,8 @@ QUOTA
   <same format>
 
 PROGRESS
-  Dispatched: 12  Completed: 12  Failed: 0  Blocked: 0
+  Session:   Dispatched: 12  Completed: 12  Failed: 0  Blocked: 0
+  All-time:  Dispatched: 68  Completed: 68
   PRs open: 0  PRs merged: 12
   All issues in current phase complete. Run checkpoint to continue.
 ```


### PR DESCRIPTION
Closes #58

## Changes
- `hooks/beacon-init.sh`: Resets `session_dispatched`/`session_completed` to 0 on startup; preserves `total_*` all-time counters with migration fallback
- `hooks/update-state.sh`: Increments both `session_*` and `total_*_all_time` on set-running/set-completed/set-merged
- `skills/beacon-status/SKILL.md`: Shows Session and All-time rows separately in PROGRESS block

## Test
`grep -c 'session_dispatched\|total_dispatched' hooks/update-state.sh` → PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)