### PR TITLE
fix(security): use mktemp for swept sentinel writes in sweep-stale.sh

### DIFF
--- a/hooks/sweep-stale.sh
+++ b/hooks/sweep-stale.sh
@@ -62,12 +62,17 @@ LOG_FILE=".autoship/poll.log"
 
 mark_issue_swept() {
   local issue_key="$1"
-  local tmp_state state_mode
+  local tmp_state state_mode state_uid state_gid
 
   tmp_state=$(mktemp "${STATE_FILE}.tmp.XXXXXX" 2>/dev/null) || return 0
   state_mode=$(stat -c '%a' "$STATE_FILE" 2>/dev/null || stat -f '%Lp' "$STATE_FILE" 2>/dev/null || true)
+  state_uid=$(stat -c '%u' "$STATE_FILE" 2>/dev/null || stat -f '%u' "$STATE_FILE" 2>/dev/null || true)
+  state_gid=$(stat -c '%g' "$STATE_FILE" 2>/dev/null || stat -f '%g' "$STATE_FILE" 2>/dev/null || true)
   if [[ -n "$state_mode" ]]; then
     chmod "$state_mode" "$tmp_state" 2>/dev/null || true
+  fi
+  if [[ -n "$state_uid" && -n "$state_gid" ]]; then
+    chown "${state_uid}:${state_gid}" "$tmp_state" 2>/dev/null || true
   fi
   jq --arg key "$issue_key" '.issues[$key].swept = true' "$STATE_FILE" > "$tmp_state" &&
     mv "$tmp_state" "$STATE_FILE" 2>/dev/null || true

--- a/hooks/sweep-stale.sh
+++ b/hooks/sweep-stale.sh
@@ -62,9 +62,13 @@ LOG_FILE=".autoship/poll.log"
 
 mark_issue_swept() {
   local issue_key="$1"
-  local tmp_state
+  local tmp_state state_mode
 
   tmp_state=$(mktemp "${STATE_FILE}.tmp.XXXXXX" 2>/dev/null) || return 0
+  state_mode=$(stat -c '%a' "$STATE_FILE" 2>/dev/null || stat -f '%Lp' "$STATE_FILE" 2>/dev/null || true)
+  if [[ -n "$state_mode" ]]; then
+    chmod "$state_mode" "$tmp_state" 2>/dev/null || true
+  fi
   jq --arg key "$issue_key" '.issues[$key].swept = true' "$STATE_FILE" > "$tmp_state" &&
     mv "$tmp_state" "$STATE_FILE" 2>/dev/null || true
   rm -f "$tmp_state" 2>/dev/null || true

--- a/hooks/sweep-stale.sh
+++ b/hooks/sweep-stale.sh
@@ -60,6 +60,16 @@ is_pane_active() {
 
 LOG_FILE=".autoship/poll.log"
 
+mark_issue_swept() {
+  local issue_key="$1"
+  local tmp_state
+
+  tmp_state=$(mktemp "${STATE_FILE}.tmp.XXXXXX" 2>/dev/null) || return 0
+  jq --arg key "$issue_key" '.issues[$key].swept = true' "$STATE_FILE" > "$tmp_state" &&
+    mv "$tmp_state" "$STATE_FILE" 2>/dev/null || true
+  rm -f "$tmp_state" 2>/dev/null || true
+}
+
 # Iterate over worktree directories
 CLEANED_COUNT=0
 shopt -s nullglob
@@ -93,7 +103,7 @@ for worktree_dir in "$WORKSPACES_DIR"/*/; do
     }
 
     # Write swept sentinel to prevent re-processing
-    jq --arg key "$ISSUE_KEY" '.issues[$key].swept = true' "$STATE_FILE" > "$STATE_FILE.tmp" && mv "$STATE_FILE.tmp" "$STATE_FILE" 2>/dev/null || true
+    mark_issue_swept "$ISSUE_KEY"
 
     CLEANED_COUNT=$((CLEANED_COUNT + 1))
     continue
@@ -120,7 +130,7 @@ for worktree_dir in "$WORKSPACES_DIR"/*/; do
       }
 
       # Write swept sentinel to prevent re-processing
-      jq --arg key "$ISSUE_KEY" '.issues[$key].swept = true' "$STATE_FILE" > "$STATE_FILE.tmp" && mv "$STATE_FILE.tmp" "$STATE_FILE" 2>/dev/null || true
+      mark_issue_swept "$ISSUE_KEY"
 
       CLEANED_COUNT=$((CLEANED_COUNT + 1))
     fi


### PR DESCRIPTION
### Motivation
- The script wrote `jq` output to a predictable temp path (`$STATE_FILE.tmp`) which allowed a local attacker to pre-create a symlink and cause arbitrary file overwrite when `sweep-stale.sh` ran.
- Harden the sentinel write so sweeping cannot overwrite attacker-controlled targets while preserving existing sweep behavior.

### Description
- Add a `mark_issue_swept` helper that uses `mktemp` to create a safe temporary file, writes the updated state via `jq`, atomically `mv`s the temp into place, and removes the temp on failure.
- Replace the two direct `> "$STATE_FILE.tmp"` write sites with calls to `mark_issue_swept` for both terminal and orphaned worktree cleanup paths.
- Preserve the previous non-fatal behavior on write failures and maintain existing logging and cleanup flow.

### Testing
- Ran `bash -n hooks/sweep-stale.sh` to validate syntax, which succeeded.
- Inspected the resulting diff to confirm only the vulnerable sentinel write paths were modified and the new helper is localized to the file.
- No automated unit tests exist for this hook, and no other automated test failures were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd1ba102248321b02da6cbf1564d18)