### PR TITLE
feat: define role-based model routing

### DIFF
--- a/hooks/opencode/select-model.sh
+++ b/hooks/opencode/select-model.sh
@@ -2,8 +2,13 @@
 set -euo pipefail
 
 ROLE=""
+POOL=""
 if [[ "${1:-}" == "--role" ]]; then
   ROLE="${2:?Role required}"
+  shift 2
+fi
+if [[ "${1:-}" == "--pool" ]]; then
+  POOL="${2:?Pool required}"
   shift 2
 fi
 
@@ -19,6 +24,11 @@ fi
 
 if [[ -n "$ROLE" ]]; then
   jq -r --arg role "$ROLE" '.roles[$role] // empty' "$ROUTING_FILE"
+  exit 0
+fi
+
+if [[ -n "$POOL" ]]; then
+  jq -r --arg pool "$POOL" '.pools[$pool].models[] // empty' "$ROUTING_FILE" 2>/dev/null || exit 0
   exit 0
 fi
 

--- a/hooks/opencode/setup.sh
+++ b/hooks/opencode/setup.sh
@@ -12,6 +12,7 @@ PLANNER_MODEL="${AUTOSHIP_PLANNER_MODEL:-openai/gpt-5.5}"
 COORDINATOR_MODEL="${AUTOSHIP_COORDINATOR_MODEL:-$PLANNER_MODEL}"
 ORCHESTRATOR_MODEL="${AUTOSHIP_ORCHESTRATOR_MODEL:-$PLANNER_MODEL}"
 REVIEWER_MODEL="${AUTOSHIP_REVIEWER_MODEL:-$PLANNER_MODEL}"
+LEAD_MODEL="${AUTOSHIP_LEAD_MODEL:-$PLANNER_MODEL}"
 LABELS="${AUTOSHIP_LABELS:-agent:ready}"
 
 NO_TUI=0
@@ -30,7 +31,8 @@ OPTIONS:
   --max-agents N        Set max concurrent agents (default: 15)
   --labels LABEL,...   Comma-separated labels to monitor (default: agent:ready)
   --refresh-models     Force refresh model inventory from OpenCode
-  --planner-model MODEL Set planner/coordinator/orchestrator/reviewer model (default: openai/gpt-5.5)
+  --planner-model MODEL Set planner/coordinator/orchestrator/reviewer/lead model (default: openai/gpt-5.5)
+  --lead-model MODEL   Set lead model separately (default: same as planner)
   --worker-models MODELS Comma-separated worker models (default: auto-detect free)
   -h, --help           Show this help message
 
@@ -49,6 +51,7 @@ ENVIRONMENT VARIABLES:
   AUTOSHIP_MODELS          Comma-separated worker models
   AUTOSHIP_REFRESH_MODELS  Set to 1 to force refresh
   AUTOSHIP_PLANNER_MODEL   Planner model (default: openai/gpt-5.5)
+  AUTOSHIP_LEAD_MODEL    Lead model (default: same as planner)
   AUTOSHIP_LABELS          Comma-separated labels (default: agent:ready)
   GH_TOKEN                 GitHub token (for gh auth)
 EOF
@@ -90,6 +93,7 @@ parse_args() {
         COORDINATOR_MODEL="$2"
         ORCHESTRATOR_MODEL="$2"
         REVIEWER_MODEL="$2"
+        LEAD_MODEL="$2"
         shift 2
         ;;
       --planner-model=*)
@@ -97,6 +101,16 @@ parse_args() {
         COORDINATOR_MODEL="$PLANNER_MODEL"
         ORCHESTRATOR_MODEL="$PLANNER_MODEL"
         REVIEWER_MODEL="$PLANNER_MODEL"
+        LEAD_MODEL="$PLANNER_MODEL"
+        shift
+        ;;
+      --lead-model)
+        [[ $# -ge 2 ]] || { echo "Error: --lead-model requires a value" >&2; usage 2; }
+        LEAD_MODEL="$2"
+        shift 2
+        ;;
+      --lead-model=*)
+        LEAD_MODEL="${1#*=}"
         shift
         ;;
       --worker-models)
@@ -214,19 +228,19 @@ if [[ -n "$missing_models" ]]; then
   exit 1
 fi
 
-missing_role_models=$(find_missing_models "$available_model_ids" "$PLANNER_MODEL" "$COORDINATOR_MODEL" "$ORCHESTRATOR_MODEL" "$REVIEWER_MODEL")
+missing_role_models=$(find_missing_models "$available_model_ids" "$PLANNER_MODEL" "$COORDINATOR_MODEL" "$ORCHESTRATOR_MODEL" "$REVIEWER_MODEL" "$LEAD_MODEL")
 if [[ -n "$missing_role_models" ]]; then
-  echo "Error: planner/coordinator/orchestrator models are not currently available in this OpenCode instance:" >&2
+  echo "Error: planner/coordinator/orchestrator/reviewer/lead models are not currently available in this OpenCode instance:" >&2
   printf '%s\n' "$missing_role_models" >&2
   exit 1
 fi
 
-python3 - "$ROUTING_FILE" "$CONFIG_FILE" "$SELECTED_MODELS" "$MAX_AGENTS" "$PLANNER_MODEL" "$COORDINATOR_MODEL" "$ORCHESTRATOR_MODEL" "$REVIEWER_MODEL" "$LABELS" <<'PY'
+python3 - "$ROUTING_FILE" "$CONFIG_FILE" "$SELECTED_MODELS" "$MAX_AGENTS" "$PLANNER_MODEL" "$COORDINATOR_MODEL" "$ORCHESTRATOR_MODEL" "$REVIEWER_MODEL" "$LEAD_MODEL" "$LABELS" <<'PY'
 import json
 import sys
 import os
 
-routing_path, config_path, selected_models, max_agents, planner_model, coordinator_model, orchestrator_model, reviewer_model, labels = sys.argv[1:]
+routing_path, config_path, selected_models, max_agents, planner_model, coordinator_model, orchestrator_model, reviewer_model, lead_model, labels = sys.argv[1:]
 models = [m.strip() for m in selected_models.split(",") if m.strip()]
 labels_list = [l.strip() for l in labels.split(",") if l.strip()]
 
@@ -282,6 +296,29 @@ with open(routing_path, "w", encoding="utf-8") as f:
             "coordinator": coordinator_model,
             "orchestrator": orchestrator_model,
             "reviewer": reviewer_model,
+            "lead": lead_model,
+        },
+        "pools": {
+            "default": {
+                "description": "Default worker pool for general tasks",
+                "models": [e["id"] for e in entries],
+            },
+            "frontend": {
+                "description": "Frontend development tasks",
+                "models": [e["id"] for e in entries if "frontend" in e.get("max_task_types", []) or "docs" in e.get("max_task_types", [])],
+            },
+            "backend": {
+                "description": "Backend development tasks",
+                "models": [e["id"] for e in entries if "medium_code" in e.get("max_task_types", []) or "complex" in e.get("max_task_types", [])],
+            },
+            "docs": {
+                "description": "Documentation tasks",
+                "models": [e["id"] for e in entries if "docs" in e.get("max_task_types", [])],
+            },
+            "mechanical": {
+                "description": "Mechanical/boilerplate tasks",
+                "models": [e["id"] for e in entries if "mechanical" in e.get("max_task_types", [])],
+            },
         },
         "defaultFallback": default,
         "models": entries,
@@ -297,6 +334,7 @@ with open(config_path, "w", encoding="utf-8") as f:
         "coordinatorModel": coordinator_model,
         "orchestratorModel": orchestrator_model,
         "reviewerModel": reviewer_model,
+        "leadModel": lead_model,
         "models": models,
         "labels": labels_list,
         "refreshModels": int(os.environ.get("AUTOSHIP_REFRESH_MODELS", "0")) == 1,

--- a/hooks/opencode/test-policy.sh
+++ b/hooks/opencode/test-policy.sh
@@ -206,7 +206,8 @@ chmod +x "$SETUP_REPO/bin/opencode"
   printf '%s\n' "$setup_output" | grep -F '/autoship' >/dev/null || fail "setup prints autoship next step"
   jq -e '.models | length == 5' .autoship/model-routing.json >/dev/null || fail "setup writes all live free models by default"
   jq -e '.maxConcurrentAgents == 15 and .max_agents == 15' .autoship/config.json >/dev/null || fail "setup writes default concurrency cap consumed by runtime"
-  jq -e '.roles.planner == "openai/gpt-5.5" and .roles.coordinator == "openai/gpt-5.5" and .roles.orchestrator == "openai/gpt-5.5"' .autoship/model-routing.json >/dev/null || fail "setup configures GPT-5.5 as planner/coordinator/orchestrator"
+  jq -e '.roles.planner == "openai/gpt-5.5" and .roles.coordinator == "openai/gpt-5.5" and .roles.orchestrator == "openai/gpt-5.5" and .roles.lead == "openai/gpt-5.5"' .autoship/model-routing.json >/dev/null || fail "setup configures GPT-5.5 as planner/coordinator/orchestrator/lead"
+  jq -e '.pools != null and .pools.default != null and .pools.frontend != null and .pools.backend != null and .pools.docs != null' .autoship/model-routing.json >/dev/null || fail "setup writes worker pools"
   jq -e 'all(.models[]; .cost == "free")' .autoship/model-routing.json >/dev/null || fail "default setup excludes paid worker models"
   jq -e 'all(.models[]; .id != "openai/gpt-5.5")' .autoship/model-routing.json >/dev/null || fail "planner model is not used as a default worker"
   jq -e 'any(.models[]; .id == "openrouter/google/gemma-3-27b-it:free")' .autoship/model-routing.json >/dev/null || fail "setup includes OpenRouter free models from live OpenCode list"
@@ -229,6 +230,8 @@ chmod +x "$SETUP_REPO/bin/opencode"
   if AUTOSHIP_MODELS='openai/gpt-5.5-fast' PATH="$SETUP_REPO/bin:$PATH" bash hooks/opencode/setup.sh >/dev/null 2>&1; then
     fail "setup rejects gpt-5.5-fast"
   fi
+  AUTOSHIP_LEAD_MODEL=openai/gpt-5.5 PATH="$SETUP_REPO/bin:$PATH" bash hooks/opencode/setup.sh >/dev/null
+  jq -e '.roles.lead == "openai/gpt-5.5"' .autoship/model-routing.json >/dev/null || fail "setup accepts lead model override via AUTOSHIP_LEAD_MODEL"
 )
 
 SELECT_REPO="$TMP_DIR/select-repo"
@@ -240,7 +243,13 @@ cat > "$SELECT_REPO/.autoship/model-routing.json" <<'JSON'
     "planner": "openai/gpt-5.5",
     "coordinator": "openai/gpt-5.5",
     "orchestrator": "openai/gpt-5.5",
-    "reviewer": "openai/gpt-5.5"
+    "reviewer": "openai/gpt-5.5",
+    "lead": "openai/gpt-5.5"
+  },
+  "pools": {
+    "default": {"description": "Default pool", "models": ["free/strong:free", "free/reliable:free"]},
+    "frontend": {"description": "Frontend", "models": ["free/strong:free"]},
+    "backend": {"description": "Backend", "models": ["free/reliable:free"]}
   },
   "models": [
     {"id":"free/strong:free","cost":"free","strength":90,"max_task_types":["simple_code"]},
@@ -262,6 +271,11 @@ assert_eq "openai/gpt-5.3-codex-spark" "$(cd "$SELECT_REPO" && bash hooks/openco
 assert_eq "opencode-go/qwen3.6-plus" "$(cd "$SELECT_REPO" && bash hooks/opencode/select-model.sh medium_code 103)" "selector can choose Go model when best for task"
 assert_eq "openai/gpt-5.5" "$(cd "$SELECT_REPO" && bash hooks/opencode/select-model.sh --role planner)" "selector returns GPT-5.5 planner role"
 assert_eq "openai/gpt-5.5" "$(cd "$SELECT_REPO" && bash hooks/opencode/select-model.sh --role reviewer)" "selector returns GPT-5.5 reviewer role"
+assert_eq "openai/gpt-5.5" "$(cd "$SELECT_REPO" && bash hooks/opencode/select-model.sh --role lead)" "selector returns GPT-5.5 lead role"
+POOL_MODELS=$(cd "$SELECT_REPO" && bash hooks/opencode/select-model.sh --pool default)
+assert_eq "true" "$(echo "$POOL_MODELS" | grep -q "free/strong:free" && echo "true" || echo "false")" "selector --pool default returns pool models"
+POOL_MODELS=$(cd "$SELECT_REPO" && bash hooks/opencode/select-model.sh --pool frontend)
+assert_eq "true" "$(echo "$POOL_MODELS" | grep -q "free/strong:free" && echo "true" || echo "false")" "selector --pool frontend returns frontend pool models"
 
 UPDATE_REPO="$TMP_DIR/update-repo"
 mkdir -p "$UPDATE_REPO/.autoship" "$UPDATE_REPO/bin" "$UPDATE_REPO/hooks"

--- a/wiki/Configuration.md
+++ b/wiki/Configuration.md
@@ -12,6 +12,93 @@ AutoShip configuration lives under `.autoship/` and should not be committed.
 | `.autoship/model-routing.json` | User-editable model routing and role config |
 | `.autoship/model-history.json` | Optional learned model success/failure history |
 
+## Model Routing Schema
+
+The `model-routing.json` file defines role assignments and worker pools:
+
+```json
+{
+  "roles": {
+    "planner": "openai/gpt-5.5",
+    "coordinator": "openai/gpt-5.5",
+    "orchestrator": "openai/gpt-5.5",
+    "reviewer": "openai/gpt-5.5",
+    "lead": "openai/gpt-5.5"
+  },
+  "pools": {
+    "default": {
+      "description": "Default worker pool for general tasks",
+      "models": ["model-a", "model-b"]
+    },
+    "frontend": {
+      "description": "Frontend development tasks",
+      "models": ["model-a"]
+    },
+    "backend": {
+      "description": "Backend development tasks",
+      "models": ["model-b"]
+    },
+    "docs": {
+      "description": "Documentation tasks",
+      "models": ["model-a"]
+    },
+    "mechanical": {
+      "description": "Mechanical/boilerplate tasks",
+      "models": ["model-a"]
+    }
+  },
+  "defaultFallback": "model-a",
+  "models": [
+    {"id": "model-a", "cost": "free", "strength": 90, "max_task_types": ["docs", "simple_code"]},
+    {"id": "model-b", "cost": "selected", "strength": 110, "max_task_types": ["medium_code", "complex"]}
+  ]
+}
+```
+
+### Roles
+
+| Role | Purpose | Default |
+| --- | --- | --- |
+| `planner` | Plans issue work and acceptance criteria | openai/gpt-5.5 |
+| `coordinator` | Coordinates multi-agent workflows | openai/gpt-5.5 |
+| `orchestrator` | Orchestrates issue→PR pipeline | openai/gpt-5.5 |
+| `reviewer` | Reviews PRs before merge | openai/gpt-5.5 |
+| `lead` | Leads individual agent work | openai/gpt-5.5 |
+
+### Worker Pools
+
+Worker pools allow routing to specialized model groups:
+
+- `default` - General task pool
+- `frontend` - Frontend/UI work
+- `backend` - Backend/complex work
+- `docs` - Documentation tasks
+- `mechanical` - Boilerplate tasks
+
+### Model Entry Fields
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `id` | string | Model ID from `opencode models` |
+| `cost` | string | "free" or "selected" |
+| `strength` | int | Capability score (0-150) |
+| `max_task_types` | array | Compatible task types |
+
+### Model Selection
+
+Use the select-model.sh hook to query models:
+
+```bash
+# Get model for a task
+bash hooks/opencode/select-model.sh medium_code 170
+
+# Get model for a specific role
+bash hooks/opencode/select-model.sh --role lead
+
+# Get models in a specific pool
+bash hooks/opencode/select-model.sh --pool frontend
+```
+
 ## Model Routing
 
 Run setup to detect current models:


### PR DESCRIPTION
# AutoShip Issue #170 Result

## Status: COMPLETE

Implemented role-based model routing schema with lead role and worker pools.

## Changes

- `hooks/opencode/setup.sh` now writes `roles.lead` and `pools` into `.autoship/model-routing.json`.
- Added `--lead-model` and `AUTOSHIP_LEAD_MODEL` support.
- `hooks/opencode/select-model.sh` now supports `--pool <name>` lookup.
- `hooks/opencode/test-policy.sh` validates lead role, pool schema, and pool selection.
- `wiki/Configuration.md` documents the routing schema.

## Verification

- `bash hooks/opencode/test-policy.sh`
- `bash -n hooks/opencode/*.sh hooks/*.sh`
- `bash hooks/opencode/smoke-test.sh`

Closes #170