### PR TITLE
fix(hooks): repair four autoship infra bugs (#2224-#2227)

### DIFF
--- a/hooks/cleanup-worktree.sh
+++ b/hooks/cleanup-worktree.sh
@@ -124,7 +124,8 @@ fi
 
 # SAFETY: Verify PR merge in git history before cleanup (prevent race condition)
 # If this is a merged PR cleanup, ensure the merge commit exists in origin before nuking worktree
-if [[ "$ISSUE_STATE" == "merged" ]]; then
+ISSUE_STATE_FROM_FILE=$(jq -r --arg key "$ISSUE_KEY" '.issues[$key].state // "unknown"' ".autoship/state.json" 2>/dev/null) || ISSUE_STATE_FROM_FILE="unknown"
+if [[ "$ISSUE_STATE_FROM_FILE" == "merged" ]]; then
   git fetch origin main 2>/dev/null || true
   # Try to find the branch in git log (crude check, but prevents accidental orphan commits)
   if ! git log --oneline origin/main 2>/dev/null | grep -qi "$ISSUE_KEY\|#$ISSUE_NUM"; then
@@ -164,14 +165,27 @@ if [[ -n "$REPO_SLUG" ]] && command -v gh >/dev/null 2>&1; then
     gh issue edit "$ISSUE_NUM" --remove-label "$label" --repo "$REPO_SLUG" 2>/dev/null || true
   done
   
-  # Check if issue is still open and close it if needed
+  # Check if issue is still open and close it if needed.
+  # SAFETY: Only close if a linked PR exists AND is actually MERGED on GitHub.
+  # Prevents closing in-flight issues on session restart when state.json says "merged"
+  # but no PR was ever opened / merged (see issue #2224).
   ISSUE_STATE=$(gh issue view "$ISSUE_NUM" --repo "$REPO_SLUG" --json state --jq '.state' 2>/dev/null) || ISSUE_STATE=""
-  
+  PR_NUM=$(jq -r --arg key "$ISSUE_KEY" '.issues[$key].pr_number // empty' ".autoship/state.json" 2>/dev/null) || PR_NUM=""
+  PR_STATE=""
+  if [[ -n "$PR_NUM" ]]; then
+    PR_STATE=$(gh pr view "$PR_NUM" --repo "$REPO_SLUG" --json state --jq '.state' 2>/dev/null) || PR_STATE=""
+  fi
+
   if [[ "$ISSUE_STATE" == "OPEN" ]]; then
-    echo "Closing issue $ISSUE_NUM on GitHub"
-    gh issue close "$ISSUE_NUM" --repo "$REPO_SLUG" --comment "Closed by AutoShip worktree cleanup after merge." 2>/dev/null || {
-      echo "Warning: failed to close issue $ISSUE_NUM"
-    }
+    if [[ -n "$PR_NUM" && "$PR_STATE" == "MERGED" ]]; then
+      echo "Closing issue $ISSUE_NUM on GitHub (PR #$PR_NUM merged)"
+      gh issue close "$ISSUE_NUM" --repo "$REPO_SLUG" --comment "Closed by AutoShip worktree cleanup after PR #$PR_NUM merged." 2>/dev/null || {
+        echo "Warning: failed to close issue $ISSUE_NUM"
+      }
+    else
+      echo "Skipping close of issue $ISSUE_NUM — PR merge not verified (pr_number='${PR_NUM:-none}', pr_state='${PR_STATE:-none}')"
+      echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] cleanup-worktree: refused to close $ISSUE_KEY — pr_number=${PR_NUM:-none} pr_state=${PR_STATE:-none}" >> .autoship/poll.log 2>/dev/null || true
+    fi
   fi
 else
   echo "Warning: could not determine repo slug or gh CLI not available; skipping GitHub cleanup"

--- a/hooks/monitor-issues.sh
+++ b/hooks/monitor-issues.sh
@@ -76,8 +76,8 @@ while true; do
     # Skip pull requests (GitHub issues API returns PRs too)
     is_pr=$(gh api "repos/$REPO_SLUG/issues/$num" --jq '.pull_request != null' 2>/dev/null) || is_pr="false"
     if [[ "$is_pr" == "false" ]]; then
-      # Only emit if not already tracked in state
-      tracked=$(jq -r --arg n "$num" '.issues[$n] // empty' "$STATE_FILE" 2>/dev/null)
+      # Only emit if not already tracked in state (state uses prefixed key "issue-<N>")
+      tracked=$(jq -r --arg n "issue-$num" '.issues[$n] // empty' "$STATE_FILE" 2>/dev/null)
       if [[ -z "$tracked" ]]; then
         echo "[ISSUE_NEW] number=$num"
       fi
@@ -92,8 +92,8 @@ while true; do
   for num in $closed_issues; do
     is_pr=$(gh api "repos/$REPO_SLUG/issues/$num" --jq '.pull_request != null' 2>/dev/null) || is_pr="false"
     if [[ "$is_pr" == "false" ]]; then
-      # Only emit if we were tracking this issue
-      tracked=$(jq -r --arg n "$num" '.issues[$n] // empty' "$STATE_FILE" 2>/dev/null)
+      # Only emit if we were tracking this issue (state uses prefixed key "issue-<N>")
+      tracked=$(jq -r --arg n "issue-$num" '.issues[$n] // empty' "$STATE_FILE" 2>/dev/null)
       if [[ -n "$tracked" ]]; then
         echo "[ISSUE_CLOSED] number=$num"
       fi

--- a/hooks/monitor-prs.sh
+++ b/hooks/monitor-prs.sh
@@ -98,25 +98,33 @@ while true; do
     --repo "$REPO_SLUG" 2>/dev/null | \
     jq -r '.[] | "\(.number) \(.mergedAt)"' | \
     while read -r num merged_at; do
-      # Only emit for merges in the last 60 seconds
-      merged_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$merged_at" "+%s" 2>/dev/null || \
-                     date -d "$merged_at" "+%s" 2>/dev/null || echo 0)
-      now_epoch=$(date +%s)
+      # Only emit for merges in the last 60 seconds.
+      # macOS `date -j -f` treats input as local time unless -u is set; force UTC.
+      merged_epoch=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%SZ" "$merged_at" "+%s" 2>/dev/null || \
+                     date -u -d "$merged_at" "+%s" 2>/dev/null || echo 0)
+      now_epoch=$(date -u +%s)
       age=$((now_epoch - merged_epoch))
       if [[ $age -lt 60 ]]; then
         emit_if_changed "$num" "[PR_MERGED]"
 
         # Transition state to merged and write completed_at for the linked issue.
         # Look up which issue this PR belongs to by matching pr_number in state.json.
+        # BEACON is gated by the same seen-set as [PR_MERGED] so it fires once per PR.
         if [[ -f "$STATE_FILE" ]] && command -v jq >/dev/null 2>&1; then
           ISSUE_ID=$(jq -r --argjson pr "$num" \
             '.issues | to_entries[] | select(.value.pr_number == $pr) | .key' \
             "$STATE_FILE" 2>/dev/null | head -1)
           if [[ -n "$ISSUE_ID" ]]; then
-            COMPLETED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-            bash "$REPO_ROOT/hooks/update-state.sh" set-merged "$ISSUE_ID" \
-              completed_at="$COMPLETED_AT" 2>/dev/null || true
-            echo "[BEACON] Transitioned issue $ISSUE_ID to merged (PR #$num, completed_at=$COMPLETED_AT)"
+            beacon_key="${num}:BEACON_MERGED"
+            beacon_seen=$(jq -r --arg k "$beacon_key" '.[$k] // empty' "$SEEN_FILE")
+            if [[ -z "$beacon_seen" ]]; then
+              COMPLETED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+              bash "$REPO_ROOT/hooks/update-state.sh" set-merged "$ISSUE_ID" \
+                completed_at="$COMPLETED_AT" 2>/dev/null || true
+              echo "[BEACON] Transitioned issue $ISSUE_ID to merged (PR #$num, completed_at=$COMPLETED_AT)"
+              jq --arg k "$beacon_key" --arg now "$(date -u +%s)" '.[$k] = $now' \
+                "$SEEN_FILE" > "$_SEEN_TMP" && mv "$_SEEN_TMP" "$SEEN_FILE"
+            fi
           fi
         fi
       fi

--- a/hooks/monitor-prs.sh
+++ b/hooks/monitor-prs.sh
@@ -100,7 +100,7 @@ while true; do
     while read -r num merged_at; do
       # Only emit for merges in the last 60 seconds.
       # macOS `date -j -f` treats input as local time unless -u is set; force UTC.
-      merged_epoch=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%SZ" "$merged_at" "+%s" 2>/dev/null || \
+      merged_epoch=$(date -j -u -f "%Y-%m-%dT%H:%M:%SZ" "$merged_at" "+%s" 2>/dev/null || \
                      date -u -d "$merged_at" "+%s" 2>/dev/null || echo 0)
       now_epoch=$(date -u +%s)
       age=$((now_epoch - merged_epoch))

--- a/skills/dispatch/SKILL.md
+++ b/skills/dispatch/SKILL.md
@@ -102,6 +102,24 @@ fi
 **Codex app-server failure protocol:**
 If `dispatch-codex-appserver.sh` returns STUCK on attempt 1, treat as tool exhaustion and immediately try the next agent in the priority list (gemini > claude-haiku > claude-sonnet) — do not retry codex. Log `CODEX_APPSERVER_STUCK` to poll.log.
 
+**⚠️ CWD HAZARD — Agent-tool (Claude Haiku/Sonnet) dispatch (see bug #2226):**
+
+Each `Bash` tool call in an Agent-tool worker spawns a fresh shell. `cd <worktree>` in one call **does not persist** to the next. If the worker runs `git commit` without re-cd'ing, the commit lands on the **parent session's branch**, not `autoship/issue-<N>`.
+
+**Required mitigation — prefix every bash call:**
+
+```bash
+cd .autoship/workspaces/issue-<N> && <actual command>
+```
+
+Every command the worker runs must include the `cd <worktree> &&` prefix. Do not rely on a setup step that cd's once.
+
+**Preferred alternatives (when available):**
+- **tmux pane dispatch** (Gemini) — pane has persistent cwd, safe by default.
+- **Codex app-server** — passes explicit `cwd` to each invocation, immune to drift.
+
+Agent-tool dispatch is the least safe channel; prefer tmux/Codex for worktree-isolated work when quota allows.
+
 ---
 
 ## Step 1: Create Worktree


### PR DESCRIPTION
## Summary

Four interrelated AutoShip hook bugs surfaced during TextQuest orchestration. All fixes landed in one branch because they were filed together and share overlapping test surface.

## Fixes

### monitor-issues.sh — state key format mismatch
Closes Maleick/TextQuest#2227

State lookup used raw issue number (`\"2227\"`) but state.json uses prefixed keys (`\"issue-2227\"`). Tracked check always missed → emitted `[ISSUE_NEW]` for every open issue on every 60s poll.

```diff
-      tracked=\$(jq -r --arg n \"\$num\" '.issues[\$n] // empty' \"\$STATE_FILE\")
+      tracked=\$(jq -r --arg n \"issue-\$num\" '.issues[\$n] // empty' \"\$STATE_FILE\")
```

Applied to both `[ISSUE_NEW]` and `[ISSUE_CLOSED]` paths.

### monitor-prs.sh — UTC parse + BEACON idempotency
Closes Maleick/TextQuest#2225

BSD \`date -j -f\` on macOS treats UTC timestamps as local. In EST this produces a 5h-stale epoch; the \`<60s\` age gate passes for hours. `[BEACON]` transition message had no seen-check, so it re-emitted every poll.

Fix: force \`TZ=UTC\` on parse; gate BEACON with \`\$SEEN_FILE\` marker (\`<pr>:BEACON_MERGED\`).

Verified: `TZ=UTC date -j -f` vs unscoped produces 18000s diff on EST — this is the bug.

### cleanup-worktree.sh — verify PR merged before closing issue
Closes Maleick/TextQuest#2224

The script closed GitHub issues whenever:
- state.json marked issue \"merged\"
- GitHub issue state was still OPEN

No check that the linked PR actually merged. On session restart, sweep-stale called cleanup-worktree for in-flight issues whose state had been pre-written merged (by prior partial runs or Haiku triage) — then `gh issue close` fired with no PR backing it.

Fix:
1. Query state.json for `\$ISSUE_STATE_FROM_FILE` (previously used undefined `\$ISSUE_STATE` in safety gate at line 127).
2. Require `pr_number` + `gh pr view --json state == MERGED` before invoking `gh issue close`.
3. Emit refusal log to poll.log when verification fails.

### skills/dispatch — document Agent-tool cwd hazard
Closes Maleick/TextQuest#2226

Each \`Bash\` tool call in an Agent-tool worker spawns a fresh shell. \`cd <worktree>\` in one call does not persist. Workers without \`cd <worktree> &&\` prefix drift to the parent session's branch on commit. Added warning section to dispatch SKILL.md with required mitigation and preferred alternatives (tmux/Codex).

## Test plan

- [x] Shell syntax: \`bash -n\` clean on all three hooks
- [x] Manual: \`TZ=UTC date -j -f\` diff confirms 5h skew on EST
- [x] Manual: prefixed jq key resolves state; raw key misses
- [ ] Live: run one full orchestration cycle post-merge and confirm:
  - \`[ISSUE_NEW]\` silent for already-tracked issues
  - \`[BEACON]\` fires exactly once per PR merge
  - No false \`gh issue close\` on session restart