### PR TITLE
feat(tokens): wire token extraction from Symphony events into ledger (#50)

### DIFF
--- a/hooks/shims/grok-appserver.sh
+++ b/hooks/shims/grok-appserver.sh
@@ -6,6 +6,9 @@ exit 1
 
 # grok-appserver.sh — Thin Symphony shim for the Grok CLI.
 #
+# DEPRECATED: Grok CLI has no OAuth support and is being phased out.
+# tokens_used is always reported as -1 (sentinel: unparseable/unavailable).
+#
 # Usage:
 #   echo '{"type":"turn/start","prompt":"..."}' | grok-appserver.sh
 #   grok-appserver.sh /path/to/prompt-file.json
@@ -82,11 +85,12 @@ EXIT_CODE=0
 grok --prompt-file "$TMPFILE" || EXIT_CODE=$?
 
 # ---------------------------------------------------------------------------
-# Emit synthetic Symphony JSON-RPC completion events
+# Emit synthetic Symphony JSON-RPC completion events.
+# Token count is always -1 (sentinel) — Grok CLI does not expose token usage.
 # ---------------------------------------------------------------------------
 if [[ $EXIT_CODE -eq 0 ]]; then
   printf '{"type":"turn/completed","threadId":"%s","status":"success"}\n' "$THREAD_ID"
-  printf '{"type":"thread/tokenUsage/updated","threadId":"%s","totalTokens":0}\n' "$THREAD_ID"
+  printf '{"type":"thread/tokenUsage/updated","threadId":"%s","totalTokens":-1}\n' "$THREAD_ID"
   echo "COMPLETE"
 else
   printf '{"type":"turn/error","threadId":"%s","status":"error","exitCode":%d}\n' \

--- a/hooks/update-state.sh
+++ b/hooks/update-state.sh
@@ -101,7 +101,7 @@ append_ledger_record() {
   fi
 
   # Read fields from state.json
-  local issue_number complexity agent pr_number attempt task_type started_at duration_ms
+  local issue_number complexity agent pr_number attempt task_type started_at duration_ms tokens_used
   issue_number=$(echo "$issue_id" | grep -o '[0-9]*' | head -1)
   complexity=$(jq -r --arg k "$issue_id" '.issues[$k].complexity // "medium"' "$STATE_FILE" 2>/dev/null) || complexity="medium"
   agent=$(jq -r --arg k "$issue_id" '.issues[$k].agent // ""' "$STATE_FILE" 2>/dev/null) || agent=""
@@ -109,6 +109,7 @@ append_ledger_record() {
   attempt=$(jq -r --arg k "$issue_id" '.issues[$k].attempt // 1' "$STATE_FILE" 2>/dev/null) || attempt=1
   task_type=$(jq -r --arg k "$issue_id" '.issues[$k].task_type // "medium_code"' "$STATE_FILE" 2>/dev/null) || task_type="medium_code"
   started_at=$(jq -r --arg k "$issue_id" '.issues[$k].started_at // ""' "$STATE_FILE" 2>/dev/null) || started_at=""
+  tokens_used=$(jq -r --arg k "$issue_id" '.issues[$k].tokens_used // 0' "$STATE_FILE" 2>/dev/null) || tokens_used=0
 
   # Compute duration_ms from started_at to now
   duration_ms=0
@@ -123,9 +124,10 @@ append_ledger_record() {
     fi
   fi
 
-  # Coerce pr_number and attempt to integers
+  # Coerce pr_number, attempt, and tokens_used to integers
   pr_number=$(( ${pr_number:-0} )) || pr_number=0
   attempt=$(( ${attempt:-1} )) || attempt=1
+  tokens_used=$(( ${tokens_used:-0} )) || tokens_used=0
 
   # Build the record JSON
   local record
@@ -134,7 +136,7 @@ append_ledger_record() {
     --arg type "$task_type" \
     --arg complexity "$complexity" \
     --arg agent "$agent" \
-    --argjson tokens 0 \
+    --argjson tokens "$tokens_used" \
     --argjson dur "$duration_ms" \
     --arg verdict "$verdict" \
     --argjson pr "$pr_number" \


### PR DESCRIPTION
## Summary
- `hooks/update-state.sh`: `append_ledger_record()` now reads `tokens_used` from state.json (integer-coerced) instead of hardcoded 0
- `hooks/shims/grok-appserver.sh`: changed totalTokens sentinel from 0 to -1 (deprecated tool)
- `gemini-appserver.sh` already correct — no changes needed

Two-step flow: `set-running tokens_used=N` accumulates during dispatch; `set-completed` reads the value when writing the ledger record.

## Test plan
- [x] All key/value writes use jq --argjson parameterization (no injection)
- [x] Fallback to 0 if set-completed called without prior token update (acceptable)
- [x] Reviewer: PASS (high confidence)

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)