### PR TITLE
fix(security): avoid exposing API keys in detect-tools.sh curl args

### DIFF
--- a/hooks/detect-tools.sh
+++ b/hooks/detect-tools.sh
@@ -40,9 +40,11 @@ quota_codex_openai_api() {
   local today
   today=$(date -u +"%Y-%m-%d")
   local response
-  response=$(curl -sf --max-time 5 \
-    "https://api.openai.com/v1/usage?date=${today}" \
-    -H "Authorization: Bearer $OPENAI_API_KEY" 2>/dev/null) || return 1
+  response=$(curl -sf --max-time 5 --config - 2>/dev/null <<EOF
+url = "https://api.openai.com/v1/usage?date=${today}"
+header = "Authorization: Bearer ${OPENAI_API_KEY}"
+EOF
+) || return 1
   # Parse total_usage (in cents); assume ~$20 daily budget → 2000 cents
   local used_cents
   used_cents=$(echo "$response" | jq -r '[.data[].total_usage // 0] | add // 0' 2>/dev/null) || return 1
@@ -80,8 +82,11 @@ quota_gemini_api() {
   [[ -z "$api_key" ]] && return 1
   # Check quota via generativelanguage API — returns 429 when rate-limited
   local status
-  status=$(curl -sf --max-time 5 -o /dev/null -w "%{http_code}" \
-    "https://generativelanguage.googleapis.com/v1beta/models?key=${api_key}" 2>/dev/null) || return 1
+  status=$(curl -sf --max-time 5 -o /dev/null -w "%{http_code}" --config - 2>/dev/null <<EOF
+url = "https://generativelanguage.googleapis.com/v1beta/models"
+header = "x-goog-api-key: ${api_key}"
+EOF
+) || return 1
   case "$status" in
     200) echo "100"; GEMINI_QUOTA_SOURCE="api" ;;  # reachable → assume full
     429) echo "0";   GEMINI_QUOTA_SOURCE="api" ;;  # rate limited → exhausted

--- a/hooks/detect-tools.sh
+++ b/hooks/detect-tools.sh
@@ -82,7 +82,7 @@ quota_gemini_api() {
   [[ -z "$api_key" ]] && return 1
   # Check quota via generativelanguage API — returns 429 when rate-limited
   local status
-  status=$(curl -sf --max-time 5 -o /dev/null -w "%{http_code}" --config - 2>/dev/null <<EOF
+  status=$(curl -sS --max-time 5 -o /dev/null -w "%{http_code}" --config - 2>/dev/null <<EOF
 url = "https://generativelanguage.googleapis.com/v1beta/models"
 header = "x-goog-api-key: ${api_key}"
 EOF


### PR DESCRIPTION
### Motivation
- The quota probes in `hooks/detect-tools.sh` previously placed API keys in `curl` command-line arguments (Authorization header and `?key=` URL), which can leak via process listings or command logging. 
- The change eliminates that local information-disclosure risk while keeping quota checks and fallbacks intact.

### Description
- Switch the OpenAI probe to pass the request URL and `Authorization: Bearer` header via `curl --config -` (stdin) instead of embedding the header in the command line. 
- Replace the Gemini `?key=` query usage with an `x-goog-api-key` header delivered via `curl --config -` so the key is not present in the URL or argv. 
- Preserve the existing API endpoints, response parsing, and fallback-to-local-quota-file behavior.

### Testing
- Ran `bash -n hooks/detect-tools.sh` and the syntax check passed. 
- Ran `hooks/detect-tools.sh | jq . >/dev/null` and the script produced valid JSON that parsed successfully. 
- Both automated checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd1c3bac0083218a860fd6446dade6)