### PR TITLE
fix: stop trusting repo-local hooks_dir before init

### DIFF
--- a/commands/start.md
+++ b/commands/start.md
@@ -45,7 +45,7 @@ Fail messages:
 ## Step 2: Probe Available Tools
 
 ```bash
-_DETECT=$(find "$HOME/.claude/plugins/cache/autoship" -maxdepth 4 -name "detect-tools.sh" 2>/dev/null | head -1)
+_DETECT=$(find "$HOME/.claude/plugins/cache/autoship" -maxdepth 4 -type f -name "detect-tools.sh" 2>/dev/null | sort | head -1)
 if [[ -n "$_DETECT" ]]; then bash "$_DETECT"; else echo "detect-tools.sh not found — all tasks routed to Claude."; fi
 ```
 

--- a/commands/start.md
+++ b/commands/start.md
@@ -45,12 +45,8 @@ Fail messages:
 ## Step 2: Probe Available Tools
 
 ```bash
-if [[ -f ".autoship/hooks_dir" ]]; then
-  bash "$(cat .autoship/hooks_dir)/detect-tools.sh"
-else
-  _DETECT=$(find "$HOME/.claude/plugins/cache/autoship" -maxdepth 4 -name "detect-tools.sh" 2>/dev/null | head -1)
-  if [[ -n "$_DETECT" ]]; then bash "$_DETECT"; else echo "detect-tools.sh not found — all tasks routed to Claude."; fi
-fi
+_DETECT=$(find "$HOME/.claude/plugins/cache/autoship" -maxdepth 4 -name "detect-tools.sh" 2>/dev/null | head -1)
+if [[ -n "$_DETECT" ]]; then bash "$_DETECT"; else echo "detect-tools.sh not found — all tasks routed to Claude."; fi
 ```
 
 Log any unavailable tools. Reassign their tasks to Claude.

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -41,12 +41,8 @@ If any check fails, report and stop.
 ### Step 2: Detect Available Tools + Quota
 
 ```bash
-if [[ -f ".autoship/hooks_dir" ]]; then
-  bash "$(cat .autoship/hooks_dir)/detect-tools.sh"
-else
-  _DETECT=$(find "$HOME/.claude/plugins/cache/autoship" -maxdepth 4 -name "detect-tools.sh" 2>/dev/null | head -1)
-  if [[ -n "$_DETECT" ]]; then bash "$_DETECT"; else echo '{}'; fi
-fi
+_DETECT=$(find "$HOME/.claude/plugins/cache/autoship" -maxdepth 4 -name "detect-tools.sh" 2>/dev/null | head -1)
+if [[ -n "$_DETECT" ]]; then bash "$_DETECT"; else echo '{}'; fi
 ```
 
 Parse the JSON output. Record quota_pct for each tool. Tools with quota_pct < 10 are considered exhausted and skipped during dispatch.

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -41,7 +41,7 @@ If any check fails, report and stop.
 ### Step 2: Detect Available Tools + Quota
 
 ```bash
-_DETECT=$(find "$HOME/.claude/plugins/cache/autoship" -maxdepth 4 -name "detect-tools.sh" 2>/dev/null | head -1)
+_DETECT=$(find "$HOME/.claude/plugins/cache/autoship" -maxdepth 4 -type f -name "detect-tools.sh" 2>/dev/null | sort | head -1)
 if [[ -n "$_DETECT" ]]; then bash "$_DETECT"; else echo '{}'; fi
 ```
 


### PR DESCRIPTION
### Motivation
- Eliminate a trust-on-first-use vulnerability where startup executed `detect-tools.sh` from a repository-local `.autoship/hooks_dir` before `init.sh` could establish a trusted hooks directory, allowing a malicious repo to run arbitrary scripts during startup.

### Description
- Removed the pre-init branch that ran `bash "$(cat .autoship/hooks_dir)/detect-tools.sh"` from `commands/start.md` and `skills/orchestrate/SKILL.md`.
- Replaced each pre-init probe with a deterministic lookup of `detect-tools.sh` in the plugin cache via `find "$HOME/.claude/plugins/cache/autoship" -maxdepth 4 -name "detect-tools.sh" | head -1` and only execute it if found.
- Preserved post-init behavior: `init.sh` continues to write `.autoship/hooks_dir` and all subsequent hook calls still use `$(cat .autoship/hooks_dir)/...`.

### Testing
- Ran `git diff -- commands/start.md skills/orchestrate/SKILL.md` to confirm the intended edits, which showed the vulnerable conditional removed; the command succeeded.
- Ran `rg -n "hooks_dir\)|detect-tools\.sh" commands/start.md skills/orchestrate/SKILL.md` to validate the startup probe now only resolves the plugin-cache path; the command succeeded.
- Verified working tree status with `git status --short` and committed the change with `git commit -m "fix: avoid untrusted hooks_dir during startup tool detection"`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc78fdbf848321a38b8b018b80edaf)