### PR TITLE
feat: parse opencode model inventory

### DIFF
--- a/hooks/opencode/model-parser.sh
+++ b/hooks/opencode/model-parser.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+normalize_model_ids() {
+  printf '%s\n' "$1" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//' | grep -E '^[a-z0-9._-]+/.+' | sort -u || true
+}
+
+is_free_model() {
+  local model
+  model=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
+  [[ "$model" == *":free" || "$model" == *"/free"* || "$model" == *"-free"* ]]
+}
+
+default_free_models() {
+  local available_model_ids="$1"
+  local free_models=""
+  while IFS= read -r model; do
+    [[ -z "$model" ]] && continue
+    if is_free_model "$model"; then
+      if [[ -n "$free_models" ]]; then
+        free_models="$free_models,$model"
+      else
+        free_models="$model"
+      fi
+    fi
+  done <<< "$available_model_ids"
+  printf '%s\n' "$free_models"
+}
+
+reject_forbidden_models() {
+  local models="$1"
+  if printf '%s\n' "$models" | tr ',' '\n' | grep -qx 'openai/gpt-5.5-fast'; then
+    echo "Error: openai/gpt-5.5-fast is not allowed for AutoShip. Use openai/gpt-5.5 instead." >&2
+    return 1
+  fi
+}
+
+find_missing_models() {
+  local available_model_ids="$1"
+  shift
+  local requested
+  requested=$(printf '%s\n' "$@" | tr ',' '\n' | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//' | grep -v '^$' || true)
+  while IFS= read -r model; do
+    [[ -z "$model" ]] && continue
+    if ! printf '%s\n' "$available_model_ids" | grep -qxF "$model"; then
+      printf '%s\n' "$model"
+    fi
+  done <<< "$requested" | awk '!seen[$0]++'
+}
+
+classify_models() {
+  local models="$1"
+  while IFS= read -r model; do
+    [[ -z "$model" ]] && continue
+    if is_free_model "$model"; then
+      printf '%s:free\n' "$model"
+    else
+      printf '%s:selected\n' "$model"
+    fi
+  done <<< "$models"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 <available_models_file> [selected_models]" >&2
+    exit 1
+  fi
+
+  available_models=$(cat "$1")
+  available_ids=$(normalize_model_ids "$available_models")
+
+  echo "=== Available IDs ==="
+  printf '%s\n' "$available_ids"
+  echo ""
+
+  echo "=== Default Free Models ==="
+  default_free_models "$available_ids"
+  echo ""
+
+  echo "=== Classification ==="
+  classify_models "$available_ids"
+fi

--- a/hooks/opencode/setup.sh
+++ b/hooks/opencode/setup.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 AUTOSHIP_DIR=".autoship"
 ROUTING_FILE="$AUTOSHIP_DIR/model-routing.json"
 CONFIG_FILE="$AUTOSHIP_DIR/config.json"
@@ -15,6 +16,8 @@ LABELS="${AUTOSHIP_LABELS:-agent:ready}"
 
 NO_TUI=0
 POSITIONAL=()
+
+source "$SCRIPT_DIR/model-parser.sh"
 
 usage() {
   cat <<EOF
@@ -53,23 +56,6 @@ EOF
 }
 
 parse_args() {
-  if [[ $# -eq 0 ]]; then
-    return 0
-  fi
-
-  if ! command -v getopt >/dev/null 2>&1; then
-    echo "Error: getopt not found. Install via 'brew install gnu-getopt' or use environment variables." >&2
-    exit 1
-  fi
-
-  local opts
-  opts=$(getopt -o h -l no-tui,max-agents:,labels:,refresh-models,planner-model:,worker-models:,help -- "$@" 2>&1) || {
-    echo "Error: $opts" >&2
-    usage 2
-  }
-
-  eval set -- "$opts"
-
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --no-tui)
@@ -77,27 +63,50 @@ parse_args() {
         shift
         ;;
       --max-agents)
+        [[ $# -ge 2 ]] || { echo "Error: --max-agents requires a value" >&2; usage 2; }
         MAX_AGENTS="$2"
         shift 2
         ;;
+      --max-agents=*)
+        MAX_AGENTS="${1#*=}"
+        shift
+        ;;
       --labels)
+        [[ $# -ge 2 ]] || { echo "Error: --labels requires a value" >&2; usage 2; }
         LABELS="$2"
         shift 2
+        ;;
+      --labels=*)
+        LABELS="${1#*=}"
+        shift
         ;;
       --refresh-models)
         REFRESH_MODELS=1
         shift
         ;;
       --planner-model)
+        [[ $# -ge 2 ]] || { echo "Error: --planner-model requires a value" >&2; usage 2; }
         PLANNER_MODEL="$2"
         COORDINATOR_MODEL="$2"
         ORCHESTRATOR_MODEL="$2"
         REVIEWER_MODEL="$2"
         shift 2
         ;;
+      --planner-model=*)
+        PLANNER_MODEL="${1#*=}"
+        COORDINATOR_MODEL="$PLANNER_MODEL"
+        ORCHESTRATOR_MODEL="$PLANNER_MODEL"
+        REVIEWER_MODEL="$PLANNER_MODEL"
+        shift
+        ;;
       --worker-models)
+        [[ $# -ge 2 ]] || { echo "Error: --worker-models requires a value" >&2; usage 2; }
         SELECTED_MODELS="$2"
         shift 2
+        ;;
+      --worker-models=*)
+        SELECTED_MODELS="${1#*=}"
+        shift
         ;;
       -h|--help)
         usage 0
@@ -106,14 +115,21 @@ parse_args() {
         shift
         break
         ;;
-      *)
+      -*)
         echo "Unknown option: $1" >&2
         usage 2
+        ;;
+      *)
+        POSITIONAL+=("$1")
+        shift
         ;;
     esac
   done
 
-  POSITIONAL=("$@")
+  while [[ $# -gt 0 ]]; do
+    POSITIONAL+=("$1")
+    shift
+  done
 }
 
 parse_args "$@"
@@ -174,50 +190,31 @@ if [[ -z "$available_models" ]]; then
   exit 1
 fi
 
-available_model_ids=$(printf '%s\n' "$available_models" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//' | grep -E '^[a-z0-9._-]+/.+' | sort -u || true)
+available_model_ids=$(normalize_model_ids "$available_models")
 if [[ -z "$available_model_ids" ]]; then
   echo "Error: no OpenCode model IDs found in model list" >&2
   exit 1
 fi
 
 if [[ -z "$SELECTED_MODELS" ]]; then
-  SELECTED_MODELS=$(printf '%s\n' "$available_model_ids" | grep -E '(:free$|(^|[-/])free($|[-/]))' | paste -sd ',' -)
+  SELECTED_MODELS=$(default_free_models "$available_model_ids")
 fi
 
-if printf '%s\n%s\n%s\n%s\n%s\n' "$SELECTED_MODELS" "$PLANNER_MODEL" "$COORDINATOR_MODEL" "$ORCHESTRATOR_MODEL" "$REVIEWER_MODEL" | grep -Eq '(^|,)openai/gpt-5\.5-fast(,|$)'; then
-  echo "Error: openai/gpt-5.5-fast is not allowed for AutoShip. Use openai/gpt-5.5 instead." >&2
-  exit 1
-fi
+reject_forbidden_models "$SELECTED_MODELS,$PLANNER_MODEL,$COORDINATOR_MODEL,$ORCHESTRATOR_MODEL,$REVIEWER_MODEL"
 
 if [[ -z "$SELECTED_MODELS" ]]; then
   echo "Error: no free OpenCode models found. Set AUTOSHIP_MODELS to choose models explicitly." >&2
   exit 1
 fi
 
-missing_models=$(AVAILABLE_MODEL_IDS="$available_model_ids" python3 - "$SELECTED_MODELS" <<'PY'
-import os
-import sys
-selected = [m.strip() for m in sys.argv[1].split(',') if m.strip()]
-available = {line.strip() for line in os.environ.get('AVAILABLE_MODEL_IDS', '').splitlines() if line.strip()}
-missing = [m for m in selected if m not in available]
-print('\n'.join(missing))
-PY
-)
+missing_models=$(find_missing_models "$available_model_ids" "$SELECTED_MODELS")
 if [[ -n "$missing_models" ]]; then
   echo "Error: selected models are not currently available in this OpenCode instance:" >&2
   printf '%s\n' "$missing_models" >&2
   exit 1
 fi
 
-missing_role_models=$(AVAILABLE_MODEL_IDS="$available_model_ids" python3 - "$PLANNER_MODEL" "$COORDINATOR_MODEL" "$ORCHESTRATOR_MODEL" "$REVIEWER_MODEL" <<'PY'
-import os
-import sys
-selected = [m.strip() for m in sys.argv[1:] if m.strip()]
-available = {line.strip() for line in os.environ.get('AVAILABLE_MODEL_IDS', '').splitlines() if line.strip()}
-missing = [m for m in selected if m not in available]
-print('\n'.join(dict.fromkeys(missing)))
-PY
-)
+missing_role_models=$(find_missing_models "$available_model_ids" "$PLANNER_MODEL" "$COORDINATOR_MODEL" "$ORCHESTRATOR_MODEL" "$REVIEWER_MODEL")
 if [[ -n "$missing_role_models" ]]; then
   echo "Error: planner/coordinator/orchestrator models are not currently available in this OpenCode instance:" >&2
   printf '%s\n' "$missing_role_models" >&2

--- a/hooks/opencode/test-model-parsing.sh
+++ b/hooks/opencode/test-model-parsing.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+assert_eq() {
+  local expected="$1"
+  local actual="$2"
+  local message="$3"
+  if [[ "$expected" != "$actual" ]]; then
+    fail "$message: expected '$expected', got '$actual'"
+  fi
+}
+
+source "$SCRIPT_DIR/model-parser.sh"
+
+AVAILABLE="opencode/nemotron-3-super-free
+opencode/minimax-m2.5-free
+openrouter/google/gemma-3-27b-it:free
+openai/gpt-5.5
+openai/gpt-5.3-codex-spark"
+AVAILABLE_IDS=$(normalize_model_ids "$AVAILABLE")
+
+echo "=== Test: free model IDs ==="
+DEFAULT_FREE=$(default_free_models "$AVAILABLE_IDS")
+DEFAULT_FREE_NL=$(printf '%s\n' "$DEFAULT_FREE" | tr ',' '\n')
+assert_eq "3" "$(classify_models "$DEFAULT_FREE_NL" | grep -c ':free' || true)" "default model pool prefers free models"
+
+echo "=== Test: explicit selected model IDs ==="
+SELECTED_INPUT="openai/gpt-5.5,openai/gpt-5.3-codex-spark"
+SELECTED_NL=$(printf '%s\n' "$SELECTED_INPUT" | tr ',' '\n')
+assert_eq "2" "$(classify_models "$SELECTED_NL" | grep -c ':selected' || true)" "explicit selected models should be marked selected"
+
+echo "=== Test: unavailable model IDs ==="
+MISSING=$(find_missing_models "$AVAILABLE_IDS" "opencode/unavailable-model,openai/gpt-5.5")
+assert_eq "opencode/unavailable-model" "$MISSING" "unavailable selected models are reported"
+
+echo "=== Test: forbidden model IDs ==="
+if reject_forbidden_models "openai/gpt-5.5-fast" 2>/dev/null; then
+  fail "gpt-5.5-fast must be rejected"
+fi
+
+echo "=== Test: setup accepts portable --no-tui flags ==="
+MODEL_REPO="$TMP_DIR/model-repo"
+mkdir -p "$MODEL_REPO/bin" "$MODEL_REPO/autoship/hooks/opencode"
+cp "$SCRIPT_DIR/setup.sh" "$SCRIPT_DIR/model-parser.sh" "$MODEL_REPO/autoship/hooks/opencode/"
+chmod +x "$MODEL_REPO/autoship/hooks/opencode/setup.sh"
+cat > "$MODEL_REPO/bin/gh" <<'SH'
+#!/usr/bin/env bash
+if [[ "$1 $2" == "auth status" ]]; then
+  exit 0
+fi
+exit 0
+SH
+cat > "$MODEL_REPO/bin/opencode" <<'SH'
+#!/usr/bin/env bash
+if [[ "$1" == "models" ]]; then
+  printf '%s\n' 'opencode/nemotron-3-super-free' 'opencode/minimax-m2.5-free' 'openai/gpt-5.5' 'openai/gpt-5.3-codex-spark'
+  exit 0
+fi
+printf '%s\n' '1.0.0'
+SH
+chmod +x "$MODEL_REPO/bin/gh" "$MODEL_REPO/bin/opencode"
+(
+  cd "$MODEL_REPO/autoship"
+  PATH="$MODEL_REPO/bin:$PATH" bash hooks/opencode/setup.sh --no-tui --max-agents=7 --labels=agent:ready,needs-review --worker-models=openai/gpt-5.3-codex-spark >/dev/null
+)
+assert_eq "openai/gpt-5.3-codex-spark" "$(jq -r '.models[0].id' "$MODEL_REPO/autoship/.autoship/model-routing.json")" "setup writes explicit selected worker model"
+assert_eq "selected" "$(jq -r '.models[0].cost' "$MODEL_REPO/autoship/.autoship/model-routing.json")" "setup classifies explicit worker model as selected"
+assert_eq "7" "$(jq -r '.maxConcurrentAgents' "$MODEL_REPO/autoship/.autoship/config.json")" "setup honors portable --max-agents flag"
+assert_eq "agent:ready,needs-review" "$(jq -r '.labels | join(",")' "$MODEL_REPO/autoship/.autoship/config.json")" "setup honors portable --labels flag"
+
+echo "=== Test: setup rejects unavailable and forbidden models ==="
+if (cd "$MODEL_REPO/autoship" && PATH="$MODEL_REPO/bin:$PATH" bash hooks/opencode/setup.sh --no-tui --refresh-models --worker-models=missing/model >/dev/null 2>&1); then
+  fail "setup should reject unavailable worker models"
+fi
+if (cd "$MODEL_REPO/autoship" && PATH="$MODEL_REPO/bin:$PATH" bash hooks/opencode/setup.sh --no-tui --refresh-models --planner-model=openai/gpt-5.5-fast >/dev/null 2>&1); then
+  fail "setup should reject forbidden planner models"
+fi
+
+echo "OpenCode model parsing tests passed"

--- a/hooks/opencode/test-policy.sh
+++ b/hooks/opencode/test-policy.sh
@@ -303,4 +303,6 @@ cp -R "$SCRIPT_DIR/../.." "$PACKAGE_REPO"
   test -f "$CONFIG_DIR/.autoship/VERSION" || fail "package installer copies VERSION"
 )
 
+bash "$SCRIPT_DIR/test-model-parsing.sh" >/dev/null
+
 echo "OpenCode policy tests passed"


### PR DESCRIPTION
# AutoShip Issue #164 Result

## Status: COMPLETE

Implemented portable setup model inventory parsing that prefers free workers by default and allows explicit selected workers.

## Changes

- Added `hooks/opencode/model-parser.sh` for model ID normalization, free-model selection, selected/free classification, unavailable-model detection, and forbidden-model rejection.
- Updated `hooks/opencode/setup.sh` to use the model parser and a portable shell argument parser instead of GNU `getopt`.
- Added `hooks/opencode/test-model-parsing.sh` with mocked OpenCode/GitHub commands covering free, selected, unavailable, and forbidden model IDs.
- Wired model parsing tests into `hooks/opencode/test-policy.sh`.

## Verification

- `bash hooks/opencode/test-model-parsing.sh`
- `bash hooks/opencode/test-policy.sh`
- `bash -n hooks/opencode/*.sh hooks/*.sh`
- `bash hooks/opencode/smoke-test.sh`

Closes #164