### PR TITLE
fix(security): validate state repo slug before applying GitHub labels

### DIFF
--- a/hooks/update-state.sh
+++ b/hooks/update-state.sh
@@ -69,16 +69,18 @@ manage_labels() {
   if [[ -z "$repo_slug" ]]; then
     return 0
   fi
+  repo_slug=$(printf '%s\n' "$repo_slug" | sed -E 's#/$##; s#\.git$##')
 
   # Resolve current repository slug from git remote and ensure state.json matches it.
   # This prevents a stale/tampered state file from causing cross-repo label edits.
   local current_repo_slug remote_url
-  remote_url=$(git config --get remote.origin.url 2>/dev/null || true)
+  remote_url=$(git remote get-url origin 2>/dev/null || true)
   if [[ -z "$remote_url" ]]; then
     return 0
   fi
   current_repo_slug=$(printf '%s\n' "$remote_url" \
-    | sed -E 's#^git@github\.com:##; s#^https?://github\.com/##; s#\.git$##')
+    | sed -E 's#^.+[:/]([^/]+/[^/]+)(\.git)?$#\1#' \
+    | sed -E 's#/$##; s#\.git$##')
   if [[ -z "$current_repo_slug" ]] || [[ "$repo_slug" != "$current_repo_slug" ]]; then
     return 0
   fi

--- a/hooks/update-state.sh
+++ b/hooks/update-state.sh
@@ -70,6 +70,19 @@ manage_labels() {
     return 0
   fi
 
+  # Resolve current repository slug from git remote and ensure state.json matches it.
+  # This prevents a stale/tampered state file from causing cross-repo label edits.
+  local current_repo_slug remote_url
+  remote_url=$(git config --get remote.origin.url 2>/dev/null || true)
+  if [[ -z "$remote_url" ]]; then
+    return 0
+  fi
+  current_repo_slug=$(printf '%s\n' "$remote_url" \
+    | sed -E 's#^git@github\.com:##; s#^https?://github\.com/##; s#\.git$##')
+  if [[ -z "$current_repo_slug" ]] || [[ "$repo_slug" != "$current_repo_slug" ]]; then
+    return 0
+  fi
+
   # Remove old labels first
   for old_label in "${remove_labels[@]}"; do
     # Verify the label exists before trying to remove it


### PR DESCRIPTION
### Motivation
- `manage_labels()` previously read the `.repo` slug from `.autoship/state.json` and used it directly for `gh` label operations, allowing a stale or tampered state file to redirect label edits to another repository. 
- The change prevents this confused-deputy integrity issue by ensuring label edits only occur for the repository currently configured as the `origin` remote.

### Description
- Add logic in `hooks/update-state.sh` `manage_labels()` to derive the current repo slug from `git config --get remote.origin.url` and normalize it. 
- Compare the normalized `remote.origin.url` slug against the `.repo` value read from `STATE_FILE` and early-return when the remote is unavailable or the slugs do not match. 
- Preserve existing label add/remove logic unchanged when the slugs match, and no-op safely when validation fails.

### Testing
- Ran `bash -n hooks/update-state.sh` to validate the script syntax and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd1c3cddb08321a9f0d203b728b218)