### PR TITLE
fix: recover stale autoship workspaces

### DIFF
--- a/hooks/opencode/create-worktree.sh
+++ b/hooks/opencode/create-worktree.sh
@@ -26,6 +26,7 @@ git fetch origin master --quiet 2>/dev/null || git fetch origin main --quiet 2>/
 
 if ! git worktree add -B "$TARGET_BRANCH" "$WORKSPACE" "$BASE_REF" 2>/dev/null; then
   git worktree remove --force "$WORKSPACE" 2>/dev/null || true
+  rm -rf "$WORKSPACE"
   git worktree add -B "$TARGET_BRANCH" "$WORKSPACE" "$BASE_REF"
 fi
 

--- a/hooks/opencode/test-policy.sh
+++ b/hooks/opencode/test-policy.sh
@@ -154,6 +154,23 @@ JSON
 expected_version=$(tr -d '[:space:]' < "$SCRIPT_DIR/../../VERSION")
 assert_eq "$expected_version" "$(jq -r '.autoship_version' "$INIT_REPO/.autoship/state.json")" "init refreshes autoship_version from VERSION file"
 
+WORKTREE_REPO="$TMP_DIR/worktree-repo"
+mkdir -p "$WORKTREE_REPO"
+git init -q "$WORKTREE_REPO"
+git -C "$WORKTREE_REPO" config user.email autoship@example.invalid
+git -C "$WORKTREE_REPO" config user.name AutoShip
+printf 'base\n' > "$WORKTREE_REPO/README.md"
+git -C "$WORKTREE_REPO" add README.md
+git -C "$WORKTREE_REPO" commit -q -m initial
+mkdir -p "$WORKTREE_REPO/.autoship/workspaces/issue-156"
+printf 'stale\n' > "$WORKTREE_REPO/.autoship/workspaces/issue-156/AUTOSHIP_RESULT.md"
+(
+  cd "$WORKTREE_REPO"
+  bash "$SCRIPT_DIR/create-worktree.sh" issue-156 autoship/issue-156 >/dev/null
+)
+test -d "$WORKTREE_REPO/.autoship/workspaces/issue-156/.git" || test -f "$WORKTREE_REPO/.autoship/workspaces/issue-156/.git" || fail "create-worktree replaces stale existing workspace directory"
+test ! -e "$WORKTREE_REPO/.autoship/workspaces/issue-156/AUTOSHIP_RESULT.md" || fail "create-worktree clears stale AutoShip artifacts after recovery"
+
 SETUP_REPO="$TMP_DIR/setup-repo"
 mkdir -p "$SETUP_REPO/bin"
 cp -R "$SCRIPT_DIR/../.." "$SETUP_REPO/autoship"


### PR DESCRIPTION
## Summary
- Recover from stale existing `.autoship/workspaces/<issue>` directories when creating worktrees.
- Add policy coverage that reproduces stale workspace recovery and artifact cleanup.

## Test Plan
- [x] bash hooks/opencode/test-policy.sh
- [x] bash -n hooks/opencode/*.sh hooks/*.sh
- [x] bash hooks/opencode/smoke-test.sh

Closes #198