### PR TITLE
feat(routing): rust_unsafe routing override for Windows/unsafe Rust issues (#101)

### DIFF
--- a/AUTOSHIP.md
+++ b/AUTOSHIP.md
@@ -7,6 +7,7 @@ routing:
   complex: [claude-sonnet, codex-gpt]
   mechanical: [claude-haiku, gemini]
   ci_fix: [claude-haiku, gemini]
+  rust_unsafe: [claude-haiku, claude-sonnet]
 quota_thresholds:
   low: 10
   exhausted: 0

--- a/hooks/init.sh
+++ b/hooks/init.sh
@@ -399,7 +399,8 @@ DEFAULT_ROUTING='{
     "medium_code":  ["codex-gpt", "claude-sonnet"],
     "complex":      ["claude-sonnet", "codex-gpt"],
     "mechanical":   ["claude-haiku", "gemini"],
-    "ci_fix":       ["claude-haiku", "gemini"]
+    "ci_fix":       ["claude-haiku", "gemini"],
+    "rust_unsafe":  ["claude-haiku", "claude-sonnet"]
   },
   "quota_thresholds": {"low": 10, "exhausted": 0},
   "stall_timeout_ms": 300000,
@@ -507,14 +508,25 @@ PYEOF
     return 0
   fi
 
+  # Detect project profile: rust_windows prefers Claude.
+  local project_profile="standard"
+  if [[ -f "Cargo.toml" ]] && grep -qr "\[cfg(windows)\]" src/ 2>/dev/null; then
+    project_profile="rust_windows"
+    echo "Project profile: rust_windows detected (routing overrides applied)"
+  fi
+
   # Merge parsed values over defaults so missing fields fall back gracefully.
   local merged
   merged=$(jq -n \
     --argjson defaults "$DEFAULT_ROUTING" \
     --argjson parsed "$parsed" \
+    --arg profile "$project_profile" \
     '
       $defaults
       | if ($parsed.routing | length) > 0 then .routing = $parsed.routing else . end
+      | if ($profile == "rust_windows") then
+          .routing |= map_values(["claude-haiku", "claude-sonnet"])
+        else . end
       | if ($parsed.quota_thresholds | length) > 0 then .quota_thresholds = $parsed.quota_thresholds else . end
       | if $parsed.stall_timeout_ms != null then .stall_timeout_ms = $parsed.stall_timeout_ms else . end
       | if $parsed.max_concurrent_agents != null then .max_concurrent_agents = $parsed.max_concurrent_agents else . end

--- a/skills/dispatch/SKILL.md
+++ b/skills/dispatch/SKILL.md
@@ -20,6 +20,24 @@ Third-party tools (Codex/Gemini/Copilot) are dispatched first for simple and med
 
 > Agent routing is configured via `AUTOSHIP.md` front matter. On dispatch, read `.autoship/routing.json` (populated by `init.sh`) to get the priority list for the issue's `task_type`. Fall back to the hardcoded matrix if routing.json is absent.
 
+---
+
+## Routing Overrides
+
+Specific task types or project profiles override the default complexity-based routing to ensure reliable outcomes for sensitive domains.
+
+**1. Task Type: `rust_unsafe`**
+Always routes to `claude-haiku` (primary) or `claude-sonnet` (fallback). This type is reserved for Rust issues involving memory safety or low-level systems work.
+
+**2. Keyword-based Promotion**
+If the issue title or body contains any of the following keywords, the dispatcher should promote the task to Claude regardless of estimated complexity:
+- `unsafe`, `#[cfg(windows)]`, `retour`, `DLL`, `cdylib`, `winapi`
+
+**3. Project Profile: `rust_windows`**
+Detected by `hooks/init.sh` when `Cargo.toml` exists and `#[cfg(windows)]` is present in `src/`. When this profile is active, `routing.json` is automatically overridden to prefer Claude for ALL task types.
+
+---
+
 ```bash
 # Read priority list for this task type from routing config
 TASK_TYPE=$(jq -r --arg id "$ISSUE_ID" '.issues[$id].task_type // "simple_code"' .autoship/state.json)


### PR DESCRIPTION
## Summary
- `hooks/init.sh`: Added `rust_unsafe` task type to `DEFAULT_ROUTING` (routes to claude-haiku/claude-sonnet); added `rust_windows` profile detection (checks `Cargo.toml` + `#[cfg(windows)]` in `src/`) with automatic Claude routing override
- `skills/dispatch/SKILL.md`: Added "Routing Overrides" section documenting keyword-based promotion (`unsafe`, `DLL`, `cdylib`, `winapi`, `retour`, `#[cfg(windows)]`) and `rust_windows` profile behavior
- `AUTOSHIP.md`: Added `rust_unsafe` task type to the routing table

## Problem solved
100% STUCK rate on Gemini/Codex for Rust/Windows projects with `unsafe`/DLL/nightly crates. Now these route directly to Claude.

## Test plan
- [ ] `bash -n hooks/init.sh` passes
- [ ] Repo with `Cargo.toml` + `#[cfg(windows)]` in src/ gets `rust_windows` profile and routes to Claude

Closes #101

🤖 Generated with [AutoShip](https://github.com/Maleick/AutoShip)