### PR TITLE
fix: keep worktree path output clean

### DIFF
--- a/hooks/opencode/create-worktree.sh
+++ b/hooks/opencode/create-worktree.sh
@@ -24,10 +24,10 @@ fi
 
 git fetch origin master --quiet 2>/dev/null || git fetch origin main --quiet 2>/dev/null || true
 
-if ! git worktree add -B "$TARGET_BRANCH" "$WORKSPACE" "$BASE_REF" 2>/dev/null; then
-  git worktree remove --force "$WORKSPACE" 2>/dev/null || true
+if ! git worktree add -B "$TARGET_BRANCH" "$WORKSPACE" "$BASE_REF" >/dev/null 2>&1; then
+  git worktree remove --force "$WORKSPACE" >/dev/null 2>&1 || true
   rm -rf "$WORKSPACE"
-  git worktree add -B "$TARGET_BRANCH" "$WORKSPACE" "$BASE_REF"
+  git worktree add -B "$TARGET_BRANCH" "$WORKSPACE" "$BASE_REF" >/dev/null
 fi
 
 rm -f \

--- a/hooks/opencode/test-policy.sh
+++ b/hooks/opencode/test-policy.sh
@@ -166,7 +166,9 @@ mkdir -p "$WORKTREE_REPO/.autoship/workspaces/issue-156"
 printf 'stale\n' > "$WORKTREE_REPO/.autoship/workspaces/issue-156/AUTOSHIP_RESULT.md"
 (
   cd "$WORKTREE_REPO"
-  bash "$SCRIPT_DIR/create-worktree.sh" issue-156 autoship/issue-156 >/dev/null
+  worktree_output=$(bash "$SCRIPT_DIR/create-worktree.sh" issue-156 autoship/issue-156)
+  expected_worktree_path="$(git rev-parse --show-toplevel)/.autoship/workspaces/issue-156"
+  assert_eq "$expected_worktree_path" "$worktree_output" "create-worktree prints only the workspace path on stdout"
 )
 test -d "$WORKTREE_REPO/.autoship/workspaces/issue-156/.git" || test -f "$WORKTREE_REPO/.autoship/workspaces/issue-156/.git" || fail "create-worktree replaces stale existing workspace directory"
 test ! -e "$WORKTREE_REPO/.autoship/workspaces/issue-156/AUTOSHIP_RESULT.md" || fail "create-worktree clears stale AutoShip artifacts after recovery"


### PR DESCRIPTION
## Summary
- Redirect git worktree chatter away from `create-worktree.sh` stdout.
- Add regression coverage that stdout contains only the absolute workspace path.

## Test Plan
- [x] bash hooks/opencode/test-policy.sh
- [x] bash -n hooks/opencode/*.sh hooks/*.sh
- [x] bash hooks/opencode/smoke-test.sh

Closes #201