### PR TITLE
security: harden verify command examples against issue-title injection

### DIFF
--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -175,23 +175,26 @@ ISSUE_TITLE="<issue-title>"      # untrusted: keep as data only
 ISSUE_NUMBER="<issue-number>"
 TOOL_NAME="<tool-name>"
 ATTEMPT="<N>"
+COMMIT_MSG_FILE=$(mktemp)
+PR_BODY_FILE=$(mktemp)
+trap 'rm -f "$COMMIT_MSG_FILE" "$PR_BODY_FILE"' EXIT
 
 # Build commit/PR text in files (no shell eval of untrusted issue title/body)
 printf '%s\n\nCloses #%s\n\nDispatched by AutoShip. Agent: %s. Attempt: %s.\nVerified by Sonnet reviewer. Tests: passing.\n' \
   "$ISSUE_KEY: $ISSUE_TITLE" \
   "$ISSUE_NUMBER" \
   "$TOOL_NAME" \
-  "$ATTEMPT" > .autoship_commit_msg.txt
+  "$ATTEMPT" > "$COMMIT_MSG_FILE"
 
 printf '## Summary\n%s\n\n## Verification\n- Tests: passing\n- Reviewer: PASS\n- Simplified: yes/no\n\nCloses #%s\n\nDispatched by [AutoShip](https://github.com/Maleick/AutoShip)\n' \
   "<from AUTOSHIP_RESULT.md>" \
-  "$ISSUE_NUMBER" > .autoship_pr_body.md
+  "$ISSUE_NUMBER" > "$PR_BODY_FILE"
 
-git commit -F .autoship_commit_msg.txt
+git commit -F "$COMMIT_MSG_FILE"
 
 gh pr create \
   --title "$ISSUE_KEY: $ISSUE_TITLE" \
-  --body-file .autoship_pr_body.md \
+  --body-file "$PR_BODY_FILE" \
   --label autoship
 ```
 

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -170,16 +170,28 @@ if [ -n "$CHANGED_FILES" ]; then
   git add $CHANGED_FILES
 fi
 # If CHANGED_FILES is empty, the agent already committed everything — skip the add step
-git commit -m "<issue-key>: <issue-title>
+ISSUE_KEY="<issue-key>"
+ISSUE_TITLE="<issue-title>"      # untrusted: keep as data only
+ISSUE_NUMBER="<issue-number>"
+TOOL_NAME="<tool-name>"
+ATTEMPT="<N>"
 
-Closes #<issue-number>
+# Build commit/PR text in files (no shell eval of untrusted issue title/body)
+printf '%s\n\nCloses #%s\n\nDispatched by AutoShip. Agent: %s. Attempt: %s.\nVerified by Sonnet reviewer. Tests: passing.\n' \
+  "$ISSUE_KEY: $ISSUE_TITLE" \
+  "$ISSUE_NUMBER" \
+  "$TOOL_NAME" \
+  "$ATTEMPT" > .autoship_commit_msg.txt
 
-Dispatched by AutoShip. Agent: <tool-name>. Attempt: <N>.
-Verified by Sonnet reviewer. Tests: passing."
+printf '## Summary\n%s\n\n## Verification\n- Tests: passing\n- Reviewer: PASS\n- Simplified: yes/no\n\nCloses #%s\n\nDispatched by [AutoShip](https://github.com/Maleick/AutoShip)\n' \
+  "<from AUTOSHIP_RESULT.md>" \
+  "$ISSUE_NUMBER" > .autoship_pr_body.md
+
+git commit -F .autoship_commit_msg.txt
 
 gh pr create \
-  --title "<issue-key>: <issue-title>" \
-  --body "## Summary\n<from AUTOSHIP_RESULT.md>\n\n## Verification\n- Tests: passing\n- Reviewer: PASS\n- Simplified: yes/no\n\nCloses #<number>\n\nDispatched by [AutoShip](https://github.com/Maleick/AutoShip)" \
+  --title "$ISSUE_KEY: $ISSUE_TITLE" \
+  --body-file .autoship_pr_body.md \
   --label autoship
 ```
 


### PR DESCRIPTION
### Motivation

- The verification docs embedded untrusted issue titles and bodies directly into shell-constructed `git commit -m` and `gh pr create --body` strings, which enables command injection if an attacker controls the issue content.
- The goal is to treat issue metadata as data (not shell source) and provide a minimal, secure approach that preserves the documented workflow.

### Description

- Reworked Step 4 in `skills/verify/SKILL.md` to stop recommending inline shell interpolation of untrusted text and instead build commit and PR payloads with `printf` into files (`.autoship_commit_msg.txt` and `.autoship_pr_body.md`).
- Switched from `git commit -m "..."` to `git commit -F .autoship_commit_msg.txt` and from `gh pr create --body "..."` to `gh pr create --body-file .autoship_pr_body.md` so untrusted titles/bodies are passed as file contents rather than shell-evaluated strings.
- Kept the PR title passed as a quoted argument (`--title "$ISSUE_KEY: $ISSUE_TITLE"`) and explicitly documented `ISSUE_TITLE` as untrusted data to ensure it is not treated as shell source.
- Left the dispatch-side prompt flow unchanged because Gemini/Codex dispatch was already updated to use a wrapper or `--prompt-file` and the docs warn not to inline prompt file contents.

### Testing

- Ran a pattern search with `rg` to confirm vulnerable inline patterns (`git commit -m "<issue-key>: <issue-title>` and `--title "<issue-key>: <issue-title>"`) are no longer present, and the search returned no matches.
- Verified repository status with `git status --short` before committing the change and confirmed only `skills/verify/SKILL.md` was modified.
- Committed the change successfully with `git commit -m "security: avoid shell injection in verify PR/commit examples"`, which completed without error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc7c03c6a4832192d70b6008ed76b7)