### PR TITLE
feat(dispatch): support compound issue sub-keys (e.g. issue-757a) (#95)

### DIFF
--- a/hooks/cleanup-worktree.sh
+++ b/hooks/cleanup-worktree.sh
@@ -13,7 +13,7 @@ if [[ -z "$ISSUE_KEY" ]]; then
 fi
 
 # Validate ISSUE_KEY to prevent path traversal
-if [[ ! "$ISSUE_KEY" =~ ^issue-[0-9]+$ ]]; then
+if [[ ! "$ISSUE_KEY" =~ ^issue-[0-9]+[a-z0-9-]*$ ]]; then
   echo "Error: invalid ISSUE_KEY: $ISSUE_KEY" >&2
   exit 1
 fi
@@ -31,7 +31,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # Paths
 WORKTREE_PATH=".autoship/workspaces/$ISSUE_KEY"
 AUTOSHIP_BRANCH="autoship/$ISSUE_KEY"
-ISSUE_NUM="${ISSUE_KEY#issue-}"
+ISSUE_NUM=$(echo "${ISSUE_KEY#issue-}" | sed 's/[^0-9].*//')
 
 # Resolve repo slug from state.json or git remote (needed for archive and GitHub cleanup)
 REPO_SLUG=""

--- a/hooks/dispatch-codex-appserver.sh
+++ b/hooks/dispatch-codex-appserver.sh
@@ -10,7 +10,7 @@ ISSUE_KEY="${1:?usage: dispatch-codex-appserver.sh <issue-key> <prompt-file>}"
 PROMPT_FILE="${2:?usage: dispatch-codex-appserver.sh <issue-key> <prompt-file>}"
 
 # Validate ISSUE_KEY to prevent path traversal
-if [[ ! "$ISSUE_KEY" =~ ^issue-[0-9]+$ ]]; then
+if [[ ! "$ISSUE_KEY" =~ ^issue-[0-9]+[a-z0-9-]*$ ]]; then
   echo "Error: invalid ISSUE_KEY: $ISSUE_KEY" >&2
   exit 1
 fi
@@ -133,7 +133,7 @@ EVENT=$(jq -n \
   --arg issueN  "$ISSUE_NUMBER" \
   --argjson tok "$TOKENS_USED" \
   --arg ts      "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
-  '{type: $type, issue: $issue, issue_number: ($issueN | tonumber), tokens_used: $tok, timestamp: $ts}')
+  '{type: $type, issue: $issue, issue_number: ($issueN | sub("[^0-9].*"; "") | tonumber), tokens_used: $tok, timestamp: $ts}')
 
 bash "${REPO_ROOT}/hooks/emit-event.sh" "$EVENT"
 

--- a/hooks/update-state.sh
+++ b/hooks/update-state.sh
@@ -187,7 +187,7 @@ ISSUE_ID="$2"
 shift 2
 
 # Validate ISSUE_ID format: reject malformed values before they reach jq keys or GitHub API calls
-if [[ ! "$ISSUE_ID" =~ ^(issue-)?[0-9]+$ ]]; then
+if [[ ! "$ISSUE_ID" =~ ^(issue-)?[0-9]+[a-z0-9-]*$ ]]; then
   echo "Error: invalid ISSUE_ID: $ISSUE_ID" >&2
   exit 1
 fi

--- a/skills/dispatch/SKILL.md
+++ b/skills/dispatch/SKILL.md
@@ -88,7 +88,8 @@ If `dispatch-codex-appserver.sh` returns STUCK on attempt 1, treat as tool exhau
 ## Step 1: Create Worktree
 
 ```bash
-ISSUE_KEY="issue-<number>"
+# Valid ISSUE_KEY formats: issue-<N>, issue-<N>a, issue-<N>-1, issue-<N>-phase1
+ISSUE_KEY="issue-<number>[suffix]"
 git worktree add .autoship/workspaces/$ISSUE_KEY -b autoship/$ISSUE_KEY main
 ```
 


### PR DESCRIPTION
## Summary
- `hooks/dispatch-codex-appserver.sh`: Updated validation regex to allow compound keys (`issue-757a`, `issue-757-1`); extract numeric prefix for `issue_number` field
- `hooks/cleanup-worktree.sh`: Updated validation regex; extract numeric `ISSUE_NUM` for `gh` CLI calls
- `hooks/update-state.sh`: Updated `ISSUE_ID` validation regex to accept compound formats
- `skills/dispatch/SKILL.md`: Documented allowed issue key formats

## Test plan
- [ ] `bash -n hooks/dispatch-codex-appserver.sh` passes
- [ ] `bash -n hooks/cleanup-worktree.sh` passes
- [ ] `bash -n hooks/update-state.sh` passes
- [ ] Compound keys like `issue-757a` are accepted without validation errors

Closes #95

🤖 Generated with [AutoShip](https://github.com/Maleick/AutoShip)