### PR TITLE
feat: add package metadata and build config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "opencode-autoship",
+  "version": "1.6.2",
+  "description": "Turn backlog into reviewed PRs with an OpenCode issue-to-PR orchestration plugin.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "bin": {
+    "opencode-autoship": "./dist/cli.js"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "hooks",
+    "commands",
+    "skills",
+    "AGENTS.md",
+    "VERSION",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "prepack": "tsc"
+  },
+  "keywords": [
+    "opencode",
+    "plugin",
+    "github",
+    "automation",
+    "agents"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Maleick/AutoShip.git"
+  },
+  "homepage": "https://autoship.teamoperator.red",
+  "bugs": {
+    "url": "https://github.com/Maleick/AutoShip/issues"
+  },
+  "license": "MIT",
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noUncheckedIndexedAccess": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
# Issue #156: Package Metadata and Build Config

## Summary

Created package.json and tsconfig.json for the opencode-autoship public package.

## Verification

- `bun install` succeeded - TypeScript 5.9.3 installed as dev dependency
- `bun run build` fails as expected - no `src/index.ts` or `src/cli.ts` yet (deferred to future sub-issues)
- `npm pack --dry-run --ignore-scripts` confirms the package contains only intended files:
  - dist, hooks, commands, skills, AGENTS.md, VERSION, README.md, LICENSE
  - No `.autoship/` runtime state included (verified in tarball)

## Expected Follow-ups

The build requires `src/index.ts` and `src/cli.ts` which will be implemented by subsequent sub-issues. Once those are created:
- Build will generate `./dist/index.js`, `./dist/index.d.ts`, and `./dist/cli.js`
- CLI will be exposed via the `bin` field

## Files Committed

- package.json (1.6.2)
- tsconfig.json

## Status

COMPLETE

Closes #156