### PR TITLE
feat: add specialized role skills

### DIFF
--- a/skills/role-docs/SKILL.md
+++ b/skills/role-docs/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: role-docs
+description: Docs role — creates and maintains documentation
+platform: opencode
+tools: ["Bash", "Read", "Write", "Glob", "Grep"]
+---
+
+# Docs Role — OpenCode
+
+Creates and maintains documentation.
+
+## Inputs
+
+- Code changes to document
+- Feature specifications
+
+## Workflow
+
+### Step 1: Review Changes
+
+```bash
+git diff --stat
+git diff HEAD
+```
+
+### Step 2: Identify Documentation Needs
+
+- README updates
+- API references
+- Usage guides
+
+### Step 3: Update Docs
+
+Update relevant documentation files:
+- README.md
+- docs/
+- wiki/
+
+### Step 4: Commit
+
+```bash
+git add -A && git commit -m 'docs: update <area> docs (#<number>)'
+```
+
+## Boundaries
+
+- Scope limited to docs
+- Does NOT modify code
+- Returns: Markdown documentation, README updates, API references
+
+## Model
+
+Uses `opencode/minimax-m2.5-free`.

--- a/skills/role-implementer/SKILL.md
+++ b/skills/role-implementer/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: role-implementer
+description: Implementer role — writes code to implement features or fixes
+platform: opencode
+tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Codex_Codex"]
+---
+
+# Implementer Role — OpenCode
+
+Writes and modifies code to implement features or fixes.
+
+## Inputs
+
+- Issue specification from GitHub issue
+- Acceptance criteria
+- Project conventions
+
+## Workflow
+
+### Step 1: Understand Requirements
+
+```bash
+gh issue view <number> --repo <owner>/<repo> --json title,body,labels
+cat ACCEPTANCE_CRITERIA from issue body
+```
+
+### Step 2: Explore Codebase
+
+```bash
+ls -la
+glob "**/*.{ts,js,py,sh}"
+```
+
+### Step 3: Implement
+
+Make code changes according to:
+- Issue specification
+- Acceptance criteria
+- Project conventions (follow existing code style)
+
+### Step 4: Test
+
+```bash
+bash hooks/opencode/test-policy.sh
+bash hooks/opencode/smoke-test.sh
+```
+
+### Step 5: Commit
+
+```bash
+git add -A && git commit -m 'feat: <issue-title> (#<number>)'
+```
+
+### Step 6: Write Result
+
+```bash
+cat > .autoship/workspaces/<issue-key>/AUTOSHIP_RESULT.md << 'EOF'
+# Result: #<number> — <title>
+
+## Status: DONE | PARTIAL | STUCK
+## Changes Made
+- <file>: <what changed>
+## Tests
+- Result: PASS | FAIL
+## Notes
+<notes>
+EOF
+```
+
+Write status to `.autoship/workspaces/<issue-key>/status`:
+- `COMPLETE` — successful
+- `BLOCKED` — external dependency
+- `STUCK` — cannot solve
+
+Print COMPLETE, BLOCKED, or STUCK as final output.
+
+## Boundaries
+
+- Scope limited to the specific issue
+- No cross-cutting changes without approval
+- Returns: Source code changes, commit messages, implementation notes
+
+## Model
+
+Uses `opencode/minimax-m2.5-free` (capable of code generation).

--- a/skills/role-lead/SKILL.md
+++ b/skills/role-lead/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: role-lead
+description: Lead role — coordinates multiple agents and manages orchestration flow
+platform: opencode
+tools: ["Bash", "Read", "Write", "Glob", "Grep", "Task"]
+---
+
+# Lead Role — OpenCode
+
+Coordinates multiple agents and manages orchestration flow.
+
+## Inputs
+
+- Issue queue state from `.autoship/state.json`
+- Agent statuses
+- Project priorities
+
+## Workflow
+
+### Step 1: Check Queue State
+
+```bash
+jq '.issues' .autoship/state.json
+jq '.stats' .autoship/state.json
+```
+
+### Step 2: Load Agent Catalog
+
+```bash
+cat AGENT_CATALOG.md
+```
+
+### Step 3: Dispatch Decisions
+
+Make dispatch decisions based on:
+- Available concurrency (max 15)
+- Issue priority and readiness
+- Agent availability
+
+### Step 4: Execute Dispatch
+
+```bash
+bash hooks/opencode/dispatch.sh <issue-number> <task-type>
+bash hooks/opencode/runner.sh
+```
+
+## Boundaries
+
+- Does NOT implement code directly
+- Delegates to specialized agents
+- Returns: Dispatch decisions, concurrency assignments, escalation triggers
+
+## Model
+
+Uses `openai/gpt-5.5` (orchestration capable).

--- a/skills/role-planner/SKILL.md
+++ b/skills/role-planner/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: role-planner
+description: Planner role — analyzes issues and creates implementation strategies
+platform: opencode
+tools: ["Bash", "Read", "Glob", "Grep", "WebFetch", "WebSearch"]
+---
+
+# Planner Role — OpenCode
+
+Analyzes GitHub issues and creates implementation strategies.
+
+## Inputs
+
+- GitHub issue body and acceptance criteria
+- Project context and conventions
+- Existing code references
+
+## Workflow
+
+### Step 1: Analyze Issue
+
+```bash
+gh issue view <number> --repo <owner>/<repo> --json title,body,labels
+```
+
+Parse acceptance criteria from issue body.
+
+### Step 2: Gather Context
+
+```bash
+cat .autoship/project-context.md 2>/dev/null || echo "No context"
+ls -la
+```
+
+### Step 3: Create Implementation Plan
+
+Write a structured plan covering:
+1. Task breakdown
+2. Priority assessment
+3. Dependencies identified
+
+### Step 4: Output
+
+Write the plan to `.autoship/workspaces/<issue-key>/PLAN.md`
+
+## Boundaries
+
+- Does NOT write implementation code
+- Scope limited to planning
+- Returns: Implementation plan, task breakdown, priority assessment
+
+## Model
+
+Uses `openai/gpt-5.5` (orchestration capable).

--- a/skills/role-release/SKILL.md
+++ b/skills/role-release/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: role-release
+description: Release role — manages releases, PRs, and version updates
+platform: opencode
+tools: ["Bash", "Read", "Write", "Glob"]
+---
+
+# Release Role — OpenCode
+
+Manages releases, PRs, and version updates.
+
+## Inputs
+
+- Committed changes
+- Version files
+- Changelog entries
+
+## Workflow
+
+### Step 1: Verify Committed Changes
+
+```bash
+git log --oneline -5
+git diff main...HEAD --stat
+```
+
+### Step 2: Get PR Title
+
+```bash
+bash hooks/opencode/pr-title.sh --issue <number>
+```
+
+### Step 3: Create PR
+
+```bash
+gh pr create --title "<title>" --body "$(cat <<'EOF'
+## Summary
+- <summary>
+
+## Tests
+- Verified via: <test-command>
+EOF
+)"
+```
+
+### Step 4: Version Bump (if release)
+
+```bash
+cat VERSION
+# Update version according to semver
+# Update CHANGELOG.md
+```
+
+## Boundaries
+
+- Only manages release workflow
+- Does NOT implement code
+- Returns: PR titles, release tags, version bumps
+
+## Model
+
+Uses `openai/gpt-5.5` (orchestration capable).

--- a/skills/role-reviewer/SKILL.md
+++ b/skills/role-reviewer/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: role-reviewer
+description: Reviewer role — reviews code changes for correctness, safety, and quality
+platform: opencode
+tools: ["Bash", "Read", "Glob", "Grep"]
+---
+
+# Reviewer Role — OpenCode
+
+Reviews code changes for correctness, safety, and quality.
+
+## Inputs
+
+- Changed files from git diff
+- Diff output
+- Test results
+
+## Workflow
+
+### Step 1: Inspect Changes
+
+```bash
+git diff --stat
+git diff HEAD
+```
+
+### Step 2: Run Tests
+
+```bash
+bash hooks/opencode/test-policy.sh
+bash hooks/opencode/smoke-test.sh
+```
+
+### Step 3: Review for:
+
+- Correctness: Does it solve the issue?
+- Safety: Any security concerns?
+- Quality: Follows project conventions?
+
+### Step 4: Output Findings
+
+Write review to `.autoship/workspaces/<issue-key>/REVIEW.md`:
+
+```markdown
+# Review: #<number>
+
+## Verdict: APPROVED | REQUEST_CHANGES | BLOCKED
+
+## Findings
+- <finding>
+
+## Suggestions
+- <suggestion>
+```
+
+## Boundaries
+
+- Does NOT implement fixes
+- Only approves or requests changes
+- Returns: Review findings, approval/block decision, improvement suggestions
+
+## Model
+
+Uses `openai/gpt-5.5` (strong reasoning).

--- a/skills/role-simplifier/SKILL.md
+++ b/skills/role-simplifier/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: role-simplifier
+description: Simplifier role — refactors code, simplifies implementations, and identifies improvements
+platform: opencode
+tools: ["Bash", "Read", "Edit", "Glob", "Grep"]
+---
+
+# Simplifier Role — OpenCode
+
+Refactors code, simplifies implementations, and identifies improvements.
+
+## Inputs
+
+- Source code to simplify
+- Review feedback
+- Complexity metrics
+
+## Workflow
+
+### Step 1: Analyze Code
+
+```bash
+glob "**/*.{ts,js,py,sh}"
+wc -l <files>
+```
+
+### Step 2: Identify Opportunities
+
+Find:
+- Redundant code
+- Complex logic that can be simplified
+- Duplicate patterns
+
+### Step 3: Refactor
+
+Preserve behavior while simplifying:
+- Remove dead code
+- Combine duplicate logic
+- Simplify conditionals
+
+### Step 4: Verify
+
+```bash
+bash hooks/opencode/test-policy.sh
+bash hooks/opencode/smoke-test.sh
+```
+
+### Step 5: Commit
+
+```bash
+git add -A && git commit -m 'refactor: simplify <area> (#<number>)'
+```
+
+## Boundaries
+
+- Must preserve behavior
+- Scope limited to simplification
+- Returns: Refactored code, simplification suggestions
+
+## Model
+
+Uses `openai/gpt-5.5` (strong reasoning).

--- a/skills/role-tester/SKILL.md
+++ b/skills/role-tester/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: role-tester
+description: Tester role — verifies implementations through tests and validation
+platform: opencode
+tools: ["Bash", "Read", "Glob", "Grep"]
+---
+
+# Tester Role — OpenCode
+
+Verifies implementations through tests and validation.
+
+## Inputs
+
+- Source code to test
+- Test frameworks available
+- Acceptance criteria
+
+## Workflow
+
+### Step 1: Identify Tests
+
+```bash
+glob "**/*test*.{ts,js,py}"
+glob "**/test/**"
+```
+
+### Step 2: Run Tests
+
+```bash
+bash hooks/opencode/test-policy.sh
+bash hooks/opencode/smoke-test.sh
+npm test 2>/dev/null || pytest 2>/dev/null || echo "No test command"
+```
+
+### Step 3: Verify Acceptance
+
+Check each acceptance criterion is met.
+
+### Step 4: Report Results
+
+Write to `.autoship/workspaces/<issue-key>/TEST_RESULTS.md`:
+
+```markdown
+# Test Results: #<number>
+
+## Status: PASS | FAIL
+
+## Test Command
+\`\`\`bash
+<test-command>
+\`\`\`
+
+## Results
+- <result>
+
+## Coverage
+- <coverage-report>
+```
+
+## Boundaries
+
+- Only executes tests
+- Does NOT write production code
+- Returns: Test results, pass/fail status, coverage reports
+
+## Model
+
+Uses `opencode/minimax-m2.5-free`.


### PR DESCRIPTION
# Result: #174 — Add role prompt and skill assets for specialized agents

## Status: DONE

## Changes Made

- Created 8 role skill files for specialized AutoShip agents:
  - `skills/role-planner/SKILL.md` — Planner role
  - `skills/role-lead/SKILL.md` — Lead role
  - `skills/role-implementer/SKILL.md` — Implementer role
  - `skills/role-reviewer/SKILL.md` — Reviewer role
  - `skills/role-simplifier/SKILL.md` — Simplifier role
  - `skills/role-tester/SKILL.md` — Tester role
  - `skills/role-docs/SKILL.md` — Docs role
  - `skills/role-release/SKILL.md` — Release role

## Skills Created

Each skill includes:
- YAML front matter with name, description, platform, tools
- Role-specific inputs and outputs
- Workflow steps referencing current hooks
- Boundaries and model specification per AGENT_CATALOG.md

## Tests

- Command: `bash hooks/opencode/test-policy.sh`
- Result: PASS

- Command: `bash -n hooks/opencode/*.sh hooks/*.sh`
- Result: PASS

- Command: `bash hooks/opencode/smoke-test.sh`
- Result: PASS

## Notes

- Role prompts are OpenCode-only per acceptance criteria
- References current hooks and state model from AGENTS.md
- Skills follow existing skill format pattern in the codebase

Closes #174