### PR TITLE
fix(security): prevent symlink-based lockfile clobbering in update-state

### DIFF
--- a/hooks/update-state.sh
+++ b/hooks/update-state.sh
@@ -24,7 +24,11 @@ if [[ -z "${AUTOSHIP_STATE_LOCKED:-}" ]]; then
   export AUTOSHIP_STATE_LOCKED=1
   if command -v flock >/dev/null 2>&1; then
     # Linux: hold FD lock for script duration
-    exec 9>"$LOCK_FILE"
+    if [[ -L "$LOCK_FILE" ]]; then
+      echo "Error: refusing symlink lock file: $LOCK_FILE" >&2
+      exit 1
+    fi
+    exec 9>>"$LOCK_FILE"
     flock -x 9
   elif command -v lockf >/dev/null 2>&1; then
     # macOS (BSD): re-exec under lockf; AUTOSHIP_STATE_LOCKED prevents infinite loop
@@ -158,7 +162,11 @@ append_ledger_record() {
   }
 
   if command -v flock >/dev/null 2>&1; then
-    exec 9>"$lock"
+    if [[ -L "$lock" ]]; then
+      echo "Error: refusing symlink lock file: $lock" >&2
+      return 1
+    fi
+    exec 9>>"$lock"
     flock -x 9
     _write_ledger_record
     exec 9>&-

--- a/hooks/update-state.sh
+++ b/hooks/update-state.sh
@@ -166,10 +166,10 @@ append_ledger_record() {
       echo "Error: refusing symlink lock file: $lock" >&2
       return 1
     fi
-    exec 9>>"$lock"
-    flock -x 9
+    exec 8>>"$lock"
+    flock -x 8
     _write_ledger_record
-    exec 9>&-
+    exec 8>&-
   elif command -v lockf >/dev/null 2>&1; then
     local record_tmp
     record_tmp=$(mktemp)


### PR DESCRIPTION
### Motivation
- Close a symlink-based file-clobbering vulnerability where lock acquisition used truncating redirection (`exec 9>...`) and could follow repo-controlled symlinks.
- Preserve the whole-script exclusive locking behavior while avoiding truncation of attacker-controlled targets in untrusted repositories.
- Ensure the same mitigation covers the ledger write path to avoid an equivalent risk there.

### Description
- Added explicit symlink refusal checks before opening lock paths by testing `[[ -L "$LOCK_FILE" ]]` and `[[ -L "$lock" ]]` and failing early if they are symlinks.
- Switched lock FD opens from truncating mode (`exec 9>...`) to non-truncating append mode (`exec 9>>...`) to avoid overwriting targets.
- Applied the same hardening to the `append_ledger_record` ledger lock branch to keep behavior consistent.
- Left the `lockf` (macOS/BSD) re-exec fallback unchanged to preserve platform compatibility.

### Testing
- Ran syntax check `bash -n hooks/update-state.sh`, which completed successfully.
- No additional automated tests were present or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd1c3ca7a0832194bebecd0838494d)