### PR TITLE
feat: add doctor readiness checks

### DIFF
--- a/hooks/opencode/test-policy.sh
+++ b/hooks/opencode/test-policy.sh
@@ -310,12 +310,31 @@ cp -R "$SCRIPT_DIR/../.." "$PACKAGE_REPO"
   test -d "$CONFIG_DIR/.autoship/skills" || fail "package installer copies skills"
   test -f "$CONFIG_DIR/.autoship/AGENTS.md" || fail "package installer copies AGENTS.md"
   test -f "$CONFIG_DIR/.autoship/VERSION" || fail "package installer copies VERSION"
+  DOCTOR_BIN="$TMP_DIR/doctor-bin"
+  mkdir -p "$DOCTOR_BIN"
+  cat > "$DOCTOR_BIN/opencode" <<'SH'
+#!/usr/bin/env bash
+if [[ "$1" == "models" ]]; then
+  printf '%s\n' opencode/minimax-m2.5-free openai/gpt-5.5
+  exit 0
+fi
+exit 0
+SH
+  cat > "$DOCTOR_BIN/gh" <<'SH'
+#!/usr/bin/env bash
+if [[ "$1 $2" == "auth status" ]]; then
+  printf '%s\n' "Token scopes: 'repo', 'workflow'"
+  exit 0
+fi
+exit 0
+SH
+  chmod +x "$DOCTOR_BIN/opencode" "$DOCTOR_BIN/gh"
   DOCTOR_CONFIG="$TMP_DIR/doctor-config"
   mkdir -p "$DOCTOR_CONFIG"
-  if OPENCODE_CONFIG_DIR="$DOCTOR_CONFIG" node dist/cli.js doctor >/"$TMP_DIR/doctor-fail-1.txt" 2>&1; then
+  if PATH="$DOCTOR_BIN:$PATH" OPENCODE_CONFIG_DIR="$DOCTOR_CONFIG" node dist/cli.js doctor >/"$TMP_DIR/doctor-fail-1.txt" 2>&1; then
     fail "doctor exits non-zero when required checks fail"
   fi
-  OPENCODE_CONFIG_DIR="$DOCTOR_CONFIG" node dist/cli.js doctor >/"$TMP_DIR/doctor-fail-2.txt" 2>&1 || true
+  PATH="$DOCTOR_BIN:$PATH" OPENCODE_CONFIG_DIR="$DOCTOR_CONFIG" node dist/cli.js doctor >/"$TMP_DIR/doctor-fail-2.txt" 2>&1 || true
   cmp "$TMP_DIR/doctor-fail-1.txt" "$TMP_DIR/doctor-fail-2.txt" >/dev/null || fail "doctor failure output is deterministic"
   grep -F '[FAIL]' "$TMP_DIR/doctor-fail-1.txt" >/dev/null || fail "doctor prints FAIL checks"
   grep -F '[WARN]' "$TMP_DIR/doctor-fail-1.txt" >/dev/null || fail "doctor prints WARN checks"
@@ -323,15 +342,30 @@ cp -R "$SCRIPT_DIR/../.." "$PACKAGE_REPO"
   printf '%s\n' '{"plugin":["opencode-autoship"]}' > "$DOCTOR_CONFIG/opencode.json"
   mkdir -p "$DOCTOR_CONFIG/.autoship/hooks" "$DOCTOR_CONFIG/.autoship/commands" "$DOCTOR_CONFIG/.autoship/skills"
   printf '{}\n' > "$DOCTOR_CONFIG/.autoship/config.json"
-  printf '{}\n' > "$DOCTOR_CONFIG/.autoship/model-routing.json"
+  printf '%s\n' '{"models":[{"id":"opencode/minimax-m2.5-free"}]}' > "$DOCTOR_CONFIG/.autoship/model-routing.json"
   cp AGENTS.md "$DOCTOR_CONFIG/.autoship/AGENTS.md"
   cp VERSION "$DOCTOR_CONFIG/.autoship/VERSION"
   date -u +%Y-%m-%dT%H:%M:%SZ > "$DOCTOR_CONFIG/.autoship/.onboarded"
-  OPENCODE_CONFIG_DIR="$DOCTOR_CONFIG" node dist/cli.js doctor >/"$TMP_DIR/doctor-pass.txt"
+  PATH="$DOCTOR_BIN:$PATH" OPENCODE_CONFIG_DIR="$DOCTOR_CONFIG" node dist/cli.js doctor >/"$TMP_DIR/doctor-pass.txt"
   grep -F '[PASS]' "$TMP_DIR/doctor-pass.txt" >/dev/null || fail "doctor prints PASS checks"
   grep -F '0 failed' "$TMP_DIR/doctor-pass.txt" >/dev/null || fail "doctor summary reports zero failures"
+  grep -F 'model-inventory' "$TMP_DIR/doctor-pass.txt" >/dev/null || fail "doctor validates OpenCode model inventory"
+  grep -F 'gh-auth' "$TMP_DIR/doctor-pass.txt" >/dev/null || fail "doctor validates GitHub auth"
+  cat > "$DOCTOR_BIN/opencode" <<'SH'
+#!/usr/bin/env bash
+exit 1
+SH
+  cat > "$DOCTOR_BIN/gh" <<'SH'
+#!/usr/bin/env bash
+exit 1
+SH
+  chmod +x "$DOCTOR_BIN/opencode" "$DOCTOR_BIN/gh"
+  PATH="$DOCTOR_BIN:$PATH" OPENCODE_CONFIG_DIR="$DOCTOR_CONFIG" node dist/cli.js doctor >/"$TMP_DIR/doctor-optional-warn.txt"
+  grep -F '[WARN] model-inventory' "$TMP_DIR/doctor-optional-warn.txt" >/dev/null || fail "doctor warns for unavailable model inventory"
+  grep -F '[WARN] gh-auth' "$TMP_DIR/doctor-optional-warn.txt" >/dev/null || fail "doctor warns for missing GitHub auth"
+  grep -F '0 failed' "$TMP_DIR/doctor-optional-warn.txt" >/dev/null || fail "doctor treats optional readiness checks as warnings"
   printf 'v0.0.0\n' > "$DOCTOR_CONFIG/.autoship/VERSION"
-  if OPENCODE_CONFIG_DIR="$DOCTOR_CONFIG" node dist/cli.js doctor >/"$TMP_DIR/doctor-version-fail.txt" 2>&1; then
+  if PATH="$DOCTOR_BIN:$PATH" OPENCODE_CONFIG_DIR="$DOCTOR_CONFIG" node dist/cli.js doctor >/"$TMP_DIR/doctor-version-fail.txt" 2>&1; then
     fail "doctor fails when installed asset version does not match package"
   fi
   grep -F 'asset version' "$TMP_DIR/doctor-version-fail.txt" >/dev/null || fail "doctor reports mismatched asset version"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -213,6 +213,60 @@ async function doctor() {
     hasFailure = true;
   }
 
+  const { exec } = await import("node:child_process");
+  const execAsync = (cmd: string): Promise<string> => new Promise((resolve, reject) => {
+    exec(cmd, { encoding: "utf8", timeout: 30000 }, (err, stdout) => {
+      if (err) reject(err);
+      else resolve(stdout);
+    });
+  });
+
+  try {
+    const modelsOutput = await execAsync("opencode models");
+    if (modelsOutput.trim().length > 0) {
+      checks.push({ name: "model-inventory", status: "PASS", message: "OpenCode model inventory is accessible" });
+      try {
+        const routingPath = join(autoshipDir, "model-routing.json");
+        await access(routingPath);
+        const routingContent = await readFile(routingPath, "utf8");
+        const routing = JSON.parse(routingContent);
+        const modelIds = modelsOutput.split("\n").map((l) => l.trim()).filter(Boolean);
+        const configuredModels = (routing.models || []).map((m: { id: string }) => m.id);
+        const missingModels = configuredModels.filter((m: string) => !modelIds.some((id: string) => id.includes(m) || m.includes(id)));
+        if (missingModels.length > 0) {
+          checks.push({ name: "model-routing-refs", status: "WARN", message: `Configured models not in current inventory: ${missingModels.join(", ")}` });
+        } else {
+          checks.push({ name: "model-routing-refs", status: "PASS", message: "All configured models are in current inventory" });
+        }
+      } catch {
+        checks.push({ name: "model-routing-refs", status: "WARN", message: "Unable to validate model-routing.json references" });
+      }
+    } else {
+      checks.push({ name: "model-inventory", status: "WARN", message: "OpenCode model inventory is empty" });
+    }
+  } catch {
+    checks.push({ name: "model-inventory", status: "WARN", message: "Unable to access OpenCode model inventory; run /autoship-setup" });
+  }
+
+  try {
+    await execAsync("gh auth status");
+    checks.push({ name: "gh-auth", status: "PASS", message: "GitHub CLI is authenticated" });
+    try {
+      const statusOutput = await execAsync("gh auth status");
+      const hasRepoScope = statusOutput.includes("repo") || statusOutput.includes("Full");
+      if (hasRepoScope) {
+        checks.push({ name: "gh-repo-perms", status: "PASS", message: "GitHub token has repo scope for issue-to-PR automation" });
+      } else {
+        checks.push({ name: "gh-repo-perms", status: "WARN", message: "GitHub token may lack repo scope; run 'gh auth refresh'" });
+      }
+    } catch {
+      checks.push({ name: "gh-repo-perms", status: "WARN", message: "Unable to verify repo permissions" });
+    }
+  } catch {
+    checks.push({ name: "gh-auth", status: "WARN", message: "GitHub CLI not authenticated; run 'gh auth login' or set GH_TOKEN" });
+    checks.push({ name: "gh-repo-perms", status: "WARN", message: "GitHub auth required for permission check" });
+  }
+
   const passChecks = checks.filter(c => c.status === "PASS");
   const warnChecks = checks.filter(c => c.status === "WARN");
   const failChecks = checks.filter(c => c.status === "FAIL");


### PR DESCRIPTION
# AutoShip Issue #169 Result

## Status: COMPLETE

Added doctor checks for model inventory, model routing references, GitHub auth, and GitHub repo-scope readiness.

## Changes

- Doctor warns when `opencode models` is unavailable or empty.
- Doctor warns when configured routing models are not in the current inventory.
- Doctor warns when `gh auth status` is unavailable or repo-scope readiness is unclear.
- Blocking install/config/asset checks remain FAIL.
- Policy tests use fake `opencode` and `gh` commands to prove readiness issues are WARN-only and deterministic.

## Verification

- `npm run build`
- `bash hooks/opencode/test-policy.sh`
- `bash -n hooks/opencode/*.sh hooks/*.sh`
- `bash hooks/opencode/smoke-test.sh`

Closes #169