### PR TITLE
fix: handle missing model history

### DIFF
--- a/hooks/opencode/select-model.sh
+++ b/hooks/opencode/select-model.sh
@@ -13,6 +13,9 @@ ROUTING_FILE=".autoship/model-routing.json"
 HISTORY_FILE=".autoship/model-history.json"
 
 [[ -f "$ROUTING_FILE" ]] || exit 0
+if [[ ! -f "$HISTORY_FILE" ]]; then
+  HISTORY_FILE="/dev/null"
+fi
 
 if [[ -n "$ROLE" ]]; then
   jq -r --arg role "$ROLE" '.roles[$role] // empty' "$ROUTING_FILE"

--- a/hooks/opencode/test-policy.sh
+++ b/hooks/opencode/test-policy.sh
@@ -221,6 +221,7 @@ cat > "$SELECT_REPO/.autoship/model-routing.json" <<'JSON'
   ]
 }
 JSON
+assert_eq "free/strong:free" "$(cd "$SELECT_REPO" && bash hooks/opencode/select-model.sh simple_code 101)" "selector treats missing model history as empty"
 cat > "$SELECT_REPO/.autoship/model-history.json" <<'JSON'
 {
   "free/strong:free": {"success": 0, "fail": 6},


### PR DESCRIPTION
## Summary
- Treat missing `.autoship/model-history.json` as empty history during first-run model selection.
- Add regression coverage so dispatch can select a model before history exists.

## Test Plan
- [x] bash hooks/opencode/test-policy.sh
- [x] bash -n hooks/opencode/*.sh hooks/*.sh
- [x] bash hooks/opencode/smoke-test.sh

Closes #160