### PR TITLE
docs: document and enforce 20-agent dynamic cap (#96)

### DIFF
--- a/AUTOSHIP.md
+++ b/AUTOSHIP.md
@@ -11,7 +11,7 @@ quota_thresholds:
   low: 10
   exhausted: 0
 stall_timeout_ms: 300000
-max_concurrent_agents: 6
+max_concurrent_agents: 20
 ---
 # AutoShip Configuration
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ You come back to merged PRs.
 **Same issues. One command. Brain free.**
 
 - **Third-party first** — burns Codex, Gemini, and Copilot quota before touching Claude tokens
-- **Parallel workers** — up to 6 issues in flight simultaneously
+- **Parallel workers** — up to 20 issues in flight simultaneously
 - **Task-type routing** — classifies issues into 7 categories, routes each to the best agent
 - **Live routing config** — edit `AUTOSHIP.md` front matter to change agent priorities, takes effect immediately
 - **Verification pipeline** — every result reviewed against acceptance criteria before a PR opens

--- a/docs/index.html
+++ b/docs/index.html
@@ -251,7 +251,7 @@
     <div class="stat-label">avg issue → merged PR</div>
   </div>
   <div class="stat">
-    <span class="stat-num">6</span>
+    <span class="stat-num">20</span>
     <div class="stat-label">parallel agents</div>
   </div>
   <div class="stat">
@@ -371,7 +371,7 @@
     <div class="card">
       <div class="card-icon">⚡</div>
       <h3>Parallel execution</h3>
-      <p>Up to 6 issues in flight simultaneously. Bash monitors watch every agent every 5 seconds without blocking the orchestrator.</p>
+      <p>Up to 20 issues in flight simultaneously. Bash monitors watch every agent every 5 seconds without blocking the orchestrator.</p>
     </div>
     <div class="card">
       <div class="card-icon">🔍</div>

--- a/hooks/init.sh
+++ b/hooks/init.sh
@@ -386,7 +386,7 @@ DEFAULT_ROUTING='{
   },
   "quota_thresholds": {"low": 10, "exhausted": 0},
   "stall_timeout_ms": 300000,
-  "max_concurrent_agents": 6
+  "max_concurrent_agents": 20
 }'
 
 load_routing_config() {

--- a/skills/dispatch/SKILL.md
+++ b/skills/dispatch/SKILL.md
@@ -78,7 +78,7 @@ fi
 | Claude Haiku     | Agent tool (`run_in_background: true`)          | Up to 20 total                       |
 | Claude Sonnet    | Agent tool (`run_in_background: true`)          | Up to 20 total                       |
 | Gemini           | tmux pane                                       | 20+ panes via `even-vertical` layout |
-| Codex app-server | `[experimental]` — **currently non-functional** | N/A — use Claude fallback            |
+| Codex app-server | `[experimental]` — **currently non-functional** | unlimited (when working) — use Claude fallback |
 
 **Codex app-server failure protocol:**
 If `dispatch-codex-appserver.sh` returns STUCK on attempt 1, treat as tool exhaustion and immediately try the next agent in the priority list — do not retry codex. Log `CODEX_APPSERVER_STUCK` to poll.log.

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -158,6 +158,8 @@ Emits: `[ISSUE_NEW]`, `[ISSUE_CLOSED]`
 
 ### Step 7: Dispatch Phase 1
 
+For each issue in Phase 1, invoke the `dispatch` skill. Dispatch all ready Phase 1 issues concurrently up to the 20-agent cap (not throttled to 6). The dispatch skill will automatically queue any issues beyond the cap for the next poll cycle.
+
 Before dispatching each issue, classify its task type:
 
 ```bash
@@ -180,7 +182,7 @@ Task types and their model/tool preferences:
 
 Pass `task_type` to `dispatch` via the issue record in state.json. The dispatch skill reads `.issues[issue-N].task_type` to select model and tool.
 
-For each issue in Phase 1, invoke `dispatch` skill. Third-party tools take priority for simple and medium issues.
+Third-party tools take priority for simple and medium issues.
 
 ### Step 8: Enter Reactive Mode
 


### PR DESCRIPTION
## Summary
- `skills/dispatch/SKILL.md`: Updated Codex app-server concurrency note
- `skills/orchestrate/SKILL.md`: Updated Step 7 to explicitly permit 20 concurrent agents
- `AUTOSHIP.md`: `max_concurrent_agents: 6` → `20`
- `hooks/init.sh`: Updated `DEFAULT_ROUTING` max_concurrent_agents to 20
- `README.md`: Updated "up to 6 issues" → "up to 20 issues"
- `docs/index.html`: Updated landing page stats and feature descriptions

## Test plan
- [ ] `bash -n hooks/init.sh` passes
- [ ] Docs reflect 20-agent cap consistently

Closes #96

🤖 Generated with [AutoShip](https://github.com/Maleick/AutoShip)