### PR TITLE
feat(init): auto-populate test_command from CLAUDE.md build patterns (#102)

### DIFF
--- a/hooks/init.sh
+++ b/hooks/init.sh
@@ -175,6 +175,37 @@ if [[ ! -f "$CONFIG_FILE" ]]; then
   echo "Initialized $CONFIG_FILE (add test_command, etc. for overrides)"
 fi
 
+# Auto-populate test_command/verify_command if not present (idempotent)
+if ! jq -e 'has("test_command")' "$CONFIG_FILE" >/dev/null 2>&1; then
+  DETECTED_TEST=""
+  # Scan CLAUDE.md and AGENTS.md for patterns
+  for f in "CLAUDE.md" "AGENTS.md"; do
+    if [[ -f "$f" ]]; then
+      for p in "python3 scripts/dev-preflight.py" "cargo test" "pytest" "npm test" "make test" "./gradlew test"; do
+        if grep -qF "$p" "$f"; then
+          DETECTED_TEST="$p"
+          break 2
+        fi
+      done
+    fi
+  done
+
+  if [[ -n "$DETECTED_TEST" ]]; then
+    UPDATED=$(jq --arg tc "$DETECTED_TEST" '.test_command = $tc | .verify_command = (.verify_command // $tc)' "$CONFIG_FILE")
+    printf '%s\n' "$UPDATED" > "$CONFIG_FILE"
+    echo "Auto-detected test_command: $DETECTED_TEST"
+  else
+    UPDATED=$(jq '.test_command = "" | .verify_command = (.verify_command // "")' "$CONFIG_FILE")
+    printf '%s\n' "$UPDATED" > "$CONFIG_FILE"
+    echo "Warning: no test_command detected — set it in .autoship/config.json"
+  fi
+elif ! jq -e 'has("verify_command")' "$CONFIG_FILE" >/dev/null 2>&1; then
+  # Migration: test_command exists but verify_command does not.
+  TC=$(jq -r '.test_command // ""' "$CONFIG_FILE")
+  UPDATED=$(jq --arg tc "$TC" '.verify_command = $tc' "$CONFIG_FILE")
+  printf '%s\n' "$UPDATED" > "$CONFIG_FILE"
+fi
+
 # Populate project-context.md from CLAUDE.md/AGENTS.md/config.json
 bash "$SCRIPT_DIR/extract-context.sh" || true
 


### PR DESCRIPTION
## Summary
- `hooks/init.sh`: After creating `config.json`, scans `CLAUDE.md` then `AGENTS.md` for test command patterns (`cargo test`, `pytest`, `npm test`, `make test`, `./gradlew test`, `python3 scripts/dev-preflight.py`). Writes detected `test_command` and `verify_command` to `config.json`. Idempotent — skips if already set. Warns if nothing detected.

## Problem solved
`config.json` was empty `{}` on new projects, causing dispatch prompts to fall back to the literal `<test-command>` placeholder and agents to skip or guess test commands.

## ⚠️ Merge note
Merge after #94 (also touches `hooks/init.sh`) — already merged.

## Test plan
- [ ] `bash -n hooks/init.sh` passes
- [ ] Running `init.sh` twice is idempotent (second run does not overwrite existing `test_command`)
- [ ] Repo with `cargo test` in CLAUDE.md gets `test_command: "cargo test"` in config.json

Closes #102

🤖 Generated with [AutoShip](https://github.com/Maleick/AutoShip)