### PR TITLE
feat: implement doctor status framework

### DIFF
--- a/hooks/opencode/test-policy.sh
+++ b/hooks/opencode/test-policy.sh
@@ -310,6 +310,22 @@ cp -R "$SCRIPT_DIR/../.." "$PACKAGE_REPO"
   test -d "$CONFIG_DIR/.autoship/skills" || fail "package installer copies skills"
   test -f "$CONFIG_DIR/.autoship/AGENTS.md" || fail "package installer copies AGENTS.md"
   test -f "$CONFIG_DIR/.autoship/VERSION" || fail "package installer copies VERSION"
+  DOCTOR_CONFIG="$TMP_DIR/doctor-config"
+  mkdir -p "$DOCTOR_CONFIG"
+  if OPENCODE_CONFIG_DIR="$DOCTOR_CONFIG" node dist/cli.js doctor >/"$TMP_DIR/doctor-fail-1.txt" 2>&1; then
+    fail "doctor exits non-zero when required checks fail"
+  fi
+  OPENCODE_CONFIG_DIR="$DOCTOR_CONFIG" node dist/cli.js doctor >/"$TMP_DIR/doctor-fail-2.txt" 2>&1 || true
+  cmp "$TMP_DIR/doctor-fail-1.txt" "$TMP_DIR/doctor-fail-2.txt" >/dev/null || fail "doctor failure output is deterministic"
+  grep -F '[FAIL]' "$TMP_DIR/doctor-fail-1.txt" >/dev/null || fail "doctor prints FAIL checks"
+  grep -F '[WARN]' "$TMP_DIR/doctor-fail-1.txt" >/dev/null || fail "doctor prints WARN checks"
+  mkdir -p "$DOCTOR_CONFIG/.autoship/hooks" "$DOCTOR_CONFIG/.autoship/commands" "$DOCTOR_CONFIG/.autoship/skills"
+  printf '{}\n' > "$DOCTOR_CONFIG/.autoship/config.json"
+  printf '{}\n' > "$DOCTOR_CONFIG/.autoship/model-routing.json"
+  date -u +%Y-%m-%dT%H:%M:%SZ > "$DOCTOR_CONFIG/.autoship/.onboarded"
+  OPENCODE_CONFIG_DIR="$DOCTOR_CONFIG" node dist/cli.js doctor >/"$TMP_DIR/doctor-pass.txt"
+  grep -F '[PASS]' "$TMP_DIR/doctor-pass.txt" >/dev/null || fail "doctor prints PASS checks"
+  grep -F '0 failed' "$TMP_DIR/doctor-pass.txt" >/dev/null || fail "doctor summary reports zero failures"
 )
 
 bash "$SCRIPT_DIR/test-model-parsing.sh" >/dev/null

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,7 @@ import {
   copyFile,
   readdir,
   stat,
+  access,
 } from "node:fs/promises";
 import { resolve, join } from "node:path";
 import { homedir } from "node:os";
@@ -115,8 +116,88 @@ async function install() {
 async function doctor() {
   console.log("opencode-autoship doctor");
   console.log("=====================");
-  console.log("This command is not yet implemented.");
-  console.log("Full diagnostics will be available in future releases.");
+  console.log();
+
+  interface Check {
+    name: string;
+    status: "PASS" | "WARN" | "FAIL";
+    message: string;
+  }
+
+  const checks: Check[] = []
+  let hasFailure = false
+
+  const configDir = resolveConfigDir()
+  const autoshipDir = join(configDir, ".autoship")
+
+  try {
+    await access(join(autoshipDir, ".onboarded"))
+    checks.push({ name: "onboarding", status: "PASS", message: "AutoShip is onboarded" })
+  } catch {
+    checks.push({ name: "onboarding", status: "WARN", message: "AutoShip has not been onboarded yet" })
+  }
+
+  try {
+    await access(join(autoshipDir, "config.json"))
+    checks.push({ name: "config", status: "PASS", message: "Config file exists" })
+  } catch {
+    checks.push({ name: "config", status: "FAIL", message: "Config file not found" })
+    hasFailure = true
+  }
+
+  try {
+    await access(join(autoshipDir, "model-routing.json"))
+    checks.push({ name: "model-routing", status: "PASS", message: "Model routing file exists" })
+  } catch {
+    checks.push({ name: "model-routing", status: "FAIL", message: "Model routing file not found" })
+    hasFailure = true
+  }
+
+  try {
+    await access(join(autoshipDir, "hooks"))
+    checks.push({ name: "hooks", status: "PASS", message: "Hooks directory exists" })
+  } catch {
+    checks.push({ name: "hooks", status: "FAIL", message: "Hooks directory not found" })
+    hasFailure = true
+  }
+
+  try {
+    await access(join(autoshipDir, "commands"))
+    checks.push({ name: "commands", status: "PASS", message: "Commands directory exists" })
+  } catch {
+    checks.push({ name: "commands", status: "FAIL", message: "Commands directory not found" })
+    hasFailure = true
+  }
+
+  try {
+    await access(join(autoshipDir, "skills"))
+    checks.push({ name: "skills", status: "PASS", message: "Skills directory exists" })
+  } catch {
+    checks.push({ name: "skills", status: "FAIL", message: "Skills directory not found" })
+    hasFailure = true
+  }
+
+  const passChecks = checks.filter(c => c.status === "PASS")
+  const warnChecks = checks.filter(c => c.status === "WARN")
+  const failChecks = checks.filter(c => c.status === "FAIL")
+
+  for (const check of passChecks) {
+    console.log(`[PASS] ${check.name}: ${check.message}`)
+  }
+  for (const check of warnChecks) {
+    console.log(`[WARN] ${check.name}: ${check.message}`)
+  }
+  for (const check of failChecks) {
+    console.log(`[FAIL] ${check.name}: ${check.message}`)
+  }
+  console.log()
+  console.log(`Summary: ${passChecks.length} passed, ${warnChecks.length} warnings, ${failChecks.length} failed`)
+
+  if (hasFailure) {
+    console.log()
+    console.log("Run 'opencode-autoship setup' to fix failures.")
+    process.exit(1)
+  }
 }
 
 function help() {
@@ -126,13 +207,13 @@ Usage: opencode-autoship <command>
 
 Commands:
   install   Install opencode-autoship to OpenCode config directory
-  doctor   Run diagnostics (not yet implemented)
+  doctor    Run diagnostics
   help     Show this help message
 
 Examples:
   opencode-autoship install
   opencode-autoship doctor
-`);
+ `);
 }
 
 async function main() {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -124,79 +124,79 @@ async function doctor() {
     message: string;
   }
 
-  const checks: Check[] = []
-  let hasFailure = false
+  const checks: Check[] = [];
+  let hasFailure = false;
 
-  const configDir = resolveConfigDir()
-  const autoshipDir = join(configDir, ".autoship")
+  const configDir = resolveConfigDir();
+  const autoshipDir = join(configDir, ".autoship");
 
   try {
-    await access(join(autoshipDir, ".onboarded"))
-    checks.push({ name: "onboarding", status: "PASS", message: "AutoShip is onboarded" })
+    await access(join(autoshipDir, ".onboarded"));
+    checks.push({ name: "onboarding", status: "PASS", message: "AutoShip is onboarded" });
   } catch {
-    checks.push({ name: "onboarding", status: "WARN", message: "AutoShip has not been onboarded yet" })
+    checks.push({ name: "onboarding", status: "WARN", message: "AutoShip has not been onboarded yet" });
   }
 
   try {
-    await access(join(autoshipDir, "config.json"))
-    checks.push({ name: "config", status: "PASS", message: "Config file exists" })
+    await access(join(autoshipDir, "config.json"));
+    checks.push({ name: "config", status: "PASS", message: "Config file exists" });
   } catch {
-    checks.push({ name: "config", status: "FAIL", message: "Config file not found" })
-    hasFailure = true
+    checks.push({ name: "config", status: "FAIL", message: "Config file not found" });
+    hasFailure = true;
   }
 
   try {
-    await access(join(autoshipDir, "model-routing.json"))
-    checks.push({ name: "model-routing", status: "PASS", message: "Model routing file exists" })
+    await access(join(autoshipDir, "model-routing.json"));
+    checks.push({ name: "model-routing", status: "PASS", message: "Model routing file exists" });
   } catch {
-    checks.push({ name: "model-routing", status: "FAIL", message: "Model routing file not found" })
-    hasFailure = true
+    checks.push({ name: "model-routing", status: "FAIL", message: "Model routing file not found" });
+    hasFailure = true;
   }
 
   try {
-    await access(join(autoshipDir, "hooks"))
-    checks.push({ name: "hooks", status: "PASS", message: "Hooks directory exists" })
+    await access(join(autoshipDir, "hooks"));
+    checks.push({ name: "hooks", status: "PASS", message: "Hooks directory exists" });
   } catch {
-    checks.push({ name: "hooks", status: "FAIL", message: "Hooks directory not found" })
-    hasFailure = true
+    checks.push({ name: "hooks", status: "FAIL", message: "Hooks directory not found" });
+    hasFailure = true;
   }
 
   try {
-    await access(join(autoshipDir, "commands"))
-    checks.push({ name: "commands", status: "PASS", message: "Commands directory exists" })
+    await access(join(autoshipDir, "commands"));
+    checks.push({ name: "commands", status: "PASS", message: "Commands directory exists" });
   } catch {
-    checks.push({ name: "commands", status: "FAIL", message: "Commands directory not found" })
-    hasFailure = true
+    checks.push({ name: "commands", status: "FAIL", message: "Commands directory not found" });
+    hasFailure = true;
   }
 
   try {
-    await access(join(autoshipDir, "skills"))
-    checks.push({ name: "skills", status: "PASS", message: "Skills directory exists" })
+    await access(join(autoshipDir, "skills"));
+    checks.push({ name: "skills", status: "PASS", message: "Skills directory exists" });
   } catch {
-    checks.push({ name: "skills", status: "FAIL", message: "Skills directory not found" })
-    hasFailure = true
+    checks.push({ name: "skills", status: "FAIL", message: "Skills directory not found" });
+    hasFailure = true;
   }
 
-  const passChecks = checks.filter(c => c.status === "PASS")
-  const warnChecks = checks.filter(c => c.status === "WARN")
-  const failChecks = checks.filter(c => c.status === "FAIL")
+  const passChecks = checks.filter(c => c.status === "PASS");
+  const warnChecks = checks.filter(c => c.status === "WARN");
+  const failChecks = checks.filter(c => c.status === "FAIL");
 
   for (const check of passChecks) {
-    console.log(`[PASS] ${check.name}: ${check.message}`)
+    console.log(`[PASS] ${check.name}: ${check.message}`);
   }
   for (const check of warnChecks) {
-    console.log(`[WARN] ${check.name}: ${check.message}`)
+    console.log(`[WARN] ${check.name}: ${check.message}`);
   }
   for (const check of failChecks) {
-    console.log(`[FAIL] ${check.name}: ${check.message}`)
+    console.log(`[FAIL] ${check.name}: ${check.message}`);
   }
-  console.log()
-  console.log(`Summary: ${passChecks.length} passed, ${warnChecks.length} warnings, ${failChecks.length} failed`)
+  console.log();
+  console.log(`Summary: ${passChecks.length} passed, ${warnChecks.length} warnings, ${failChecks.length} failed`);
 
   if (hasFailure) {
-    console.log()
-    console.log("Run 'opencode-autoship setup' to fix failures.")
-    process.exit(1)
+    console.log();
+    console.log("Run 'opencode-autoship install', then /autoship-setup to fix failures.");
+    process.exit(1);
   }
 }
 


### PR DESCRIPTION
# AutoShip Issue #167 Result

## Status: COMPLETE

Implemented and verified the `opencode-autoship doctor` PASS/WARN/FAIL framework.

## Changes

- `src/cli.ts` doctor command now emits grouped `[PASS]`, `[WARN]`, and `[FAIL]` checks with a summary.
- Doctor exits non-zero when required checks fail.
- Doctor output is deterministic across repeated runs.
- Policy tests cover failing and passing doctor states.

## Verification

- `npm run build`
- `bash hooks/opencode/test-policy.sh`
- `bash -n hooks/opencode/*.sh hooks/*.sh`
- `bash hooks/opencode/smoke-test.sh`

Closes #167