### PR TITLE
feat: Capture structured failure artifacts for self-improvement (#176)

### DIFF
--- a/hooks/capture-failure.sh
+++ b/hooks/capture-failure.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# capture-failure.sh — Capture structured failure artifacts for self-improvement
+#
+# Usage:
+#   bash hooks/capture-failure.sh <category> <issue-id> [key=value ...]
+#
+# Categories:
+#   stuck              — Worker exited without terminal status
+#   failed_verification — Verification hook(s) failed
+#   reviewer_rejection  — PR reviewer rejected the work
+#   model_failure     — Model/API returned an error
+#   e2e_failure      — End-to-end test failed
+#
+# Artifacts captured:
+#   - issue: issue number/ID
+#   - model: model used
+#   - workspace: workspace directory path
+#   - hook: relevant hook script
+#   - logs: failure logs
+#   - failure_category: category above
+#   - timestamp: ISO timestamp
+#   - attempt: retry attempt number
+#   - error_summary: brief error message
+
+set -euo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
+  echo "Error: not inside a git repository" >&2
+  exit 1
+}
+cd "$REPO_ROOT"
+
+AUTOSHIP_DIR=".autoship"
+FAILURES_DIR="$AUTOSHIP_DIR/failures"
+STATE_FILE="$AUTOSHIP_DIR/state.json"
+
+CATEGORY="${1:-usage}"
+shift 2>/dev/null || true
+
+case "$CATEGORY" in
+  stuck|failed_verification|reviewer_rejection|model_failure|e2e_failure) ;;
+  *)
+    echo "Usage: $0 <category> <issue-id> [key=value ...]" >&2
+    echo "Categories: stuck, failed_verification, reviewer_rejection, model_failure, e2e_failure" >&2
+    exit 1
+    ;;
+esac
+
+ISSUE_ID="${1:-}"
+if [[ -z "$ISSUE_ID" ]]; then
+  echo "Error: issue-id required" >&2
+  exit 1
+fi
+
+if [[ ! "$ISSUE_ID" =~ ^(issue-)?[0-9]+$ ]]; then
+  echo "Error: invalid ISSUE_ID: $ISSUE_ID" >&2
+  exit 1
+fi
+
+ISSUE_NUMBER=$(echo "$ISSUE_ID" | grep -o '[0-9]*' | head -1)
+ISSUE_ID="issue-${ISSUE_NUMBER}"
+
+mkdir -p "$FAILURES_DIR"
+
+FAILURE_ID="$(date -u +"%Y%m%dT%H%M%SZ")-${ISSUE_ID}"
+FAILURE_FILE="$FAILURES_DIR/${FAILURE_ID}.json"
+
+WORKSPACE_DIR="$AUTOSHIP_DIR/workspaces/${ISSUE_ID}"
+MODEL="unknown"
+ROLE="unknown"
+ATTEMPT=1
+
+if [[ -f "$STATE_FILE" ]]; then
+  MODEL=$(jq -r --arg k "$ISSUE_ID" '.issues[$k].model // "unknown"' "$STATE_FILE" 2>/dev/null || echo "unknown")
+  ROLE=$(jq -r --arg k "$ISSUE_ID" '.issues[$k].agent // "unknown"' "$STATE_FILE" 2>/dev/null || echo "unknown")
+  ATTEMPT=$(jq -r --arg k "$ISSUE_ID" '.issues[$k].attempt // 1' "$STATE_FILE" 2>/dev/null || echo 1)
+fi
+
+if [[ -f "$WORKSPACE_DIR/model" ]]; then
+  MODEL=$(cat "$WORKSPACE_DIR/model" 2>/dev/null || echo "$MODEL")
+fi
+if [[ -f "$WORKSPACE_DIR/role" ]]; then
+  ROLE=$(cat "$WORKSPACE_DIR/role" 2>/dev/null || echo "$ROLE")
+fi
+
+ERROR_SUMMARY=""
+for pair in "$@"; do
+  if [[ "$pair" == error_summary=* ]]; then
+    ERROR_SUMMARY="${pair#*=}"
+    break
+  fi
+done
+
+LOGS=""
+if [[ -f "$WORKSPACE_DIR/AUTOSHIP_RUNNER.log" ]]; then
+  LOGS=$(cat "$WORKSPACE_DIR/AUTOSHIP_RUNNER.log" 2>/dev/null | tail -100 || true)
+fi
+
+HOOK=""
+case "$CATEGORY" in
+  stuck)
+    HOOK="hooks/opencode/runner.sh"
+    ;;
+  failed_verification)
+    HOOK="hooks/opencode/test-policy.sh"
+    ;;
+  reviewer_rejection)
+    HOOK="hooks/opencode/reviewer.sh"
+    ;;
+  model_failure)
+    HOOK="hooks/opencode/select-model.sh"
+    ;;
+  e2e_failure)
+    HOOK="hooks/opencode/smoke-test.sh"
+    ;;
+esac
+
+jq -n \
+  --arg id "$FAILURE_ID" \
+  --arg issue "$ISSUE_ID" \
+  --arg category "$CATEGORY" \
+  --arg model "$MODEL" \
+  --arg role "$ROLE" \
+  --arg workspace "$WORKSPACE_DIR" \
+  --arg hook "$HOOK" \
+  --arg logs "$LOGS" \
+  --arg error "$ERROR_SUMMARY" \
+  --argjson attempt "$ATTEMPT" \
+  --arg now "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+  '{
+    failure_id: $id,
+    issue: $issue,
+    failure_category: $category,
+    model: $model,
+    role: $role,
+    workspace: $workspace,
+    hook: $hook,
+    logs: $logs,
+    error_summary: $error,
+    attempt: $attempt,
+    timestamp: $now
+  }' > "$FAILURE_FILE"
+
+echo "Failure artfact captured: $FAILURE_FILE"

--- a/hooks/capture-failure.sh
+++ b/hooks/capture-failure.sh
@@ -8,8 +8,8 @@
 #   stuck              — Worker exited without terminal status
 #   failed_verification — Verification hook(s) failed
 #   reviewer_rejection  — PR reviewer rejected the work
-#   model_failure     — Model/API returned an error
-#   e2e_failure      — End-to-end test failed
+#   model_failure       — Model/API returned an error
+#   e2e_failure         — End-to-end test failed
 #
 # Artifacts captured:
 #   - issue: issue number/ID
@@ -57,7 +57,7 @@ if [[ ! "$ISSUE_ID" =~ ^(issue-)?[0-9]+$ ]]; then
   exit 1
 fi
 
-ISSUE_NUMBER=$(echo "$ISSUE_ID" | grep -o '[0-9]*' | head -1)
+ISSUE_NUMBER="${ISSUE_ID#issue-}"
 ISSUE_ID="issue-${ISSUE_NUMBER}"
 
 mkdir -p "$FAILURES_DIR"
@@ -66,13 +66,14 @@ FAILURE_ID="$(date -u +"%Y%m%dT%H%M%SZ")-${ISSUE_ID}"
 FAILURE_FILE="$FAILURES_DIR/${FAILURE_ID}.json"
 
 WORKSPACE_DIR="$AUTOSHIP_DIR/workspaces/${ISSUE_ID}"
+WORKSPACE_PATH="$REPO_ROOT/$WORKSPACE_DIR"
 MODEL="unknown"
 ROLE="unknown"
 ATTEMPT=1
 
 if [[ -f "$STATE_FILE" ]]; then
   MODEL=$(jq -r --arg k "$ISSUE_ID" '.issues[$k].model // "unknown"' "$STATE_FILE" 2>/dev/null || echo "unknown")
-  ROLE=$(jq -r --arg k "$ISSUE_ID" '.issues[$k].agent // "unknown"' "$STATE_FILE" 2>/dev/null || echo "unknown")
+  ROLE=$(jq -r --arg k "$ISSUE_ID" '.issues[$k].role // .issues[$k].agent // "unknown"' "$STATE_FILE" 2>/dev/null || echo "unknown")
   ATTEMPT=$(jq -r --arg k "$ISSUE_ID" '.issues[$k].attempt // 1' "$STATE_FILE" 2>/dev/null || echo 1)
 fi
 
@@ -91,27 +92,32 @@ for pair in "$@"; do
   fi
 done
 
-LOGS=""
-if [[ -f "$WORKSPACE_DIR/AUTOSHIP_RUNNER.log" ]]; then
-  LOGS=$(cat "$WORKSPACE_DIR/AUTOSHIP_RUNNER.log" 2>/dev/null | tail -100 || true)
+if [[ ! "$ATTEMPT" =~ ^[0-9]+$ ]]; then
+  ATTEMPT=1
 fi
 
-HOOK=""
+LOG_FILE="${AUTOSHIP_FAILURE_LOG:-$WORKSPACE_DIR/AUTOSHIP_RUNNER.log}"
+LOGS=""
+if [[ -f "$LOG_FILE" ]]; then
+  LOGS=$(tail -100 "$LOG_FILE" 2>/dev/null || true)
+fi
+
+HOOK="${AUTOSHIP_FAILURE_HOOK:-}"
 case "$CATEGORY" in
   stuck)
-    HOOK="hooks/opencode/runner.sh"
+    HOOK="${HOOK:-hooks/opencode/runner.sh}"
     ;;
   failed_verification)
-    HOOK="hooks/opencode/test-policy.sh"
+    HOOK="${HOOK:-hooks/opencode/test-policy.sh}"
     ;;
   reviewer_rejection)
-    HOOK="hooks/opencode/reviewer.sh"
+    HOOK="${HOOK:-hooks/opencode/reviewer.sh}"
     ;;
   model_failure)
-    HOOK="hooks/opencode/select-model.sh"
+    HOOK="${HOOK:-hooks/opencode/runner.sh}"
     ;;
   e2e_failure)
-    HOOK="hooks/opencode/smoke-test.sh"
+    HOOK="${HOOK:-hooks/opencode/smoke-test.sh}"
     ;;
 esac
 
@@ -121,7 +127,7 @@ jq -n \
   --arg category "$CATEGORY" \
   --arg model "$MODEL" \
   --arg role "$ROLE" \
-  --arg workspace "$WORKSPACE_DIR" \
+  --arg workspace "$WORKSPACE_PATH" \
   --arg hook "$HOOK" \
   --arg logs "$LOGS" \
   --arg error "$ERROR_SUMMARY" \
@@ -141,4 +147,4 @@ jq -n \
     timestamp: $now
   }' > "$FAILURE_FILE"
 
-echo "Failure artfact captured: $FAILURE_FILE"
+echo "Failure artifact captured: $FAILURE_FILE"

--- a/hooks/opencode/reviewer.sh
+++ b/hooks/opencode/reviewer.sh
@@ -45,8 +45,8 @@ EOF
   opencode run --model "$MODEL" "$(cat "$PROMPT_FILE")"
 ) || {
   echo "VERDICT: FAIL — reviewer model failed"
-  if [[ -x "$SCRIPT_DIR/../../../capture-failure.sh" ]]; then
-    REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+  REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+  if [[ -x "$REPO_ROOT/hooks/capture-failure.sh" ]]; then
     bash "$REPO_ROOT/hooks/capture-failure.sh" reviewer_rejection "$ISSUE_KEY" "error_summary=reviewer model failed with non-zero exit" 2>/dev/null || true
   fi
   exit 1

--- a/hooks/opencode/reviewer.sh
+++ b/hooks/opencode/reviewer.sh
@@ -43,4 +43,11 @@ EOF
 (
   cd "$WORKTREE_PATH"
   opencode run --model "$MODEL" "$(cat "$PROMPT_FILE")"
-)
+) || {
+  echo "VERDICT: FAIL — reviewer model failed"
+  if [[ -x "$SCRIPT_DIR/../../../capture-failure.sh" ]]; then
+    REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+    bash "$REPO_ROOT/hooks/capture-failure.sh" reviewer_rejection "$ISSUE_KEY" "error_summary=reviewer model failed with non-zero exit" 2>/dev/null || true
+  fi
+  exit 1
+}

--- a/hooks/opencode/runner.sh
+++ b/hooks/opencode/runner.sh
@@ -39,11 +39,19 @@ run_worker() {
 }
 
 mark_stuck_unless_terminal() {
+  local wid="$1"
+  local repo_root="$2"
   local current=""
   [[ -f status ]] && current=$(tr -d '[:space:]' < status)
   case "$current" in
     COMPLETE|BLOCKED|STUCK) ;;
-    *) echo "STUCK" > status ;;
+    *)
+      echo "STUCK" > status
+      if [[ -x "$repo_root/hooks/capture-failure.sh" ]]; then
+        error_msg=$(tail -5 AUTOSHIP_RUNNER.log 2>/dev/null || echo "worker exited without terminal status")
+        bash "$repo_root/hooks/capture-failure.sh" stuck "$wid" "error_summary=$error_msg" 2>/dev/null || true
+      fi
+      ;;
   esac
 }
 
@@ -68,6 +76,7 @@ for dir in "$WORKSPACES_DIR"/*/; do
   role="implementer"
   [[ -f "$model_file" ]] && model=$(cat "$model_file")
   [[ -f "$role_file" ]] && role=$(cat "$role_file")
+  issue_id="$(basename "$dir")"
   echo "RUNNING" > "$status_file"
   bash "$REPO_ROOT/hooks/update-state.sh" set-running "$(basename "$dir")" agent="$model" model="$model" role="$role" 2>/dev/null || true
 
@@ -78,13 +87,20 @@ for dir in "$WORKSPACES_DIR"/*/; do
       cd "$dir"
       if command -v opencode >/dev/null 2>&1; then
         if run_worker "$model" > AUTOSHIP_RUNNER.log 2>&1; then
-          mark_stuck_unless_terminal
+          mark_stuck_unless_terminal "$issue_id" "$REPO_ROOT"
         else
           echo "STUCK" > status
+          if [[ -x "$REPO_ROOT/hooks/capture-failure.sh" ]]; then
+            error_msg=$(tail -5 AUTOSHIP_RUNNER.log 2>/dev/null || echo "worker run failed")
+            bash "$REPO_ROOT/hooks/capture-failure.sh" model_failure "$issue_id" "error_summary=$error_msg" 2>/dev/null || true
+          fi
         fi
       else
         echo "opencode CLI not found" > AUTOSHIP_RUNNER.log
         echo "STUCK" > status
+        if [[ -x "$REPO_ROOT/hooks/capture-failure.sh" ]]; then
+          bash "$REPO_ROOT/hooks/capture-failure.sh" model_failure "$issue_id" "error_summary=opencode CLI not found" 2>/dev/null || true
+        fi
       fi
     ) &
     echo "Started $(basename "$dir") with $model"

--- a/hooks/opencode/smoke-test.sh
+++ b/hooks/opencode/smoke-test.sh
@@ -6,6 +6,14 @@ REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
   exit 1
 }
 
+capture_e2e_failure() {
+  local status="$1"
+  if [[ $status -ne 0 && -n "${AUTOSHIP_FAILURE_ISSUE:-${AUTOSHIP_ISSUE_ID:-}}" && -x "$REPO_ROOT/hooks/capture-failure.sh" ]]; then
+    AUTOSHIP_FAILURE_HOOK="hooks/opencode/smoke-test.sh" \
+      bash "$REPO_ROOT/hooks/capture-failure.sh" e2e_failure "${AUTOSHIP_FAILURE_ISSUE:-${AUTOSHIP_ISSUE_ID:-}}" "error_summary=smoke test failed with exit $status" 2>/dev/null || true
+  fi
+}
+
 CONFIG_HOME="$(mktemp -d)"
 AUTOSHIP_BACKUP=""
 if [[ -d "$REPO_ROOT/.autoship" ]]; then
@@ -14,7 +22,7 @@ if [[ -d "$REPO_ROOT/.autoship" ]]; then
   rm -rf "$REPO_ROOT/.autoship"
 fi
 
-trap 'rm -rf "$CONFIG_HOME"; if [[ -n "$AUTOSHIP_BACKUP" && -d "$AUTOSHIP_BACKUP/.autoship" ]]; then rm -rf "$REPO_ROOT/.autoship"; cp -R "$AUTOSHIP_BACKUP/.autoship" "$REPO_ROOT/"; fi; rm -rf "$AUTOSHIP_BACKUP"' EXIT
+trap 'status=$?; capture_e2e_failure "$status"; rm -rf "$CONFIG_HOME"; if [[ -n "$AUTOSHIP_BACKUP" && -d "$AUTOSHIP_BACKUP/.autoship" ]]; then rm -rf "$REPO_ROOT/.autoship"; cp -R "$AUTOSHIP_BACKUP/.autoship" "$REPO_ROOT/"; fi; rm -rf "$AUTOSHIP_BACKUP"; exit $status' EXIT
 
 export XDG_CONFIG_HOME="$CONFIG_HOME"
 BIN_DIR="$CONFIG_HOME/bin"

--- a/hooks/opencode/test-policy.sh
+++ b/hooks/opencode/test-policy.sh
@@ -7,6 +7,10 @@ trap 'rm -rf "$TMP_DIR"' EXIT
 
 fail() {
   printf 'FAIL: %s\n' "$1" >&2
+  if [[ -n "${AUTOSHIP_FAILURE_ISSUE:-${AUTOSHIP_ISSUE_ID:-}}" && -x "$SCRIPT_DIR/../capture-failure.sh" ]]; then
+    AUTOSHIP_FAILURE_HOOK="hooks/opencode/test-policy.sh" \
+      bash "$SCRIPT_DIR/../capture-failure.sh" failed_verification "${AUTOSHIP_FAILURE_ISSUE:-${AUTOSHIP_ISSUE_ID:-}}" "error_summary=$1" 2>/dev/null || true
+  fi
   exit 1
 }
 
@@ -107,9 +111,10 @@ mkdir -p "$RUNNER_REPO/.autoship/workspaces/issue-996" "$RUNNER_REPO/hooks/openc
 git init -q "$RUNNER_REPO"
 cp "$SCRIPT_DIR/runner.sh" "$RUNNER_REPO/hooks/opencode/runner.sh"
 cp "$SCRIPT_DIR/../update-state.sh" "$RUNNER_REPO/hooks/update-state.sh"
-chmod +x "$RUNNER_REPO/hooks/opencode/runner.sh" "$RUNNER_REPO/hooks/update-state.sh"
+cp "$SCRIPT_DIR/../capture-failure.sh" "$RUNNER_REPO/hooks/capture-failure.sh"
+chmod +x "$RUNNER_REPO/hooks/opencode/runner.sh" "$RUNNER_REPO/hooks/update-state.sh" "$RUNNER_REPO/hooks/capture-failure.sh"
 cat > "$RUNNER_REPO/.autoship/state.json" <<'JSON'
-{"repo":"owner/repo","issues":{"issue-996":{"state":"queued"}},"stats":{},"config":{"maxConcurrentAgents":15}}
+{"repo":"owner/repo","issues":{"issue-996":{"state":"queued","model":"opencode/test-free","role":"implementer","attempt":2}},"stats":{},"config":{"maxConcurrentAgents":15}}
 JSON
 printf 'QUEUED\n' > "$RUNNER_REPO/.autoship/workspaces/issue-996/status"
 printf 'test prompt\n' > "$RUNNER_REPO/.autoship/workspaces/issue-996/AUTOSHIP_PROMPT.md"
@@ -136,6 +141,10 @@ assert_eq "STUCK" "$(tr -d '[:space:]' < "$RUNNER_REPO/.autoship/workspaces/issu
 if grep -F 'ENV_LEAK' "$RUNNER_REPO/.autoship/workspaces/issue-996/AUTOSHIP_RUNNER.log" >/dev/null 2>&1; then
   fail "runner must unset parent OpenCode session environment before nested opencode run"
 fi
+artifact_count=$(find "$RUNNER_REPO/.autoship/failures" -name '*-issue-996.json' 2>/dev/null | wc -l | tr -d '[:space:]')
+assert_eq "1" "$artifact_count" "runner captures a stuck worker failure artifact"
+artifact_file=$(find "$RUNNER_REPO/.autoship/failures" -name '*-issue-996.json' | head -1)
+jq -e '.issue == "issue-996" and .model == "opencode/test-free" and .role == "implementer" and .workspace != "" and .hook == "hooks/opencode/runner.sh" and .failure_category == "stuck" and (.logs | contains("ok")) and .attempt == 2' "$artifact_file" >/dev/null || fail "failure artifact includes issue, model, workspace, hook, logs, category, role, and attempt"
 
 grep -F 'AUTOSHIP_VERSION="1.5.0-opencode"' "$SCRIPT_DIR/init.sh" >/dev/null 2>&1 && fail "init must not hardcode stale 1.5.0-opencode version"
 


### PR DESCRIPTION
## Summary
- Add structured failure artifact capture for stuck workers, verification failures, reviewer failures, model failures, and E2E failures.
- Include issue, model, role, workspace, hook, logs, category, attempt, timestamp, and error summary in `.autoship/failures/*.json`.
- Wire capture into runner, reviewer, test policy, and smoke-test failure paths with regression coverage.

## Verification
- `bash hooks/opencode/test-policy.sh`
- `bash -n hooks/opencode/*.sh hooks/*.sh`
- `bash hooks/opencode/smoke-test.sh`