### PR TITLE
fix(hooks): initialize .pr-monitor-seen.json and event-queue.json in init.sh (#94)

### DIFF
--- a/hooks/init.sh
+++ b/hooks/init.sh
@@ -57,6 +57,20 @@ fi
 # Create directory structure
 mkdir -p "$WORKSPACES_DIR"
 
+# Initialize .pr-monitor-seen.json (used by monitor-prs.sh)
+PR_SEEN_FILE="$AUTOSHIP_DIR/.pr-monitor-seen.json"
+if [[ ! -f "$PR_SEEN_FILE" ]]; then
+  echo '{}' > "$PR_SEEN_FILE"
+  echo "Initialized $PR_SEEN_FILE"
+fi
+
+# Initialize event-queue.json (used by emit-event.sh)
+EVENT_QUEUE_FILE="$AUTOSHIP_DIR/event-queue.json"
+if [[ ! -f "$EVENT_QUEUE_FILE" ]]; then
+  echo '[]' > "$EVENT_QUEUE_FILE"
+  echo "Initialized $EVENT_QUEUE_FILE"
+fi
+
 # Detect tools and parse quotas.
 # detect-tools.sh outputs: {"claude": {"available": bool, "quota_pct": N}, ...}
 # Transform to state.json format:  {"claude": {"status": "available"|"unavailable", "quota_pct": N}, ...}

--- a/hooks/monitor-prs.sh
+++ b/hooks/monitor-prs.sh
@@ -35,8 +35,11 @@ if [[ -z "$REPO_SLUG" ]]; then
   REPO_SLUG=$(git remote get-url origin 2>/dev/null | sed -E 's#^.+[:/]([^/]+/[^/]+)(\.git)?$#\1#' | sed 's/\.git$//')
 fi
 
-# Initialize seen state (track last known CI state per PR to avoid duplicate events)
-[[ -f "$SEEN_FILE" ]] || echo '{}' > "$SEEN_FILE"
+# Verify seen state file exists
+if [[ ! -f "$SEEN_FILE" ]]; then
+  echo "Error: $SEEN_FILE not found. Run init.sh first." >&2
+  exit 1
+fi
 
 emit_if_changed() {
   local pr_number="$1"


### PR DESCRIPTION
## Summary
- `hooks/init.sh`: Added initialization for `.autoship/.pr-monitor-seen.json` and `.autoship/event-queue.json` after creating `.autoship/workspaces/`, ensuring all monitor state files exist on first run
- `hooks/monitor-prs.sh`: Removed redundant initialization; added existence check with clear error message directing users to run `init.sh`

## Test plan
- [ ] `bash hooks/init.sh` initializes both files
- [ ] Running `bash hooks/init.sh` twice is idempotent (second run skips existing files)
- [ ] `bash hooks/monitor-prs.sh` starts correctly when files present; errors clearly when missing

Closes #94

🤖 Generated with [AutoShip](https://github.com/Maleick/AutoShip)