### PR TITLE
feat: design setup wizard flags

### DIFF
--- a/commands/setup.md
+++ b/commands/setup.md
@@ -7,6 +7,56 @@ description: Configure AutoShip for OpenCode-first-party routing
 
 Configure AutoShip for OpenCode-only workers.
 
-The setup flow verifies `opencode`, discovers models with `opencode models`, writes `.autoship/model-routing.json`, writes `.autoship/config.json`, and chooses a concurrency cap. The default cap is 15 active workers.
+## Interactive Mode
 
-By default setup includes only currently available model IDs flagged free in the live OpenCode model list, across all providers. Set `AUTOSHIP_MODELS` to a comma-separated list to choose exact models from the discovered OpenCode list.
+Runs a wizard that asks about:
+1. OpenCode availability (verified automatically)
+2. GitHub authentication (verified automatically)
+3. Model inventory discovery (from `opencode models`)
+4. Concurrency (default: 15 agents)
+5. Labels to monitor (default: agent:ready)
+6. Refresh behavior (auto-refresh models on startup?)
+
+```bash
+/autoship-setup
+```
+
+## Non-Interactive Mode (--no-tui)
+
+Use `--no-tui` for scripted or CI setups:
+
+```bash
+bash hooks/opencode/setup.sh --no-tui \
+  --max-agents 10 \
+  --labels "agent:ready,autoship:in-progress" \
+  --refresh-models \
+  --planner-model openai/gpt-5.5
+```
+
+### Flags
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--no-tui` | Run in non-interactive mode | false |
+| `--max-agents N` | Max concurrent agents | 15 |
+| `--labels LABEL1,LABEL2` | Labels to monitor | agent:ready |
+| `--refresh-models` | Force refresh model inventory | false |
+| `--planner-model MODEL` | Planner/coordinator/orchestrator model | openai/gpt-5.5 |
+| `--worker-models MODEL1,MODEL2` | Worker models (comma-separated) | auto-detect free |
+
+### Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `AUTOSHIP_MAX_AGENTS` | Max concurrent agents | 15 |
+| `AUTOSHIP_MODELS` | Worker models | auto-detect free |
+| `AUTOSHIP_REFRESH_MODELS` | Set to 1 to force refresh | 0 |
+| `AUTOSHIP_PLANNER_MODEL` | Planner model | openai/gpt-5.5 |
+| `AUTOSHIP_LABELS` | Labels to monitor | agent:ready |
+| `GH_TOKEN` | GitHub token | from gh config |
+
+### Defaults
+
+- Setup includes only currently available model IDs flagged free in the live OpenCode model list
+- Set `AUTOSHIP_MODELS` or `--worker-models` to choose exact models
+- Use `--refresh-models` to regenerate from current model inventory

--- a/hooks/opencode/setup.sh
+++ b/hooks/opencode/setup.sh
@@ -11,8 +11,145 @@ PLANNER_MODEL="${AUTOSHIP_PLANNER_MODEL:-openai/gpt-5.5}"
 COORDINATOR_MODEL="${AUTOSHIP_COORDINATOR_MODEL:-$PLANNER_MODEL}"
 ORCHESTRATOR_MODEL="${AUTOSHIP_ORCHESTRATOR_MODEL:-$PLANNER_MODEL}"
 REVIEWER_MODEL="${AUTOSHIP_REVIEWER_MODEL:-$PLANNER_MODEL}"
+LABELS="${AUTOSHIP_LABELS:-agent:ready}"
+
+NO_TUI=0
+POSITIONAL=()
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+AutoShip OpenCode setup wizard.
+
+OPTIONS:
+  --no-tui              Run in non-interactive mode (skip prompts)
+  --max-agents N        Set max concurrent agents (default: 15)
+  --labels LABEL,...   Comma-separated labels to monitor (default: agent:ready)
+  --refresh-models     Force refresh model inventory from OpenCode
+  --planner-model MODEL Set planner/coordinator/orchestrator/reviewer model (default: openai/gpt-5.5)
+  --worker-models MODELS Comma-separated worker models (default: auto-detect free)
+  -h, --help           Show this help message
+
+EXAMPLES:
+  # Interactive setup
+  $(basename "$0")
+
+  # Non-interactive with defaults
+  $(basename "$0") --no-tui
+
+  # Custom configuration
+  $(basename "$0") --no-tui --max-agents 10 --labels "agent:ready,needs-work" --refresh-models
+
+ENVIRONMENT VARIABLES:
+  AUTOSHIP_MAX_AGENTS       Max concurrent agents
+  AUTOSHIP_MODELS          Comma-separated worker models
+  AUTOSHIP_REFRESH_MODELS  Set to 1 to force refresh
+  AUTOSHIP_PLANNER_MODEL   Planner model (default: openai/gpt-5.5)
+  AUTOSHIP_LABELS          Comma-separated labels (default: agent:ready)
+  GH_TOKEN                 GitHub token (for gh auth)
+EOF
+  exit "${1:-0}"
+}
+
+parse_args() {
+  if [[ $# -eq 0 ]]; then
+    return 0
+  fi
+
+  if ! command -v getopt >/dev/null 2>&1; then
+    echo "Error: getopt not found. Install via 'brew install gnu-getopt' or use environment variables." >&2
+    exit 1
+  fi
+
+  local opts
+  opts=$(getopt -o h -l no-tui,max-agents:,labels:,refresh-models,planner-model:,worker-models:,help -- "$@" 2>&1) || {
+    echo "Error: $opts" >&2
+    usage 2
+  }
+
+  eval set -- "$opts"
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --no-tui)
+        NO_TUI=1
+        shift
+        ;;
+      --max-agents)
+        MAX_AGENTS="$2"
+        shift 2
+        ;;
+      --labels)
+        LABELS="$2"
+        shift 2
+        ;;
+      --refresh-models)
+        REFRESH_MODELS=1
+        shift
+        ;;
+      --planner-model)
+        PLANNER_MODEL="$2"
+        COORDINATOR_MODEL="$2"
+        ORCHESTRATOR_MODEL="$2"
+        REVIEWER_MODEL="$2"
+        shift 2
+        ;;
+      --worker-models)
+        SELECTED_MODELS="$2"
+        shift 2
+        ;;
+      -h|--help)
+        usage 0
+        ;;
+      --)
+        shift
+        break
+        ;;
+      *)
+        echo "Unknown option: $1" >&2
+        usage 2
+        ;;
+    esac
+  done
+
+  POSITIONAL=("$@")
+}
+
+parse_args "$@"
+
+if [[ ${#POSITIONAL[@]} -gt 0 ]]; then
+  echo "Error: Unexpected positional arguments: ${POSITIONAL[*]}" >&2
+  usage 2
+fi
+
+if [[ "$NO_TUI" -eq 0 && -t 0 ]]; then
+  echo "Running in interactive mode. Use --no-tui for non-interactive."
+fi
 
 mkdir -p "$AUTOSHIP_DIR"
+
+if [[ "$REFRESH_MODELS" == "1" ]]; then
+  rm -f "$ROUTING_FILE" "$CONFIG_FILE"
+fi
+
+if [[ -f "$ROUTING_FILE" && -z "$SELECTED_MODELS" && "$REFRESH_MODELS" != "1" ]]; then
+  if jq -e '(.models // []) | length > 0' "$ROUTING_FILE" >/dev/null 2>&1; then
+    if [[ ! -f "$CONFIG_FILE" ]]; then
+      jq -n --argjson max "$MAX_AGENTS" --arg labels "$LABELS" \
+        '{runtime: "opencode", maxConcurrentAgents: $max, max_agents: $max, models: [], labels: ($labels | split(",")), refreshModels: false}' > "$CONFIG_FILE"
+    fi
+    echo "AutoShip OpenCode setup already configured"
+    echo "Model routing preserved: $ROUTING_FILE"
+    echo "Set --refresh-models to regenerate from current opencode models."
+    exit 0
+  fi
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+  echo "Error: GitHub authentication required. Run 'gh auth login' or set GH_TOKEN." >&2
+  exit 1
+fi
 
 if [[ -f "$ROUTING_FILE" && -z "$SELECTED_MODELS" && "$REFRESH_MODELS" != "1" ]]; then
   if jq -e '(.models // []) | length > 0' "$ROUTING_FILE" >/dev/null 2>&1; then
@@ -87,12 +224,14 @@ if [[ -n "$missing_role_models" ]]; then
   exit 1
 fi
 
-python3 - "$ROUTING_FILE" "$CONFIG_FILE" "$SELECTED_MODELS" "$MAX_AGENTS" "$PLANNER_MODEL" "$COORDINATOR_MODEL" "$ORCHESTRATOR_MODEL" "$REVIEWER_MODEL" <<'PY'
+python3 - "$ROUTING_FILE" "$CONFIG_FILE" "$SELECTED_MODELS" "$MAX_AGENTS" "$PLANNER_MODEL" "$COORDINATOR_MODEL" "$ORCHESTRATOR_MODEL" "$REVIEWER_MODEL" "$LABELS" <<'PY'
 import json
 import sys
+import os
 
-routing_path, config_path, selected_models, max_agents, planner_model, coordinator_model, orchestrator_model, reviewer_model = sys.argv[1:]
+routing_path, config_path, selected_models, max_agents, planner_model, coordinator_model, orchestrator_model, reviewer_model, labels = sys.argv[1:]
 models = [m.strip() for m in selected_models.split(",") if m.strip()]
+labels_list = [l.strip() for l in labels.split(",") if l.strip()]
 
 def strength(model: str) -> int:
     lower = model.lower()
@@ -162,6 +301,8 @@ with open(config_path, "w", encoding="utf-8") as f:
         "orchestratorModel": orchestrator_model,
         "reviewerModel": reviewer_model,
         "models": models,
+        "labels": labels_list,
+        "refreshModels": int(os.environ.get("AUTOSHIP_REFRESH_MODELS", "0")) == 1,
     }, f, indent=2)
     f.write("\n")
 PY
@@ -169,3 +310,5 @@ PY
 date -u +%Y-%m-%dT%H:%M:%SZ > "$AUTOSHIP_DIR/.onboarded"
 echo "AutoShip OpenCode setup complete"
 echo "Configured models: $SELECTED_MODELS"
+echo "Max agents: $MAX_AGENTS"
+echo "Labels: $LABELS"

--- a/hooks/opencode/smoke-test.sh
+++ b/hooks/opencode/smoke-test.sh
@@ -11,11 +11,34 @@ AUTOSHIP_BACKUP=""
 if [[ -d "$REPO_ROOT/.autoship" ]]; then
   AUTOSHIP_BACKUP="$(mktemp -d)"
   cp -R "$REPO_ROOT/.autoship" "$AUTOSHIP_BACKUP/"
+  rm -rf "$REPO_ROOT/.autoship"
 fi
 
 trap 'rm -rf "$CONFIG_HOME"; if [[ -n "$AUTOSHIP_BACKUP" && -d "$AUTOSHIP_BACKUP/.autoship" ]]; then rm -rf "$REPO_ROOT/.autoship"; cp -R "$AUTOSHIP_BACKUP/.autoship" "$REPO_ROOT/"; fi; rm -rf "$AUTOSHIP_BACKUP"' EXIT
 
 export XDG_CONFIG_HOME="$CONFIG_HOME"
+BIN_DIR="$CONFIG_HOME/bin"
+mkdir -p "$BIN_DIR"
+cat > "$BIN_DIR/opencode" <<'SH'
+#!/usr/bin/env bash
+if [[ "$1" == "models" ]]; then
+  printf '%s\n' 'opencode/minimax-m2.5-free' 'opencode/nemotron-3-super-free' 'openai/gpt-5.5'
+  exit 0
+fi
+printf '%s\n' '1.14.22'
+SH
+cat > "$BIN_DIR/gh" <<'SH'
+#!/usr/bin/env bash
+if [[ "$1 $2" == "auth status" ]]; then
+  exit 0
+fi
+if [[ "$1 $2" == "label create" ]]; then
+  exit 0
+fi
+exit 0
+SH
+chmod +x "$BIN_DIR/opencode" "$BIN_DIR/gh"
+export PATH="$BIN_DIR:$PATH"
 
 PACKAGE_REPO="$(mktemp -d)"
 cp -R "$REPO_ROOT/." "$PACKAGE_REPO/"

--- a/skills/autoship-setup/SKILL.md
+++ b/skills/autoship-setup/SKILL.md
@@ -11,13 +11,36 @@ Guide users through model selection and configuration on first run.
 
 ---
 
+## Usage
+
+### Interactive Mode (default)
+
+```bash
+/autoship-setup
+```
+
+### Non-Interactive Mode (--no-tui)
+
+```bash
+/autoship-setup --no-tui \
+  --max-agents 10 \
+  --labels "agent:ready,autoship:in-progress" \
+  --refresh-models \
+  --planner-model openai/gpt-5.5
+```
+
+---
+
 ## Flow Overview
 
 1. **Runtime Detection** — Check for OpenCode CLI
-2. **Model Discovery** — List models from the current `opencode models` output
-3. **Model Selection** — Default to free models, or let the operator choose explicit models
-3. **Concurrency** — How many agents?
-4. **Summary** — Ready to go
+2. **GitHub Auth** — Verify `gh` auth status
+3. **Model Discovery** — List models from `opencode models`
+4. **Model Selection** — Free-first or custom
+5. **Concurrency** — How many agents?
+6. **Labels** — Which labels to monitor?
+7. **Refresh Behavior** — Auto-refresh model inventory?
+8. **Summary** — Ready to go
 
 ---
 
@@ -27,13 +50,36 @@ Guide users through model selection and configuration on first run.
 command -v opencode >/dev/null 2>&1 && opencode --version
 ```
 
-## Step 2: Model Discovery
+Ask user: "OpenCode not found. Install it first."
+
+---
+
+## Step 2: GitHub Auth
+
+```bash
+gh auth status
+```
+
+Ask user if not authenticated:
+```
+GitHub authentication required.
+
+Run: gh auth login
+
+Or set GH_TOKEN environment variable.
+```
+
+---
+
+## Step 3: Model Discovery
 
 ```bash
 opencode models
 ```
 
-## Step 3: Model Configuration
+---
+
+## Step 4: Model Configuration
 
 Ask the user:
 
@@ -52,7 +98,7 @@ Which model configuration?
 
 ---
 
-## Step 3: Concurrency
+## Step 5: Concurrency
 
 Ask:
 
@@ -71,31 +117,82 @@ How many concurrent agents?
 
 ---
 
-## Step 4: Generate Config
+## Step 6: Labels
 
-```bash
-# Create .autoship directory
-mkdir -p .autoship
+Ask:
 
-AUTOSHIP_MAX_AGENTS="$MAX_AGENTS" AUTOSHIP_MODELS="$SELECTED_MODELS" bash hooks/opencode/setup.sh
 ```
+Which labels should AutoShip monitor for issues?
 
-Setup preserves existing `.autoship/model-routing.json` by default so operators can edit it manually. Use `AUTOSHIP_REFRESH_MODELS=1` to regenerate free defaults from the current OpenCode model inventory.
+◉ agent:ready (default)
+  └ Standard AutoShip queue label
+
+◯ Custom labels (comma-separated)
+  └ e.g., "agent:ready,needs-triage"
+```
 
 ---
 
-## Step 5: Summary
+## Step 7: Refresh Behavior
+
+Ask:
+
+```
+How often should AutoShip refresh model inventory?
+
+◉ Auto-refresh on startup
+  └ Checks for new models each time AutoShip starts
+
+◯ Manual only
+  └ Only refreshes when AUTOSHIP_REFRESH_MODELS=1 is set
+```
+
+---
+
+## Step 8: Generate Config
+
+```bash
+# Interactive mode
+bash hooks/opencode/setup.sh
+
+# Non-interactive mode (--no-tui)
+bash hooks/opencode/setup.sh --no-tui \
+  --max-agents 10 \
+  --labels "agent:ready" \
+  --refresh-models \
+  --planner-model openai/gpt-5.5
+```
+
+Setup preserves existing `.autoship/model-routing.json` by default so operators can edit it manually. Use `AUTOSHIP_REFRESH_MODELS=1` or `--refresh-models` to regenerate free defaults from the current OpenCode model inventory.
+
+---
+
+## Step 9: Summary
 
 ```
 ✓ AutoShip configured!
 
-Model configuration: <config>
 Runtime: OpenCode
+GitHub: Authenticated
 Models: <free discovered models or explicit operator selection>
 Concurrency: <N> agents
+Labels: <configured labels>
+Refresh: <auto/manual>
 
 Next: Run /autoship to start
 ```
+
+---
+
+## Non-Interactive Flags (--no-tui)
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--max-agents N` | Set max concurrent agents | 15 |
+| `--labels LABEL1,LABEL2` | Comma-separated labels to monitor | agent:ready |
+| `--refresh-models` | Force refresh model inventory | false |
+| `--planner-model MODEL` | Set planner/coordinator/orchestrator model | openai/gpt-5.5 |
+| `--worker-models MODEL1,MODEL2` | Comma-separated worker models | auto-detect free models |
 
 ---
 
@@ -104,13 +201,18 @@ Next: Run /autoship to start
 | Error | Recovery |
 |-------|----------|
 | OpenCode not found | Install OpenCode before starting workers |
+| GitHub not authenticated | Run `gh auth login` or set GH_TOKEN |
 | Config write fails | Check file permissions |
+| No free models found | Use `--worker-models` to specify explicitly |
 
 ---
 
 ## Reconfiguration
 
 ```bash
+# Remove onboarding marker to re-run wizard
 rm .autoship/.onboarded
-# Then re-run /autoship-setup
+
+# Or re-run with --no-tui flags
+/autoship-setup --no-tui --max-agents 10 --refresh-models
 ```


### PR DESCRIPTION
# AutoShip Issue #163: Setup Wizard Prompts and Noninteractive Flags

## Summary

Implemented the interactive setup wizard and `--no-tui` non-interactive mode for OpenCode-only AutoShip.

## Changes Made

### 1. Skills (`skills/autoship-setup/SKILL.md`)
- Expanded wizard flow from 4 to 8 steps covering all acceptance criteria:
  1. Runtime Detection (OpenCode)
  2. GitHub Auth verification
  3. Model Discovery
  4. Model Configuration
  5. Concurrency
  6. Labels
  7. Refresh Behavior
  8. Summary
- Added `--no-tui` flag documentation with all supported options

### 2. Hook (`hooks/opencode/setup.sh`)
- Added CLI argument parsing with `--no-tui`, `--max-agents`, `--labels`, `--refresh-models`, `--planner-model`, `--worker-models`
- Added GitHub auth verification (`gh auth status`)
- Added labels and refreshModels to `config.json`
- Added `-h/--help` usage output

### 3. Command (`commands/setup.md`)
- Documented interactive and non-interactive modes
- Added flags table and environment variables table
- Documented wizard questions coverage

## Acceptance Criteria

| Criterion | Status |
|-----------|--------|
| Wizard covers OpenCode availability | ✓ |
| Wizard covers GitHub auth | ✓ |
| Wizard covers model inventory | ✓ |
| Wizard covers concurrency | ✓ |
| Wizard covers labels | ✓ |
| Wizard covers refresh behavior | ✓ |
| --no-tui non-interactive mode | ✓ |

## Verification

- `bash -n hooks/opencode/setup.sh` - syntax OK
- `bash hooks/opencode/test-policy.sh` - passed

## Files Modified

- `commands/setup.md`
- `hooks/opencode/setup.sh`
- `skills/autoship-setup/SKILL.md`
## Additional Verification Fix

Smoke test was updated to use deterministic fake `opencode` and `gh` commands under the temporary config so package/setup verification does not depend on the operator's real OpenCode auth/config.

Closes #163