### PR TITLE
fix: wire monitor-prs.sh completion detection for Claude agents (#59)

### DIFF
--- a/hooks/monitor-agents.sh
+++ b/hooks/monitor-agents.sh
@@ -5,6 +5,7 @@
 
 BEACON_DIR=".beacon"
 WORKSPACE_DIR="$BEACON_DIR/workspaces"
+STATE_FILE="$BEACON_DIR/state.json"
 
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
   echo "Error: not inside a git repository" >&2
@@ -55,6 +56,22 @@ check_dead_panes() {
     done
 }
 
+# Return true (0) if the issue with the given key has worktree_free=true in state.json.
+# These issues are dispatched without a worktree (e.g. claude-haiku/claude-sonnet subagents)
+# and their completion is detected by monitor-prs.sh when the PR merges — not by watching
+# a pane.log that doesn't exist.
+is_worktree_free() {
+  local key="$1"
+  local issue_num="${key#issue-}"
+  if [[ -f "$STATE_FILE" ]] && command -v jq >/dev/null 2>&1; then
+    local flag
+    flag=$(jq -r --arg k "$issue_num" '.issues[$k].worktree_free // false' "$STATE_FILE" 2>/dev/null)
+    [[ "$flag" == "true" ]]
+  else
+    return 1
+  fi
+}
+
 # Watch all existing pane.log files. Also periodically scan for new ones.
 watch_logs() {
   local pids=()
@@ -65,6 +82,11 @@ watch_logs() {
       [[ -f "$logfile" ]] || continue
       key=$(basename "$(dirname "$logfile")")
       pid_file="$WORKSPACE_DIR/$key/.watcher.pid"
+
+      # Skip worktree_free issues — their completion is handled by monitor-prs.sh
+      if is_worktree_free "$key"; then
+        continue
+      fi
 
       # Skip if already watching this log
       if [[ -f "$pid_file" ]]; then

--- a/hooks/monitor-prs.sh
+++ b/hooks/monitor-prs.sh
@@ -102,6 +102,20 @@ while true; do
       age=$((now_epoch - merged_epoch))
       if [[ $age -lt 60 ]]; then
         emit_if_changed "$num" "[PR_MERGED]"
+
+        # Transition state to merged and write completed_at for the linked issue.
+        # Look up which issue this PR belongs to by matching pr_number in state.json.
+        if [[ -f "$STATE_FILE" ]] && command -v jq >/dev/null 2>&1; then
+          ISSUE_ID=$(jq -r --argjson pr "$num" \
+            '.issues | to_entries[] | select(.value.pr_number == $pr) | .key' \
+            "$STATE_FILE" 2>/dev/null | head -1)
+          if [[ -n "$ISSUE_ID" ]]; then
+            COMPLETED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+            bash "$REPO_ROOT/hooks/update-state.sh" set-merged "$ISSUE_ID" \
+              completed_at="$COMPLETED_AT" 2>/dev/null || true
+            echo "[BEACON] Transitioned issue $ISSUE_ID to merged (PR #$num, completed_at=$COMPLETED_AT)"
+          fi
+        fi
       fi
     done
 

--- a/hooks/update-state.sh
+++ b/hooks/update-state.sh
@@ -272,6 +272,19 @@ for pair in "$@"; do
       '.issues[$id][$key] = $val' \
       "$STATE_FILE" > "$TMP" && mv "$TMP" "$STATE_FILE"
   fi
+
+  # When agent is set to a Claude model (non-worktree dispatch), mark worktree_free=true
+  # so monitor-agents.sh skips the issue and defers to monitor-prs.sh for completion.
+  if [[ "$KEY" == "agent" ]]; then
+    case "$VALUE" in
+      claude-haiku|claude-sonnet|claude-haiku-*|claude-sonnet-*)
+        TMP=$(make_tmp)
+        jq --arg id "$ISSUE_ID" \
+          '.issues[$id].worktree_free = true' \
+          "$STATE_FILE" > "$TMP" && mv "$TMP" "$STATE_FILE"
+        ;;
+    esac
+  fi
 done
 
 echo "Updated issue $ISSUE_ID: state=$NEW_STATE"


### PR DESCRIPTION
Closes #59

## Changes
- `hooks/monitor-prs.sh`: On PR merge detection, looks up issue by `pr_number` in state.json and calls `update-state.sh set-merged <ISSUE_ID> completed_at=<timestamp>` — transitions stuck `pr-open` records to `merged`
- `hooks/update-state.sh`: When `agent=claude-haiku|claude-sonnet` (+ versioned variants), atomically sets `worktree_free: true` on the issue record
- `hooks/monitor-agents.sh`: Added `is_worktree_free()` helper; `watch_logs()` loop skips `worktree_free` issues, deferring to `monitor-prs.sh`

## Test
`grep -c 'completed_at\|worktree_free' hooks/monitor-prs.sh` → 3 matches (PASS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)