### PR TITLE
fix: initialize quota from shared hook

### DIFF
--- a/hooks/opencode/init.sh
+++ b/hooks/opencode/init.sh
@@ -49,7 +49,7 @@ mkdir -p "$AUTOSHIP_DIR/results"
 # Initialize files
 [[ ! -f "$AUTOSHIP_DIR/event-queue.json" ]] && echo '[]' > "$AUTOSHIP_DIR/event-queue.json"
 [[ ! -f "$AUTOSHIP_DIR/.pr-monitor-seen.json" ]] && echo '{}' > "$AUTOSHIP_DIR/.pr-monitor-seen.json"
-[[ ! -f "$AUTOSHIP_DIR/quota.json" ]] && bash "$SCRIPT_DIR/quota-update.sh" init 2>/dev/null || true
+[[ ! -f "$AUTOSHIP_DIR/quota.json" ]] && bash "$(dirname "$SCRIPT_DIR")/quota-update.sh" init 2>/dev/null || true
 [[ ! -f "$AUTOSHIP_DIR/config.json" ]] && echo '{}' > "$AUTOSHIP_DIR/config.json"
 
 # Initialize state.json

--- a/hooks/opencode/test-policy.sh
+++ b/hooks/opencode/test-policy.sh
@@ -153,6 +153,7 @@ JSON
 )
 expected_version=$(tr -d '[:space:]' < "$SCRIPT_DIR/../../VERSION")
 assert_eq "$expected_version" "$(jq -r '.autoship_version' "$INIT_REPO/.autoship/state.json")" "init refreshes autoship_version from VERSION file"
+test -f "$INIT_REPO/.autoship/quota.json" || fail "init creates quota.json using the shared quota-update hook"
 
 WORKTREE_REPO="$TMP_DIR/worktree-repo"
 mkdir -p "$WORKTREE_REPO"


### PR DESCRIPTION
# AutoShip Issue #161 Result

## Status: COMPLETE

Fixed the OpenCode init quota initialization path.

## Changes

- `hooks/opencode/init.sh` now calls the shared `hooks/quota-update.sh` via `$(dirname "$SCRIPT_DIR")/quota-update.sh`.
- `hooks/opencode/test-policy.sh` now asserts init creates `.autoship/quota.json`.

## Verification

- `bash hooks/opencode/test-policy.sh`
- `bash -n hooks/opencode/*.sh hooks/*.sh`
- `bash hooks/opencode/smoke-test.sh`

Closes #161