### PR TITLE
feat(tools): replace Grok CLI with Copilot CLI (#79)

### DIFF
--- a/BEACON_RESULT.md
+++ b/BEACON_RESULT.md
@@ -1,20 +1,21 @@
-# Result: #43 — Implement Codex app-server JSON-RPC dispatch (replace tmux pipe-pane)
+# Result: #79 — Replace Grok CLI with Copilot CLI in detect-tools.sh and dispatch routing
 
 ## Status: DONE
 
 ## Changes Made
 
-- `hooks/dispatch-codex-appserver.sh` (new, executable): Spawns `codex app-server` via mkfifo IPC, drives JSON-RPC protocol (initialize → thread/start → turn/start), reads turn/completed|turn/failed|thread/tokenUsage/updated events, writes COMPLETE/STUCK to pane.log, emits verify/agent_stuck event to event-queue.json via atomic flock write. 300s stall watchdog kills subprocess on timeout.
-- `skills/beacon-dispatch/SKILL.md`: Removed Step 0 (Verify Tmux Layout) entirely. Replaced Step 3A Codex tmux block with `bash hooks/dispatch-codex-appserver.sh "$ISSUE_KEY" "$PROMPT_FILE" &`. Gemini tmux dispatch preserved. Updated Step 2 and "20+ Pane Handling" sections to note Codex exclusion. Removed `pane_id=$PANE_ID` from Codex state update.
+- `hooks/detect-tools.sh`: Removed `detect_grok()` function and its call in the JSON output section. Added `detect_copilot()` function that detects `gh copilot` (extension) or standalone `copilot` binary, outputs quota_pct: -1 (unknown/unlimited) and exhausted: false.
+- `hooks/shims/grok-appserver.sh`: Added deprecation notice at top of file (early exit with error message). File preserved for git history.
+- `skills/beacon-dispatch/SKILL.md`: Updated intro line and Dispatch Priority Matrix table to reference Copilot instead of Grok. Removed TODO comment about Grok support.
+- `CLAUDE.md`: Updated Workers line to reference Codex/Gemini/Copilot instead of Codex/Gemini/Grok.
 
 ## Tests
 
-- Command: `test -x hooks/dispatch-codex-appserver.sh && grep -c 'app-server' hooks/dispatch-codex-appserver.sh`
-- Result: PASS
+- Command: N/A (no automated tests in this repo)
+- Result: N/A
 - New tests added: no
 
 ## Notes
 
-- `monitor-agents.sh` unchanged — already tails pane.log; dispatch-codex-appserver.sh writes status words there directly
-- Gemini retains tmux pane dispatch; only Codex migrated to app-server
-- `pane_id` field deprecated for Codex issues in state.json
+- `detect_copilot()` supports two variants: `gh copilot` (GitHub CLI extension) and standalone `copilot` binary. Both report `quota_pct: -1` since Copilot quota is not queryable via CLI.
+- The grok-appserver.sh shim exits 1 immediately with an error to stderr, preventing accidental use.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Four-tier model: Bash watches → Haiku thinks → Sonnet orchestrates → Opus 
 
 - **Executor**: Sonnet — event-driven orchestration, dispatch, verification pipeline
 - **Advisor**: Opus — spawned at strategic decision points (UltraPlan, phase checkpoints, escalations)
-- **Workers**: Third-party first (Codex/Gemini/Grok) for simple/medium; Claude Haiku/Sonnet as fallback
+- **Workers**: Third-party first (Codex/Gemini/Copilot) for simple/medium; Claude Haiku/Sonnet as fallback
 - **Triage**: Haiku — interprets Monitor events, categorizes PR comments, queues actions
 - **Reviewer**: Sonnet — verifies work against acceptance criteria
 - **Monitors**: 3 bash scripts (agent 5s, PR 30s, issues 60s) via Monitor tool

--- a/hooks/detect-tools.sh
+++ b/hooks/detect-tools.sh
@@ -145,13 +145,19 @@ detect_gemini() {
   fi
 }
 
-detect_grok() {
-  if command -v grok >/dev/null 2>&1; then
-    ver=$(grok --version 2>/dev/null | head -1) || ver="unknown"
-    qpct=$(_read_quota "grok")
-    printf '"grok": {"available": true, "version": "%s", "quota_pct": %s}' "$ver" "$qpct"
+detect_copilot() {
+  if command -v gh >/dev/null 2>&1 && gh copilot --version >/dev/null 2>&1; then
+    local ver
+    ver=$(gh copilot --version 2>/dev/null | head -1) || ver="unknown"
+    ver=$(printf '%s' "$ver" | sed 's/\\/\\\\/g; s/"/\\"/g' | tr -d '\n')
+    printf '"copilot": {"available": true, "version": "%s", "quota_pct": -1, "exhausted": false}' "$ver"
+  elif command -v copilot >/dev/null 2>&1; then
+    local ver
+    ver=$(copilot --version 2>/dev/null | head -1) || ver="unknown"
+    ver=$(printf '%s' "$ver" | sed 's/\\/\\\\/g; s/"/\\"/g' | tr -d '\n')
+    printf '"copilot": {"available": true, "version": "%s", "quota_pct": -1, "exhausted": false}' "$ver"
   else
-    printf '"grok": {"available": false, "quota_pct": -1}'
+    printf '"copilot": {"available": false, "quota_pct": -1}'
   fi
 }
 
@@ -166,7 +172,7 @@ detect_codex
 echo -n ", "
 detect_gemini
 echo -n ", "
-detect_grok
+detect_copilot
 echo "}"
 
 exit 0

--- a/hooks/shims/grok-appserver.sh
+++ b/hooks/shims/grok-appserver.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# DEPRECATED: Grok CLI removed — does not support OAuth authentication.
+# This shim is no longer used. Kept for git history only.
+echo "ERROR: grok-appserver.sh is deprecated. Use copilot or gemini instead." >&2
+exit 1
+
 # grok-appserver.sh — Thin Symphony shim for the Grok CLI.
 #
 # Usage:

--- a/skills/beacon-dispatch/SKILL.md
+++ b/skills/beacon-dispatch/SKILL.md
@@ -6,19 +6,17 @@ tools: ["Bash", "Agent", "Write", "Read", "TeamCreate"]
 
 # Beacon Dispatch Protocol — v3
 
-Third-party tools (Codex/Gemini) are dispatched first for simple and medium issues to maximize external quota usage. Claude agents are reserved for complex work and fallback.
+Third-party tools (Codex/Gemini/Copilot) are dispatched first for simple and medium issues to maximize external quota usage. Claude agents are reserved for complex work and fallback.
 
 ---
 
 ## Dispatch Priority Matrix
 
-| Complexity | Primary                       | Fallback                      | Last Resort              |
-| ---------- | ----------------------------- | ----------------------------- | ------------------------ |
-| Simple     | Codex-Spark/GPT (quota > 10%) | Gemini (quota > 10%) → Haiku  | Claude Haiku (rate-lim)  |
-| Medium     | Codex-Spark/GPT (quota > 10%) | Gemini (quota > 10%) → Sonnet | Claude Sonnet (rate-lim) |
-| Complex    | Claude Sonnet + autoresearch  | Claude Sonnet (retry)         | Opus advisor: re-slice   |
-
-# TODO: Grok support pending CLI detection
+| Complexity | Primary                       | Fallback                                      | Last Resort              |
+| ---------- | ----------------------------- | --------------------------------------------- | ------------------------ |
+| Simple     | Codex-Spark/GPT (quota > 10%) | Gemini/Copilot (quota > 10%) → Haiku          | Claude Haiku (rate-lim)  |
+| Medium     | Codex-Spark/GPT (quota > 10%) | Gemini/Copilot (quota > 10%) → Sonnet         | Claude Sonnet (rate-lim) |
+| Complex    | Claude Sonnet + autoresearch  | Claude Sonnet (retry)                         | Opus advisor: re-slice   |
 
 Check quota before dispatch:
 


### PR DESCRIPTION
## Summary
- `hooks/detect-tools.sh`: removes `detect_grok()`, adds `detect_copilot()` (checks `gh copilot` extension first, then standalone `copilot` binary; quota_pct: -1)
- `hooks/shims/grok-appserver.sh`: deprecation header added — exits 1 with error, file retained for git history
- `skills/beacon-dispatch/SKILL.md`: routing matrix updated to reference `copilot` instead of `grok`; TODO comment removed
- `CLAUDE.md`: Workers line updated to `Codex/Gemini/Copilot`

Grok CLI removed — does not support OAuth authentication.

## Test plan
- [x] detect_copilot() version sanitization prevents shell injection
- [x] grok-appserver.sh preserved with deprecation header
- [x] Reviewer: PASS (high confidence)

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)