### PR TITLE
feat: route tasks to specialized roles

### DIFF
--- a/hooks/opencode/dispatch.sh
+++ b/hooks/opencode/dispatch.sh
@@ -78,7 +78,21 @@ resolve_model() {
   printf '%s\n' ""
 }
 
+resolve_role() {
+  case "$1" in
+    docs|documentation) printf '%s\n' docs ;;
+    review|code_review) printf '%s\n' reviewer ;;
+    test|tests|ci_fix) printf '%s\n' tester ;;
+    release) printf '%s\n' release ;;
+    simplify|refactor) printf '%s\n' simplifier ;;
+    plan|planning) printf '%s\n' planner ;;
+    lead|orchestration|coordination) printf '%s\n' lead ;;
+    *) printf '%s\n' implementer ;;
+  esac
+}
+
 MODEL=$(resolve_model "$TASK_TYPE" "$ISSUE_NUM" "$MODEL_OVERRIDE")
+ROLE=$(resolve_role "$TASK_TYPE")
 if [[ -z "$MODEL" ]]; then
   mkdir -p "$WORKSPACE_PATH"
   printf 'BLOCKED\n' > "$WORKSPACE_PATH/status"
@@ -101,6 +115,7 @@ mkdir -p "$WORKSPACE_PATH"
 date -u +%Y-%m-%dT%H:%M:%SZ > "$WORKSPACE_PATH/started_at"
 printf 'QUEUED\n' > "$WORKSPACE_PATH/status"
 printf '%s\n' "$MODEL" > "$WORKSPACE_PATH/model"
+printf '%s\n' "$ROLE" > "$WORKSPACE_PATH/role"
 
 cat > "$WORKSPACE_PATH/AUTOSHIP_PROMPT.md" <<EOF
 # AutoShip Agent Prompt
@@ -115,6 +130,9 @@ $TASK_TYPE
 
 ## Selected Model
 $MODEL
+
+## Specialized Role
+$ROLE
 
 ## Body
 $BODY
@@ -132,9 +150,9 @@ Use this conventional PR title when creating a PR:
 $(bash "$SCRIPT_DIR/pr-title.sh" --issue "$ISSUE_NUM" --title "$TITLE" --labels "$LABELS")
 EOF
 
-bash "$REPO_ROOT/hooks/update-state.sh" set-queued "$ISSUE_KEY" agent="$MODEL" task_type="$TASK_TYPE" 2>/dev/null || true
+bash "$REPO_ROOT/hooks/update-state.sh" set-queued "$ISSUE_KEY" agent="$MODEL" model="$MODEL" role="$ROLE" task_type="$TASK_TYPE" 2>/dev/null || true
 
-echo "Queued issue #$ISSUE_NUM for $MODEL ($TASK_TYPE)"
+echo "Queued issue #$ISSUE_NUM for $MODEL ($TASK_TYPE, role=$ROLE)"
 [[ -n "$cap_note" ]] && echo "$cap_note"
 echo "Worktree: $FULL_WORKSPACE_PATH"
 echo "Run: bash hooks/opencode/runner.sh"

--- a/hooks/opencode/runner.sh
+++ b/hooks/opencode/runner.sh
@@ -53,6 +53,7 @@ for dir in "$WORKSPACES_DIR"/*/; do
   status_file="$dir/status"
   prompt_file="$dir/AUTOSHIP_PROMPT.md"
   model_file="$dir/model"
+  role_file="$dir/role"
   [[ -f "$status_file" && -f "$prompt_file" ]] || continue
   status=$(tr -d '[:space:]' < "$status_file")
   [[ "$status" == "QUEUED" ]] || continue
@@ -64,9 +65,11 @@ for dir in "$WORKSPACES_DIR"/*/; do
   fi
 
   model="opencode/nemotron-3-super-free"
+  role="implementer"
   [[ -f "$model_file" ]] && model=$(cat "$model_file")
+  [[ -f "$role_file" ]] && role=$(cat "$role_file")
   echo "RUNNING" > "$status_file"
-  bash "$REPO_ROOT/hooks/update-state.sh" set-running "$(basename "$dir")" agent="$model" 2>/dev/null || true
+  bash "$REPO_ROOT/hooks/update-state.sh" set-running "$(basename "$dir")" agent="$model" model="$model" role="$role" 2>/dev/null || true
 
   if [[ "$DRY_RUN" == "true" ]]; then
     echo "DRY_RUN start $(basename "$dir") with $model"

--- a/hooks/opencode/test-policy.sh
+++ b/hooks/opencode/test-policy.sh
@@ -346,6 +346,52 @@ chmod +x "$UPDATE_REPO/bin/gh" "$UPDATE_REPO/hooks/update-state.sh"
 assert_eq "running" "$(jq -r '.issues["issue-123"].state' "$UPDATE_REPO/.autoship/state.json")" "update-state stores normalized issue key"
 assert_eq "123" "$(head -1 "$UPDATE_REPO/gh-issues.log")" "update-state passes numeric issue to gh"
 
+DISPATCH_REPO="$TMP_DIR/dispatch-repo"
+mkdir -p "$DISPATCH_REPO/.autoship" "$DISPATCH_REPO/hooks/opencode" "$DISPATCH_REPO/hooks" "$DISPATCH_REPO/bin"
+git init -q "$DISPATCH_REPO"
+git -C "$DISPATCH_REPO" config user.email autoship@example.invalid
+git -C "$DISPATCH_REPO" config user.name AutoShip
+git -C "$DISPATCH_REPO" remote add origin git@github.com:owner/repo.git
+printf 'base\n' > "$DISPATCH_REPO/README.md"
+git -C "$DISPATCH_REPO" add README.md
+git -C "$DISPATCH_REPO" commit -q -m initial
+cp "$SCRIPT_DIR/dispatch.sh" "$SCRIPT_DIR/create-worktree.sh" "$SCRIPT_DIR/select-model.sh" "$SCRIPT_DIR/safety-filter.sh" "$SCRIPT_DIR/pr-title.sh" "$DISPATCH_REPO/hooks/opencode/"
+cp "$SCRIPT_DIR/../update-state.sh" "$DISPATCH_REPO/hooks/update-state.sh"
+cat > "$DISPATCH_REPO/.autoship/state.json" <<'JSON'
+{"repo":"owner/repo","issues":{},"stats":{},"config":{"maxConcurrentAgents":15}}
+JSON
+cat > "$DISPATCH_REPO/.autoship/model-routing.json" <<'JSON'
+{"models":[{"id":"free/strong:free","cost":"free","strength":90,"max_task_types":["docs","medium_code"]}]}
+JSON
+cat > "$DISPATCH_REPO/bin/gh" <<'SH'
+#!/usr/bin/env bash
+if [[ "$1 $2" == "issue view" ]]; then
+  case "$4" in
+    title) printf 'Issue title\n' ;;
+    body) printf 'Issue body\n' ;;
+    labels) printf 'agent:ready\n' ;;
+  esac
+  exit 0
+fi
+if [[ "$1 $2" == "label list" ]]; then
+  printf '%s\n' autoship:in-progress autoship:blocked autoship:paused autoship:done
+  exit 0
+fi
+if [[ "$1 $2" == "issue edit" ]]; then
+  exit 0
+fi
+exit 0
+SH
+chmod +x "$DISPATCH_REPO/bin/gh" "$DISPATCH_REPO/hooks/opencode/dispatch.sh" "$DISPATCH_REPO/hooks/opencode/create-worktree.sh" "$DISPATCH_REPO/hooks/opencode/select-model.sh" "$DISPATCH_REPO/hooks/opencode/safety-filter.sh" "$DISPATCH_REPO/hooks/opencode/pr-title.sh" "$DISPATCH_REPO/hooks/update-state.sh"
+(
+  cd "$DISPATCH_REPO"
+  PATH="$DISPATCH_REPO/bin:$PATH" bash hooks/opencode/dispatch.sh 456 docs >/dev/null
+)
+assert_eq "docs" "$(cat "$DISPATCH_REPO/.autoship/workspaces/issue-456/role")" "dispatch records specialized role file"
+assert_eq "docs" "$(jq -r '.issues["issue-456"].role' "$DISPATCH_REPO/.autoship/state.json")" "dispatch records specialized role in state"
+assert_eq "free/strong:free" "$(jq -r '.issues["issue-456"].model' "$DISPATCH_REPO/.autoship/state.json")" "dispatch records selected model in state"
+grep -F '## Specialized Role' "$DISPATCH_REPO/.autoship/workspaces/issue-456/AUTOSHIP_PROMPT.md" >/dev/null || fail "dispatch records specialized role in prompt"
+
 PACKAGE_REPO="$TMP_DIR/package-repo"
 cp -R "$SCRIPT_DIR/../.." "$PACKAGE_REPO"
 (


### PR DESCRIPTION
# AutoShip Issue #175 Result

## Status: COMPLETE

Mapped task types to specialized AutoShip roles and recorded role/model choices in workspace artifacts and state.

## Changes

- `dispatch.sh` maps task types to specialized roles such as docs, reviewer, tester, release, simplifier, planner, lead, and implementer.
- Dispatch writes the chosen role to `.autoship/workspaces/<issue>/role`.
- Dispatch includes `## Specialized Role` in the worker prompt.
- Dispatch and runner record both `role` and `model` in `.autoship/state.json`.
- Policy tests verify role file, prompt, selected model, and state updates.

## Verification

- `bash hooks/opencode/test-policy.sh`
- `bash -n hooks/opencode/*.sh hooks/*.sh`
- `bash hooks/opencode/smoke-test.sh`

Closes #175