### PR TITLE
feat: token-ledger.json schema + write path (#48)

### DIFF
--- a/hooks/beacon-init.sh
+++ b/hooks/beacon-init.sh
@@ -9,6 +9,7 @@ BEACON_VERSION="0.1.0"
 BEACON_DIR=".beacon"
 STATE_FILE="$BEACON_DIR/state.json"
 WORKSPACES_DIR="$BEACON_DIR/workspaces"
+LEDGER_FILE="$BEACON_DIR/token-ledger.json"
 
 # Resolve the directory this script lives in so we can call sibling scripts.
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -159,6 +160,72 @@ if [[ ! -f "$CONFIG_FILE" ]]; then
   echo '{}' > "$CONFIG_FILE"
   echo "Initialized $CONFIG_FILE (add test_command, etc. for overrides)"
 fi
+
+# --- Token Ledger: create + append new session entry ---
+init_token_ledger() {
+  local ledger="$BEACON_DIR/token-ledger.json"
+  local lock="${ledger%.json}.lock"
+  local now
+  now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+  # Generate a session ID from epoch seconds + PID for uniqueness
+  local session_id
+  session_id="session-$(date -u +%s)-$$"
+
+  # Build new session object
+  local new_session
+  new_session=$(jq -n \
+    --arg sid "$session_id" \
+    --arg now "$now" \
+    --arg repo "$REPO_SLUG" \
+    '{session_id: $sid, started_at: $now, repo: $repo, issues: []}')
+
+  # Write new session into the ledger (caller must hold lock)
+  _ledger_write() {
+    local tmp
+    tmp=$(mktemp)
+    if [[ -f "$ledger" ]] && jq '.' "$ledger" >/dev/null 2>&1; then
+      jq --argjson s "$new_session" '.sessions += [$s]' "$ledger" > "$tmp" \
+        && mv "$tmp" "$ledger"
+    else
+      jq -n --argjson s "$new_session" \
+        '{schema_version: 1, sessions: [$s]}' > "$tmp" \
+        && mv "$tmp" "$ledger"
+    fi
+  }
+
+  if command -v flock >/dev/null 2>&1; then
+    exec 9>"$lock"
+    flock -x 9
+    _ledger_write
+    exec 9>&-
+  elif command -v lockf >/dev/null 2>&1; then
+    # lockf -k holds the lock for the duration of the child process.
+    # We write the session object to a temp file so the child can read it
+    # without quoting/escaping issues.
+    local session_tmp
+    session_tmp=$(mktemp)
+    printf '%s' "$new_session" > "$session_tmp"
+    lockf -k "$lock" bash -c "
+      ledger='$ledger'
+      new_session=\$(cat '$session_tmp')
+      tmp=\$(mktemp)
+      if [[ -f \"\$ledger\" ]] && jq '.' \"\$ledger\" >/dev/null 2>&1; then
+        jq --argjson s \"\$new_session\" '.sessions += [\$s]' \"\$ledger\" > \"\$tmp\" && mv \"\$tmp\" \"\$ledger\"
+      else
+        jq -n --argjson s \"\$new_session\" '{schema_version: 1, sessions: [\$s]}' > \"\$tmp\" && mv \"\$tmp\" \"\$ledger\"
+      fi
+    "
+    rm -f "$session_tmp"
+  else
+    # No lock mechanism available — write directly
+    _ledger_write
+  fi
+
+  echo "Token ledger updated: $ledger (session $session_id)"
+}
+
+init_token_ledger || true
 
 # Create GitHub labels if the repo is on GitHub and gh CLI is available
 create_github_labels() {

--- a/hooks/update-state.sh
+++ b/hooks/update-state.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 
 BEACON_DIR=".beacon"
 STATE_FILE="$BEACON_DIR/state.json"
+LEDGER_FILE="$BEACON_DIR/token-ledger.json"
 
 # Locate repo root
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
@@ -14,6 +15,7 @@ REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
   exit 1
 }
 STATE_FILE="$REPO_ROOT/$STATE_FILE"
+LEDGER_FILE="$REPO_ROOT/$LEDGER_FILE"
 
 # Acquire exclusive lock for entire script duration.
 # Prevents concurrent read-modify-write races between parallel update-state.sh invocations.
@@ -81,6 +83,98 @@ manage_labels() {
     if gh label list --repo "$repo_slug" --json name --jq ".[].name" 2>/dev/null | grep -q "^${add_label}$"; then
       gh issue edit "$issue_id" --repo "$repo_slug" --add-label "$add_label" 2>/dev/null || true
     fi
+  fi
+}
+
+# append_ledger_record — append an issue record to the current session in token-ledger.json.
+# Usage: append_ledger_record <issue_id> <verdict>
+# Reads complexity, agent, pr_number, attempt, task_type, started_at from state.json.
+append_ledger_record() {
+  local issue_id="$1"
+  local verdict="$2"
+  local ledger="$LEDGER_FILE"
+  local lock="${ledger%.json}.lock"
+
+  if [[ ! -f "$ledger" ]]; then
+    # Ledger not created yet (beacon-init hasn't run with ledger support) — skip
+    return 0
+  fi
+
+  # Read fields from state.json
+  local issue_number complexity agent pr_number attempt task_type started_at duration_ms
+  issue_number=$(echo "$issue_id" | grep -o '[0-9]*' | head -1)
+  complexity=$(jq -r --arg k "$issue_id" '.issues[$k].complexity // "medium"' "$STATE_FILE" 2>/dev/null) || complexity="medium"
+  agent=$(jq -r --arg k "$issue_id" '.issues[$k].agent // ""' "$STATE_FILE" 2>/dev/null) || agent=""
+  pr_number=$(jq -r --arg k "$issue_id" '.issues[$k].pr_number // 0' "$STATE_FILE" 2>/dev/null) || pr_number=0
+  attempt=$(jq -r --arg k "$issue_id" '.issues[$k].attempt // 1' "$STATE_FILE" 2>/dev/null) || attempt=1
+  task_type=$(jq -r --arg k "$issue_id" '.issues[$k].task_type // "medium_code"' "$STATE_FILE" 2>/dev/null) || task_type="medium_code"
+  started_at=$(jq -r --arg k "$issue_id" '.issues[$k].started_at // ""' "$STATE_FILE" 2>/dev/null) || started_at=""
+
+  # Compute duration_ms from started_at to now
+  duration_ms=0
+  if [[ -n "$started_at" ]]; then
+    local start_epoch now_epoch
+    start_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$started_at" +%s 2>/dev/null \
+      || date -d "$started_at" +%s 2>/dev/null \
+      || echo 0)
+    now_epoch=$(date -u +%s)
+    if [[ "$start_epoch" -gt 0 && "$now_epoch" -ge "$start_epoch" ]]; then
+      duration_ms=$(( (now_epoch - start_epoch) * 1000 ))
+    fi
+  fi
+
+  # Coerce pr_number and attempt to integers
+  pr_number=$(( ${pr_number:-0} )) || pr_number=0
+  attempt=$(( ${attempt:-1} )) || attempt=1
+
+  # Build the record JSON
+  local record
+  record=$(jq -n \
+    --argjson num "$issue_number" \
+    --arg type "$task_type" \
+    --arg complexity "$complexity" \
+    --arg agent "$agent" \
+    --argjson tokens 0 \
+    --argjson dur "$duration_ms" \
+    --arg verdict "$verdict" \
+    --argjson pr "$pr_number" \
+    --argjson att "$attempt" \
+    '{number: $num, type: $type, complexity: $complexity, agent: $agent,
+      tokens_used: $tokens, duration_ms: $dur, verdict: $verdict,
+      pr_number: $pr, attempt: $att}')
+
+  # Write record into last session using lock
+  _write_ledger_record() {
+    local tmp
+    tmp=$(mktemp)
+    jq --argjson r "$record" \
+      'if (.sessions | length) > 0
+       then .sessions[-1].issues += [$r]
+       else .
+       end' \
+      "$ledger" > "$tmp" && mv "$tmp" "$ledger"
+  }
+
+  if command -v flock >/dev/null 2>&1; then
+    exec 9>"$lock"
+    flock -x 9
+    _write_ledger_record
+    exec 9>&-
+  elif command -v lockf >/dev/null 2>&1; then
+    local record_tmp
+    record_tmp=$(mktemp)
+    printf '%s' "$record" > "$record_tmp"
+    lockf -k "$lock" bash -c "
+      ledger='$ledger'
+      record=\$(cat '$record_tmp')
+      tmp=\$(mktemp)
+      jq --argjson r \"\$record\" \
+        'if (.sessions | length) > 0 then .sessions[-1].issues += [\$r] else . end' \
+        \"\$ledger\" > \"\$tmp\" && mv \"\$tmp\" \"\$ledger\"
+    "
+    rm -f "$record_tmp"
+  else
+    _write_ledger_record
   fi
 }
 
@@ -238,6 +332,11 @@ if [[ -n "$STAT_KEY" ]]; then
         "$STATE_FILE" > "$TMP" && mv "$TMP" "$STATE_FILE"
       ;;
   esac
+fi
+
+# Append issue record to token ledger for completion events
+if [[ "$ACTION" == "set-completed" || "$ACTION" == "set-merged" ]]; then
+  append_ledger_record "$ISSUE_ID" "pass" || true
 fi
 
 # Manage GitHub labels for lifecycle transitions


### PR DESCRIPTION
Closes #48

## Changes
- `hooks/beacon-init.sh`: `init_token_ledger()` creates `.beacon/token-ledger.json` on first start; appends new session entry on each startup (never overwrites); uses flock/lockf for concurrent safety
- `hooks/update-state.sh`: `append_ledger_record()` triggered on set-completed/set-merged — appends full issue record (number, type, complexity, agent, tokens_used=0, duration_ms, verdict, pr_number, attempt) to current session

`tokens_used` is 0 for now — wired in #50.

## Test
`bash hooks/beacon-init.sh && test -f .beacon/token-ledger.json && echo PASS`

🤖 Generated with [Claude Code](https://claude.com/claude-code)