### PR TITLE
fix(commands): correct skill name and output message in /autoship:start

### DIFF
--- a/commands/start.md
+++ b/commands/start.md
@@ -53,6 +53,6 @@ Log any unavailable tools. Reassign their tasks to Claude.
 
 ## Step 3: Invoke Orchestration Protocol
 
-Invoke the `autoship:orchestrate` skill via the Skill tool and follow its startup sequence exactly.
+Output exactly: "Invoking AutoShip." — then invoke the `autoship:beacon` skill via the Skill tool and follow its startup sequence exactly.
 
 </autoship-start>


### PR DESCRIPTION
## Summary

- Replaces stale `autoship:orchestrate` skill reference with the active `autoship:beacon` skill
- Adds explicit instruction to output `"Invoking AutoShip."` so the user sees a clean message instead of the internal skill name

## Test plan

- [ ] Run `/autoship:start` — confirm output reads "Invoking AutoShip." before skill loads
- [ ] Confirm orchestration proceeds normally via `autoship:beacon`

🤖 Generated with [Claude Code](https://claude.com/claude-code)