### PR TITLE
fix: prevent update-state from exiting on PR body parse failures

### DIFF
--- a/hooks/update-state.sh
+++ b/hooks/update-state.sh
@@ -363,7 +363,13 @@ for pair in "$@"; do
   if [[ "$KEY" == "pr_number" ]]; then
     ISSUE_NUMBER=$(echo "$ISSUE_ID" | grep -o '[0-9]*')
     if command -v gh >/dev/null 2>&1; then
-      PR_ISSUE=$(gh pr view "$VALUE" --json body --jq '.body' 2>/dev/null | grep -o '#[0-9]*' | head -1 | tr -d '#')
+      PR_ISSUE=$(
+        gh pr view "$VALUE" --json body --jq '.body' 2>/dev/null \
+          | grep -o '#[0-9]*' \
+          | head -1 \
+          | tr -d '#' \
+          || true
+      )
       if [[ -n "$PR_ISSUE" && "$PR_ISSUE" != "$ISSUE_NUMBER" ]]; then
         echo "WARN: PR #$VALUE body references #$PR_ISSUE but expected #$ISSUE_NUMBER — possible transposition" >> "$REPO_ROOT/.autoship/poll.log"
       fi


### PR DESCRIPTION
### Motivation
- The PR→issue validation pipeline in `hooks/update-state.sh` ran `gh | grep | head | tr` under `set -euo pipefail`, so a failing `gh` invocation or a PR body without a `#<number>` match could return a non-zero exit and terminate the script, turning a non-blocking warning into a hard failure.

### Description
- Updated `hooks/update-state.sh` to make the PR body extraction explicitly non-fatal by appending `|| true` inside the command substitution used to set `PR_ISSUE`, preserving the existing warning when a mismatch is detected while avoiding script termination on parse or `gh` errors.

### Testing
- Ran an automated reproduction where a stubbed `gh` returned a PR body with no `#<number>` reference and verified `hooks/update-state.sh` exits `0` and updates state successfully (succeeded).
- Ran an automated reproduction where a stubbed `gh` returned a different issue reference and verified the expected `WARN:` line is logged to `.autoship/poll.log` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd1c3bac908321a766a671a704920b)