### PR TITLE
docs: add metrics automation guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ AutoShip detects available tools at startup and routes work accordingly.
 | `/autoship:start`  | Launch orchestration — classify issues, dispatch agents, loop until done |
 | `/autoship:plan`   | Dry run — analyze issues and show dispatch plan without executing        |
 | `/autoship:stop`   | Gracefully stop all agents, save state, add `autoship:paused` labels     |
-| `/autoship:status` | Live dashboard — active agents, quota bars, per-model token spend        |
+| `/autoship:status` | Live dashboard — active agents, quota bars, PR backlog, token spend      |
 
 ## How It Works
 
@@ -180,6 +180,8 @@ flowchart TD
 ```
 
 Every agent writes `AUTOSHIP_RESULT.md` and emits `COMPLETE`, `BLOCKED`, or `STUCK` as its final line. AutoShip never trusts conversation output — only the result file.
+
+Metrics can be refreshed from the same lifecycle boundary: merge, cleanup, and session close. A scheduled job can read `.autoship/state.json`, `.autoship/token-ledger.json`, and GitHub PR metadata, then regenerate the metrics snapshot in the README or wiki without hand-editing numbers.
 
 ## Dispatch Matrix
 
@@ -343,6 +345,17 @@ Real dispatch results from AutoShip running on its own codebase:
 | **Average**         | —                | **~9 min**        | **issue open → PR merged**        |
 
 > AutoShip shipped all 9 v1.4.0 self-improvement issues — open to merged PR — in a single session. Zero manual PRs. Zero manual merges.
+
+### Automated Metrics Snapshot
+
+| Metric | Source | Refresh | Notes |
+| ------ | ------ | ------- | ----- |
+| Open PRs | `gh pr list --state open` | nightly | Backlog size |
+| Merged PRs | GitHub merge events | on merge | Completed work by session |
+| Time to merge | PR created/merged timestamps | nightly | Median and p90 are useful |
+| Token spend | `.autoship/token-ledger.json` | on session close | Per issue and per session |
+
+A cron, GitHub Action, or local scheduled run can regenerate this table and commit it back into the README/wiki as the live metrics snapshot.
 
 ## Star This Repo
 

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -113,7 +113,10 @@ COMPLETE signal received
   → CI pass + simple: auto-merge
   → CI pass + complex: Sonnet review → merge
   → Merged: hooks/cleanup-worktree.sh
+  → Metrics snapshot refresh (state + ledger + PR metadata)
 ```
+
+Metrics should be derived from the machine-readable state files, not from chat logs. The merge/cleanup boundary is where AutoShip should update lifecycle counters, and any scheduled report should render the current backlog, merge latency, and token spend from `.autoship/state.json`, `.autoship/token-ledger.json`, and GitHub PR metadata.
 
 ---
 
@@ -123,11 +126,12 @@ COMPLETE signal received
 | ------------------ | -------------------------- | ----------------- |
 | Orchestration plan | `.autoship/state.json`       | Yes (disk)        |
 | Event queue        | `.autoship/event-queue.json` | Yes (disk)        |
+| Metrics snapshot   | README/wiki or CI artifact  | Yes, if regenerated |
 | Agent labels       | GitHub labels on issues    | Yes (GitHub)      |
 | Pane state         | tmux (in-memory)           | No                |
 | Monitor processes  | tmux / Monitor tool        | No — restart them |
 
-On session restart: read state.json, reconcile GitHub labels, re-initialize event queue, restart 3 Monitor processes.
+On session restart: read state.json, reconcile GitHub labels, re-initialize event queue, restart 3 Monitor processes. Metrics automation should treat `.autoship/state.json` as the lifecycle source of truth and `.autoship/token-ledger.json` as the spend source of truth; higher-level reporting fields can be rendered into the snapshot layer without changing the conversation flow.
 
 ---
 

--- a/wiki/Configuration.md
+++ b/wiki/Configuration.md
@@ -57,6 +57,8 @@ The primary runtime state file. Created by `hooks/init.sh`. Never edit directly 
 }
 ```
 
+`stats` is the canonical counters block for automation. The merge and cleanup pipeline should update these totals, and any scheduled metrics job can derive higher-level reporting fields such as merged PR count, open PR backlog, time-to-merge, or total token spend from `.autoship/token-ledger.json` plus GitHub PR metadata. Keep this object machine-readable so the README/wiki snapshot can be regenerated without scraping chat logs.
+
 ### Issue States
 
 | State       | Meaning                                 |


### PR DESCRIPTION
Adds README and wiki guidance for keeping AutoShip metrics automated and machine-readable, including the live status surface, the post-completion metrics refresh, and the state/token-ledger sources of truth.