### PR TITLE
refactor: extract emit-event.sh helper to DRY flock/event-queue pattern (#81)

### DIFF
--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -86,7 +86,5 @@ After writing `BEACON_RESULT.md`, write your verdict to `.beacon/event-queue.jso
 ```bash
 VERDICT="PASS"  # or FAIL
 EVENT="{\"type\":\"verify\",\"issue\":\"<issue-key>\",\"priority\":2,\"data\":{\"verdict\":\"$VERDICT\"}}"
-flock .beacon/event-queue.lock \
-  jq --argjson evt "$EVENT" '. + [$evt]' .beacon/event-queue.json \
-  > .beacon/event-queue.tmp && mv .beacon/event-queue.tmp .beacon/event-queue.json
+bash hooks/emit-event.sh "$EVENT"
 ```

--- a/hooks/dispatch-codex-appserver.sh
+++ b/hooks/dispatch-codex-appserver.sh
@@ -11,8 +11,7 @@ PROMPT_FILE="${2:?usage: dispatch-codex-appserver.sh <issue-key> <prompt-file>}"
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 WORKSPACE="${REPO_ROOT}/.beacon/workspaces/${ISSUE_KEY}"
 PANE_LOG="${WORKSPACE}/pane.log"
-EVENT_QUEUE="${REPO_ROOT}/.beacon/event-queue.json"
-EVENT_LOCK="${REPO_ROOT}/.beacon/event-queue.lock"
+
 STALL_TIMEOUT="${STALL_TIMEOUT_MS:-300000}"
 STALL_SECS=$(( STALL_TIMEOUT / 1000 ))
 
@@ -135,10 +134,7 @@ EVENT=$(jq -n \
   --arg ts      "$NOW" \
   '{type: $type, issue: $issue, issue_number: ($issueN | tonumber), tokens_used: $tok, timestamp: $ts}')
 
-touch "$EVENT_QUEUE" "$EVENT_LOCK"
-flock "${EVENT_LOCK}" \
-  jq --argjson evt "$EVENT" '. + [$evt]' "$EVENT_QUEUE" > "${EVENT_QUEUE}.tmp" \
-  && mv "${EVENT_QUEUE}.tmp" "$EVENT_QUEUE"
+bash "${REPO_ROOT}/hooks/emit-event.sh" "$EVENT"
 
 # Update token count in state.json
 bash "${REPO_ROOT}/hooks/update-state.sh" set-running "$ISSUE_KEY" "tokens_used=${TOKENS_USED}" 2>/dev/null || true

--- a/hooks/emit-event.sh
+++ b/hooks/emit-event.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# emit-event.sh — Atomically append one event to .beacon/event-queue.json
+#
+# Usage:
+#   bash hooks/emit-event.sh '<json-event-object>'
+#
+# Example:
+#   bash hooks/emit-event.sh '{"type":"verify","issue":"issue-42","tokens_used":1200}'
+#
+# The event is appended to event-queue.json using flock to prevent
+# concurrent writes from corrupting the JSON array.
+#
+# Environment:
+#   BEACON_ROOT — repo root (default: current directory)
+
+set -euo pipefail
+
+EVENT="${1:?usage: emit-event.sh '<json-event-string>'}"
+REPO_ROOT="${BEACON_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || echo ".")}"
+QUEUE="${REPO_ROOT}/.beacon/event-queue.json"
+LOCK="${REPO_ROOT}/.beacon/event-queue.lock"
+
+# Ensure queue exists as a valid JSON array
+if [[ ! -f "$QUEUE" ]] || ! jq -e 'if type == "array" then true else false end' "$QUEUE" >/dev/null 2>&1; then
+  echo "[]" > "$QUEUE"
+fi
+touch "$LOCK"
+
+flock "$LOCK" \
+  jq --argjson evt "$EVENT" '. + [$evt]' "$QUEUE" > "${QUEUE}.tmp" \
+  && mv "${QUEUE}.tmp" "$QUEUE"

--- a/skills/beacon-dispatch/SKILL.md
+++ b/skills/beacon-dispatch/SKILL.md
@@ -386,9 +386,7 @@ After dispatching, write a dispatch record to the event queue:
 
 ```bash
 EVENT='{"type":"verify","issue":"<issue-key>","priority":2,"data":{"agent":"claude-haiku","worktree_free":true}}'
-flock .beacon/event-queue.lock \
-  jq --argjson evt "$EVENT" '. + [$evt]' .beacon/event-queue.json \
-  > .beacon/event-queue.tmp && mv .beacon/event-queue.tmp .beacon/event-queue.json
+bash hooks/emit-event.sh "$EVENT"
 ```
 
 Update state:
@@ -476,9 +474,7 @@ After dispatching, write a dispatch record to the event queue:
 
 ```bash
 EVENT='{"type":"verify","issue":"<issue-key>","priority":2,"data":{"agent":"claude-sonnet","worktree_free":true}}'
-flock .beacon/event-queue.lock \
-  jq --argjson evt "$EVENT" '. + [$evt]' .beacon/event-queue.json \
-  > .beacon/event-queue.tmp && mv .beacon/event-queue.tmp .beacon/event-queue.json
+bash hooks/emit-event.sh "$EVENT"
 ```
 
 Update state:


### PR DESCRIPTION
## Summary
Eliminates duplicated flock/event-queue write pattern across 4 files.

- New `hooks/emit-event.sh`: atomic flock append to `.beacon/event-queue.json` with JSON array validation/init
- Updated: `dispatch-codex-appserver.sh`, `skills/beacon-dispatch/SKILL.md` (Step 3B + 3C), `agents/reviewer.md`

## Test plan
- [x] emit-event.sh syntax check passes
- [x] All 4 call sites updated

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)