### PR TITLE
test: cover package-style install

### DIFF
--- a/hooks/opencode/smoke-test.sh
+++ b/hooks/opencode/smoke-test.sh
@@ -17,20 +17,27 @@ trap 'rm -rf "$CONFIG_HOME"; if [[ -n "$AUTOSHIP_BACKUP" && -d "$AUTOSHIP_BACKUP
 
 export XDG_CONFIG_HOME="$CONFIG_HOME"
 
-bash "$REPO_ROOT/hooks/opencode/install.sh" >/dev/null
+PACKAGE_REPO="$(mktemp -d)"
+cp -R "$REPO_ROOT/." "$PACKAGE_REPO/"
+rm -rf "$PACKAGE_REPO/.git" "$PACKAGE_REPO/.autoship" "$PACKAGE_REPO/node_modules" "$PACKAGE_REPO/dist"
+(cd "$PACKAGE_REPO" && npm install --package-lock=false --no-audit --no-fund >/dev/null && npm run build >/dev/null)
+node "$PACKAGE_REPO/dist/cli.js" install >/dev/null
 
 CONFIG_FILE="$CONFIG_HOME/opencode/opencode.json"
 STATE_FILE="$REPO_ROOT/.autoship/state.json"
 HOOKS_FILE="$REPO_ROOT/.autoship/hooks_dir"
-PLUGIN_DEST="$CONFIG_HOME/opencode/plugins/autoship.ts"
-VERSION_FILE="$CONFIG_HOME/opencode/plugins/autoship.version"
-PLUGIN_URL="file://$PLUGIN_DEST"
+AUTOSHIP_INSTALL_DIR="$CONFIG_HOME/opencode/.autoship"
 
-[[ -f "$PLUGIN_DEST" ]]
-[[ -f "$VERSION_FILE" ]]
-[[ -f "$STATE_FILE" ]]
-[[ "$(cat "$HOOKS_FILE")" == "$REPO_ROOT/hooks" ]]
-grep -F "\"$PLUGIN_URL\"" "$CONFIG_FILE" >/dev/null
+jq -e '.plugin | index("opencode-autoship")' "$CONFIG_FILE" >/dev/null
+if jq -e '.plugin[] | select(type == "string" and contains("autoship.ts"))' "$CONFIG_FILE" >/dev/null; then
+  echo "FAIL: package install registered legacy autoship.ts plugin" >&2
+  exit 1
+fi
+[[ -d "$AUTOSHIP_INSTALL_DIR/hooks" ]]
+[[ -d "$AUTOSHIP_INSTALL_DIR/commands" ]]
+[[ -d "$AUTOSHIP_INSTALL_DIR/skills" ]]
+[[ -f "$AUTOSHIP_INSTALL_DIR/AGENTS.md" ]]
+[[ -f "$AUTOSHIP_INSTALL_DIR/VERSION" ]]
 
 bash "$REPO_ROOT/hooks/opencode/init.sh" >/dev/null
 

--- a/hooks/opencode/test-policy.sh
+++ b/hooks/opencode/test-policy.sh
@@ -278,4 +278,28 @@ chmod +x "$UPDATE_REPO/bin/gh" "$UPDATE_REPO/hooks/update-state.sh"
 assert_eq "running" "$(jq -r '.issues["issue-123"].state' "$UPDATE_REPO/.autoship/state.json")" "update-state stores normalized issue key"
 assert_eq "123" "$(head -1 "$UPDATE_REPO/gh-issues.log")" "update-state passes numeric issue to gh"
 
+PACKAGE_REPO="$TMP_DIR/package-repo"
+cp -R "$SCRIPT_DIR/../.." "$PACKAGE_REPO"
+(
+  cd "$PACKAGE_REPO"
+  rm -rf .autoship node_modules dist
+  npm install --package-lock=false --no-audit --no-fund >/dev/null
+  npm run build >/dev/null
+  CONFIG_DIR="$TMP_DIR/package-config"
+  mkdir -p "$CONFIG_DIR"
+  printf '%s\n' '{"plugin":["file:///tmp/legacy/autoship.ts","other-plugin"],"customSetting":true}' > "$CONFIG_DIR/opencode.json"
+  OPENCODE_CONFIG_DIR="$CONFIG_DIR" node dist/cli.js install >/dev/null
+  jq -e '.plugin | index("opencode-autoship")' "$CONFIG_DIR/opencode.json" >/dev/null || fail "package installer registers opencode-autoship plugin"
+  jq -e '.plugin | index("other-plugin")' "$CONFIG_DIR/opencode.json" >/dev/null || fail "package installer preserves unrelated plugins"
+  jq -e '.customSetting == true' "$CONFIG_DIR/opencode.json" >/dev/null || fail "package installer preserves unrelated config"
+  if jq -e '.plugin[] | select(type == "string" and contains("autoship.ts"))' "$CONFIG_DIR/opencode.json" >/dev/null; then
+    fail "package installer removes legacy autoship.ts plugin entries"
+  fi
+  test -d "$CONFIG_DIR/.autoship/hooks" || fail "package installer copies hooks"
+  test -d "$CONFIG_DIR/.autoship/commands" || fail "package installer copies commands"
+  test -d "$CONFIG_DIR/.autoship/skills" || fail "package installer copies skills"
+  test -f "$CONFIG_DIR/.autoship/AGENTS.md" || fail "package installer copies AGENTS.md"
+  test -f "$CONFIG_DIR/.autoship/VERSION" || fail "package installer copies VERSION"
+)
+
 echo "OpenCode policy tests passed"


### PR DESCRIPTION
# AutoShip Issue #159 Result

## Status: COMPLETE

Updated smoke and policy tests so package-style install is the public path.

## Changes

- `hooks/opencode/smoke-test.sh` now builds the package in a temporary copy and installs via `dist/cli.js install` into a temporary OpenCode config.
- Smoke test asserts `opencode.json` contains `opencode-autoship` and no legacy `autoship.ts` plugin entry.
- Smoke test asserts installed assets exist under `.autoship/hooks`, `.autoship/commands`, `.autoship/skills`, plus `AGENTS.md` and `VERSION`.
- `hooks/opencode/test-policy.sh` now tests package CLI install, legacy plugin removal, unrelated plugin/config preservation, and asset sync.
- Existing selector and update-state coverage remains intact.

## Verification

- `bash hooks/opencode/test-policy.sh`
- `bash -n hooks/opencode/*.sh hooks/*.sh`
- `bash hooks/opencode/smoke-test.sh`

Closes #159