### PR TITLE
fix: prevent git add option/pathspec injection in verify skill

### DIFF
--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -165,9 +165,9 @@ Continue to Step 4 with the pre-simplification code. Log that simplification was
 cd .autoship/workspaces/<issue-key>
 # Stage only files changed from the base branch — avoids staging AUTOSHIP_PROMPT.md,
 # .watcher.pid, debug files, and other unintended artifacts
-CHANGED_FILES=$(git diff --name-only main...HEAD)
-if [ -n "$CHANGED_FILES" ]; then
-  git add $CHANGED_FILES
+mapfile -d '' CHANGED_FILES < <(git diff --name-only -z main...HEAD)
+if [ "${#CHANGED_FILES[@]}" -gt 0 ]; then
+  git add -- "${CHANGED_FILES[@]}"
 fi
 # If CHANGED_FILES is empty, the agent already committed everything — skip the add step
 git commit -m "<issue-key>: <issue-title>

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -165,7 +165,10 @@ Continue to Step 4 with the pre-simplification code. Log that simplification was
 cd .autoship/workspaces/<issue-key>
 # Stage only files changed from the base branch — avoids staging AUTOSHIP_PROMPT.md,
 # .watcher.pid, debug files, and other unintended artifacts
-mapfile -d '' CHANGED_FILES < <(git diff --name-only -z main...HEAD)
+CHANGED_FILES=()
+while IFS= read -r -d '' file; do
+  CHANGED_FILES+=("$file")
+done < <(git diff --name-only -z main...HEAD)
 if [ "${#CHANGED_FILES[@]}" -gt 0 ]; then
   git add -- "${CHANGED_FILES[@]}"
 fi


### PR DESCRIPTION
### Motivation
- Remediate an option/pathspec injection risk in the verify skill where unquoted, space-delimited output from `git diff --name-only` was passed to `git add`, allowing filenames beginning with `-` or containing globs to be interpreted as git options or expanded.

### Description
- Update `skills/verify/SKILL.md` to enumerate changed files using NUL-delimited output (`git diff --name-only -z`), load paths into a Bash array with `mapfile -d ''`, and stage safely with `git add -- "${CHANGED_FILES[@]}"` to eliminate option/pathspec injection and glob expansion.

### Testing
- Verified the change and file contents with repository inspection commands which completed successfully: `git status --short`, `git diff -- skills/verify/SKILL.md`, and `nl -ba skills/verify/SKILL.md | sed -n '160,182p'`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd1c3c7ee48321b1dbd6cf9a2d009c)