### PR TITLE
feat: Claude Haiku/Sonnet → Symphony event-queue dispatch (#46)

### DIFF
--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -78,3 +78,15 @@ ACCEPTANCE_CRITERIA_MET:
 - If confidence is LOW, say so — Opus will escalate to deeper review.
 - Never modify code. You only evaluate.
 - If tests fail but the failures are pre-existing (not related to the diff), note this and do not auto-FAIL.
+
+## After Writing BEACON_RESULT.md
+
+After writing `BEACON_RESULT.md`, write your verdict to `.beacon/event-queue.json` as a verify event using the atomic flock pattern:
+
+```bash
+VERDICT="PASS"  # or FAIL
+EVENT="{\"type\":\"verify\",\"issue\":\"<issue-key>\",\"priority\":2,\"data\":{\"verdict\":\"$VERDICT\"}}"
+flock .beacon/event-queue.lock \
+  jq --argjson evt "$EVENT" '. + [$evt]' .beacon/event-queue.json \
+  > .beacon/event-queue.tmp && mv .beacon/event-queue.tmp .beacon/event-queue.json
+```

--- a/skills/beacon-dispatch/SKILL.md
+++ b/skills/beacon-dispatch/SKILL.md
@@ -307,6 +307,8 @@ This check runs after every `split-window` call in Step 3A.
 
 ## Step 3B: Dispatch Claude Haiku Agent (Simple)
 
+> **Note:** Claude agents do NOT use pane.log or pipe-pane. `monitor-prs.sh` handles their completion detection. `completed_at` is written by `monitor-prs.sh` on PR merge (implemented in #59).
+
 Use TeamCreate for visibility:
 
 ```
@@ -383,15 +385,26 @@ Agent({
 })
 ```
 
+After dispatching, write a dispatch record to the event queue:
+
+```bash
+EVENT='{"type":"verify","issue":"<issue-key>","priority":2,"data":{"agent":"claude-haiku","worktree_free":true}}'
+flock .beacon/event-queue.lock \
+  jq --argjson evt "$EVENT" '. + [$evt]' .beacon/event-queue.json \
+  > .beacon/event-queue.tmp && mv .beacon/event-queue.tmp .beacon/event-queue.json
+```
+
 Update state:
 
 ```bash
-bash hooks/update-state.sh set-running <issue-id> agent=claude-haiku
+bash hooks/update-state.sh set-running <issue-id> agent=claude-haiku worktree_free=true
 ```
 
 ---
 
 ## Step 3C: Dispatch Claude Sonnet Agent (Medium/Complex)
+
+> **Note:** Claude agents do NOT use pane.log or pipe-pane. `monitor-prs.sh` handles their completion detection. `completed_at` is written by `monitor-prs.sh` on PR merge (implemented in #59).
 
 Same structure as Haiku, but with autoresearch and more context:
 
@@ -462,10 +475,19 @@ Agent({
 })
 ```
 
+After dispatching, write a dispatch record to the event queue:
+
+```bash
+EVENT='{"type":"verify","issue":"<issue-key>","priority":2,"data":{"agent":"claude-sonnet","worktree_free":true}}'
+flock .beacon/event-queue.lock \
+  jq --argjson evt "$EVENT" '. + [$evt]' .beacon/event-queue.json \
+  > .beacon/event-queue.tmp && mv .beacon/event-queue.tmp .beacon/event-queue.json
+```
+
 Update state:
 
 ```bash
-bash hooks/update-state.sh set-running <issue-id> agent=claude-sonnet
+bash hooks/update-state.sh set-running <issue-id> agent=claude-sonnet worktree_free=true
 ```
 
 ---


### PR DESCRIPTION
Closes #46

## Changes
- `skills/beacon-dispatch/SKILL.md`: Step 3B (Haiku) and 3C (Sonnet) — added `worktree_free=true` to dispatch state update, atomic flock event-queue write after dispatch, explicit "do NOT use pane.log/pipe-pane" notes
- `agents/reviewer.md`: Added section instructing reviewer to write verify event to `.beacon/event-queue.json` using atomic flock pattern after writing BEACON_RESULT.md

## Test
`grep -c 'worktree_free' skills/beacon-dispatch/SKILL.md` → 4 matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)