### PR TITLE
feat: log worker model routing decisions

### DIFF
--- a/hooks/opencode/dispatch.sh
+++ b/hooks/opencode/dispatch.sh
@@ -63,7 +63,16 @@ resolve_model() {
     return 0
   fi
   if [[ -f "$ROUTING_FILE" ]]; then
-    bash "$SCRIPT_DIR/select-model.sh" "$task_type" "$issue_num"
+    local routing_log
+    routing_log=$(bash "$SCRIPT_DIR/select-model.sh" --log "$task_type" "$issue_num" 2>/dev/null || echo "")
+    local selected_model
+    selected_model=$(bash "$SCRIPT_DIR/select-model.sh" "$task_type" "$issue_num" 2>/dev/null || echo "")
+    if [[ -n "$routing_log" ]]; then
+      mkdir -p "$WORKSPACE_PATH"
+      log_file="$WORKSPACE_PATH/routing-log.txt"
+      printf '%s\n' "$routing_log" > "$log_file"
+    fi
+    printf '%s\n' "$selected_model"
     return 0
   fi
   printf '%s\n' ""

--- a/hooks/opencode/select-model.sh
+++ b/hooks/opencode/select-model.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROLE=""
 POOL=""
+LOG=false
 if [[ "${1:-}" == "--role" ]]; then
   ROLE="${2:?Role required}"
   shift 2
@@ -10,6 +11,10 @@ fi
 if [[ "${1:-}" == "--pool" ]]; then
   POOL="${2:?Pool required}"
   shift 2
+fi
+if [[ "${1:-}" == "--log" ]]; then
+  LOG=true
+  shift
 fi
 
 TASK_TYPE="${1:-simple_code}"
@@ -29,6 +34,43 @@ fi
 
 if [[ -n "$POOL" ]]; then
   jq -r --arg pool "$POOL" '.pools[$pool].models[] // empty' "$ROUTING_FILE" 2>/dev/null || exit 0
+  exit 0
+fi
+
+if [[ "$LOG" == true ]]; then
+  jq -r --arg task "$TASK_TYPE" --argjson issue "$ISSUE_NUM" --slurpfile history "$HISTORY_FILE" '
+    def hist($id):
+      (($history[0] // {})[$id] // {success: 0, fail: 0});
+    def compatible:
+      (.enabled // true) == true
+      and (((.max_task_types // []) | length == 0) or ((.max_task_types // []) | index($task) != null));
+    def cost_score:
+      if .cost == "free" then 100
+      elif (.id | test("(^|/)gpt-5\\.3-codex-spark$|spark"; "i")) then 85
+      elif (.id | startswith("opencode-go/")) then 80
+      elif (.cost // "") == "selected" then 70
+      else 50 end;
+    def reason:
+      if .cost == "free" then "free model selected by default"
+      elif (.id | test("(^|/)gpt-5\\.3-codex-spark$|spark"; "i")) then "Spark model selected for complex task suitability"
+      elif (.cost // "") == "selected" then "operator-selected model for task"
+      else "model selected as fallback" end;
+    [.models[] | select(compatible) |
+      . as $m |
+      (hist($m.id)) as $h |
+      .score = ((cost_score) + (.strength // 0) + (($h.success // 0) * 12) - (($h.fail // 0) * 20))
+      | .reason = reason
+    ] | sort_by(-.score, .id) |
+    . as $candidates |
+    if length > 0 then
+      "routing_log:" +
+      (map("\nselection: \(.id)\nscore: \(.score)\nreason: \(.reason)") | join("")) +
+      "\nfinal_selection: " + $candidates[0].id +
+      "\nfinal_reason: " + $candidates[0].reason
+    else
+      "routing_log:\nfinal_selection:"
+    end
+  ' "$ROUTING_FILE"
   exit 0
 fi
 

--- a/hooks/opencode/test-policy.sh
+++ b/hooks/opencode/test-policy.sh
@@ -277,6 +277,50 @@ assert_eq "true" "$(echo "$POOL_MODELS" | grep -q "free/strong:free" && echo "tr
 POOL_MODELS=$(cd "$SELECT_REPO" && bash hooks/opencode/select-model.sh --pool frontend)
 assert_eq "true" "$(echo "$POOL_MODELS" | grep -q "free/strong:free" && echo "true" || echo "false")" "selector --pool frontend returns frontend pool models"
 
+ROUTING_LOG=$(cd "$SELECT_REPO" && bash hooks/opencode/select-model.sh --log simple_code 101)
+assert_eq "true" "$(echo "$ROUTING_LOG" | grep -q "routing_log:" && echo "true" || echo "false")" "selector --log outputs routing log"
+assert_eq "true" "$(echo "$ROUTING_LOG" | grep -q "selection: free/strong:free" && echo "true" || echo "false")" "routing log shows free model selection"
+assert_eq "true" "$(echo "$ROUTING_LOG" | grep -q "score:" && echo "true" || echo "false")" "routing log shows score"
+assert_eq "true" "$(echo "$ROUTING_LOG" | grep -q "reason:" && echo "true" || echo "false")" "routing log shows reason"
+assert_eq "true" "$(echo "$ROUTING_LOG" | grep -q "final_selection: free/reliable:free" && echo "true" || echo "false")" "routing log shows final selection"
+
+cat > "$SELECT_REPO/.autoship/model-history.json" <<'JSON'
+{
+  "free/strong:free": {"success": 0, "fail": 6},
+  "free/reliable:free": {"success": 4, "fail": 0}
+}
+JSON
+
+ROUTING_LOG_ESCALATE=$(cd "$SELECT_REPO" && bash hooks/opencode/select-model.sh --log simple_code 101)
+assert_eq "true" "$(echo "$ROUTING_LOG_ESCALATE" | grep -q "free model selected by default" && echo "true" || echo "false")" "routing log shows free selection reason"
+
+cat > "$SELECT_REPO/.autoship/model-routing.json" <<'JSON'
+{
+  "roles": {
+    "planner": "openai/gpt-5.5",
+    "coordinator": "openai/gpt-5.5",
+    "orchestrator": "openai/gpt-5.5",
+    "reviewer": "openai/gpt-5.5",
+    "lead": "openai/gpt-5.5"
+  },
+  "pools": {
+    "default": {"description": "Default pool", "models": ["free/strong:free", "free/reliable:free"]},
+    "frontend": {"description": "Frontend", "models": ["free/strong:free"]},
+    "backend": {"description": "Backend", "models": ["free/reliable:free"]}
+  },
+  "models": [
+    {"id":"free/strong:free","cost":"free","strength":90,"max_task_types":["simple_code"]},
+    {"id":"free/reliable:free","cost":"free","strength":70,"max_task_types":["simple_code"]},
+    {"id":"openai/gpt-5.3-codex-spark","cost":"selected","strength":95,"max_task_types":["complex"]},
+    {"id":"opencode-go/qwen3.6-plus","cost":"selected","strength":110,"max_task_types":["medium_code"]}
+  ]
+}
+JSON
+
+ROUTING_LOG_COMPLEX=$(cd "$SELECT_REPO" && bash hooks/opencode/select-model.sh --log complex 102)
+assert_eq "true" "$(echo "$ROUTING_LOG_COMPLEX" | grep -q "final_selection: openai/gpt-5.3-codex-spark" && echo "true" || echo "false")" "routing log shows Spark for complex task"
+assert_eq "true" "$(echo "$ROUTING_LOG_COMPLEX" | grep -q "Spark model selected for complex task" && echo "true" || echo "false")" "routing log shows escalation reason for Spark"
+
 UPDATE_REPO="$TMP_DIR/update-repo"
 mkdir -p "$UPDATE_REPO/.autoship" "$UPDATE_REPO/bin" "$UPDATE_REPO/hooks"
 git init -q "$UPDATE_REPO"


### PR DESCRIPTION
# AutoShip Issue #172 Result

## Status: COMPLETE

Added routing decision logs for worker model selection so free-first choices and escalation/fallback reasons are visible.

## Changes

- `select-model.sh --log` emits candidate scores, reasons, final selection, and final reason.
- Free models log `free model selected by default`.
- Spark/selected models log escalation/selection reasons.
- `dispatch.sh` writes `.autoship/workspaces/<issue>/routing-log.txt` during model resolution.
- Policy tests cover routing logs, free-first selection, learned history selection, and Spark complex-task escalation reason.

## Verification

- `bash hooks/opencode/test-policy.sh`
- `bash -n hooks/opencode/*.sh hooks/*.sh`
- `bash hooks/opencode/smoke-test.sh`

Closes #172