### PR TITLE
feat: check package install in doctor

### DIFF
--- a/hooks/opencode/test-policy.sh
+++ b/hooks/opencode/test-policy.sh
@@ -319,13 +319,22 @@ cp -R "$SCRIPT_DIR/../.." "$PACKAGE_REPO"
   cmp "$TMP_DIR/doctor-fail-1.txt" "$TMP_DIR/doctor-fail-2.txt" >/dev/null || fail "doctor failure output is deterministic"
   grep -F '[FAIL]' "$TMP_DIR/doctor-fail-1.txt" >/dev/null || fail "doctor prints FAIL checks"
   grep -F '[WARN]' "$TMP_DIR/doctor-fail-1.txt" >/dev/null || fail "doctor prints WARN checks"
+  grep -F 'opencode-autoship install' "$TMP_DIR/doctor-fail-1.txt" >/dev/null || fail "doctor failure output includes package install remediation"
+  printf '%s\n' '{"plugin":["opencode-autoship"]}' > "$DOCTOR_CONFIG/opencode.json"
   mkdir -p "$DOCTOR_CONFIG/.autoship/hooks" "$DOCTOR_CONFIG/.autoship/commands" "$DOCTOR_CONFIG/.autoship/skills"
   printf '{}\n' > "$DOCTOR_CONFIG/.autoship/config.json"
   printf '{}\n' > "$DOCTOR_CONFIG/.autoship/model-routing.json"
+  cp AGENTS.md "$DOCTOR_CONFIG/.autoship/AGENTS.md"
+  cp VERSION "$DOCTOR_CONFIG/.autoship/VERSION"
   date -u +%Y-%m-%dT%H:%M:%SZ > "$DOCTOR_CONFIG/.autoship/.onboarded"
   OPENCODE_CONFIG_DIR="$DOCTOR_CONFIG" node dist/cli.js doctor >/"$TMP_DIR/doctor-pass.txt"
   grep -F '[PASS]' "$TMP_DIR/doctor-pass.txt" >/dev/null || fail "doctor prints PASS checks"
   grep -F '0 failed' "$TMP_DIR/doctor-pass.txt" >/dev/null || fail "doctor summary reports zero failures"
+  printf 'v0.0.0\n' > "$DOCTOR_CONFIG/.autoship/VERSION"
+  if OPENCODE_CONFIG_DIR="$DOCTOR_CONFIG" node dist/cli.js doctor >/"$TMP_DIR/doctor-version-fail.txt" 2>&1; then
+    fail "doctor fails when installed asset version does not match package"
+  fi
+  grep -F 'asset version' "$TMP_DIR/doctor-version-fail.txt" >/dev/null || fail "doctor reports mismatched asset version"
 )
 
 bash "$SCRIPT_DIR/test-model-parsing.sh" >/dev/null

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -129,6 +129,21 @@ async function doctor() {
 
   const configDir = resolveConfigDir();
   const autoshipDir = join(configDir, ".autoship");
+  const opencodeConfigPath = join(configDir, "opencode.json");
+
+  try {
+    const opencodeConfig = await loadConfig(opencodeConfigPath);
+    const plugins = Array.isArray(opencodeConfig.plugin) ? opencodeConfig.plugin : [];
+    if (plugins.includes("opencode-autoship")) {
+      checks.push({ name: "package-registration", status: "PASS", message: "opencode-autoship is registered in opencode.json" });
+    } else {
+      checks.push({ name: "package-registration", status: "FAIL", message: "opencode.json does not register opencode-autoship; run opencode-autoship install" });
+      hasFailure = true;
+    }
+  } catch {
+    checks.push({ name: "package-registration", status: "FAIL", message: "Unable to read opencode.json; run opencode-autoship install" });
+    hasFailure = true;
+  }
 
   try {
     await access(join(autoshipDir, ".onboarded"));
@@ -174,6 +189,27 @@ async function doctor() {
     checks.push({ name: "skills", status: "PASS", message: "Skills directory exists" });
   } catch {
     checks.push({ name: "skills", status: "FAIL", message: "Skills directory not found" });
+    hasFailure = true;
+  }
+
+  try {
+    await access(join(autoshipDir, "AGENTS.md"));
+    checks.push({ name: "agents-guide", status: "PASS", message: "AGENTS.md is installed" });
+  } catch {
+    checks.push({ name: "agents-guide", status: "FAIL", message: "AGENTS.md not found; run opencode-autoship install" });
+    hasFailure = true;
+  }
+
+  try {
+    const assetVersion = (await readFile(join(autoshipDir, "VERSION"), "utf8")).trim();
+    if (assetVersion === VERSION) {
+      checks.push({ name: "asset-version", status: "PASS", message: `Installed assets match package ${VERSION}` });
+    } else {
+      checks.push({ name: "asset-version", status: "FAIL", message: `Installed asset version ${assetVersion} does not match package ${VERSION}; run opencode-autoship install` });
+      hasFailure = true;
+    }
+  } catch {
+    checks.push({ name: "asset-version", status: "FAIL", message: "Installed VERSION not found; run opencode-autoship install" });
     hasFailure = true;
   }
 


### PR DESCRIPTION
# AutoShip Issue #168 Result

## Status: COMPLETE

Added doctor checks for package registration, installed assets, and installed asset version alignment.

## Changes

- Doctor validates `opencode.json` registers `opencode-autoship`.
- Doctor validates installed `.autoship` asset directories and `AGENTS.md` exist.
- Doctor validates installed `.autoship/VERSION` matches the package `VERSION`.
- Failure messages include actionable `opencode-autoship install` remediation.
- Policy tests cover broken installs, deterministic doctor output, passing installs, and version mismatches.

## Verification

- `npm run build`
- `bash hooks/opencode/test-policy.sh`
- `bash -n hooks/opencode/*.sh hooks/*.sh`
- `bash hooks/opencode/smoke-test.sh`

Closes #168