### PR TITLE
fix: Clean AutoShip worktrees before deleting merged branches (#210)

### DIFF
--- a/hooks/opencode/cleanup-worktree.sh
+++ b/hooks/opencode/cleanup-worktree.sh
@@ -12,7 +12,7 @@ REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "$REPO_ROOT"
 
 # Validate issue key format
-if [[ ! "$ISSUE_KEY" =~ ^issue-[0-9]+ ]]; then
+if [[ ! "$ISSUE_KEY" =~ ^issue-[0-9]+$ ]]; then
   echo "Error: Invalid issue key format: $ISSUE_KEY"
   exit 1
 fi
@@ -29,14 +29,15 @@ fi
 
 # Remove worktree
 if [[ -d "$WORKSPACE_DIR" ]]; then
+  git worktree prune >/dev/null 2>&1 || true
   git worktree remove "$WORKSPACE_DIR" --force 2>/dev/null || true
   echo "Removed worktree: $WORKSPACE_DIR"
 fi
 
 # Delete branch
 BRANCH="autoship/$ISSUE_KEY"
-if git branch --list "$BRANCH" >/dev/null 2>&1; then
-  git branch -D "$BRANCH" 2>/dev/null || true
+if [[ -n "$(git branch --list "$BRANCH")" ]]; then
+  git branch -D "$BRANCH"
   echo "Deleted branch: $BRANCH"
 fi
 

--- a/hooks/opencode/merge-pr.sh
+++ b/hooks/opencode/merge-pr.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PR_NUMBER="${1:-}"
+ISSUE_KEY="${2:-}"
+
+if [[ -z "$PR_NUMBER" || -z "$ISSUE_KEY" ]]; then
+  echo "Usage: $0 <pr-number> <issue-key>" >&2
+  exit 1
+fi
+
+if [[ ! "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+  echo "Error: invalid PR number: $PR_NUMBER" >&2
+  exit 1
+fi
+
+if [[ ! "$ISSUE_KEY" =~ ^issue-[0-9]+$ ]]; then
+  echo "Error: invalid issue key: $ISSUE_KEY" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Do not pass --delete-branch here: gh attempts local branch deletion before
+# AutoShip removes the issue worktree, which fails while that branch is checked out.
+gh pr merge "$PR_NUMBER" --squash
+bash "$SCRIPT_DIR/cleanup-worktree.sh" "$ISSUE_KEY"

--- a/hooks/opencode/test-policy.sh
+++ b/hooks/opencode/test-policy.sh
@@ -183,6 +183,42 @@ printf 'stale\n' > "$WORKTREE_REPO/.autoship/workspaces/issue-156/AUTOSHIP_RESUL
 test -d "$WORKTREE_REPO/.autoship/workspaces/issue-156/.git" || test -f "$WORKTREE_REPO/.autoship/workspaces/issue-156/.git" || fail "create-worktree replaces stale existing workspace directory"
 test ! -e "$WORKTREE_REPO/.autoship/workspaces/issue-156/AUTOSHIP_RESULT.md" || fail "create-worktree clears stale AutoShip artifacts after recovery"
 
+MERGE_REPO="$TMP_DIR/merge-repo"
+mkdir -p "$MERGE_REPO/bin"
+git init -q "$MERGE_REPO"
+git -C "$MERGE_REPO" config user.email autoship@example.invalid
+git -C "$MERGE_REPO" config user.name AutoShip
+printf 'base\n' > "$MERGE_REPO/README.md"
+git -C "$MERGE_REPO" add README.md
+git -C "$MERGE_REPO" commit -q -m initial
+mkdir -p "$MERGE_REPO/hooks/opencode" "$MERGE_REPO/.autoship/workspaces"
+cp "$SCRIPT_DIR/cleanup-worktree.sh" "$MERGE_REPO/hooks/opencode/cleanup-worktree.sh"
+cp "$SCRIPT_DIR/merge-pr.sh" "$MERGE_REPO/hooks/opencode/merge-pr.sh"
+chmod +x "$MERGE_REPO/hooks/opencode/cleanup-worktree.sh" "$MERGE_REPO/hooks/opencode/merge-pr.sh"
+cat > "$MERGE_REPO/.autoship/state.json" <<'JSON'
+{"repo":"owner/repo","issues":{"issue-210":{"state":"completed"}},"stats":{},"config":{"maxConcurrentAgents":15}}
+JSON
+git -C "$MERGE_REPO" branch autoship/issue-210
+git -C "$MERGE_REPO" worktree add -q "$MERGE_REPO/.autoship/workspaces/issue-210" autoship/issue-210
+printf 'result\n' > "$MERGE_REPO/.autoship/workspaces/issue-210/AUTOSHIP_RESULT.md"
+cat > "$MERGE_REPO/bin/gh" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GH_ARGS_LOG"
+exit 0
+SH
+chmod +x "$MERGE_REPO/bin/gh"
+(
+  cd "$MERGE_REPO"
+  GH_ARGS_LOG="$MERGE_REPO/gh-args.log" PATH="$MERGE_REPO/bin:$PATH" bash hooks/opencode/merge-pr.sh 210 issue-210 >/dev/null
+)
+test ! -d "$MERGE_REPO/.autoship/workspaces/issue-210" || fail "merge cleanup removes issue worktree before branch deletion"
+if git -C "$MERGE_REPO" show-ref --verify --quiet refs/heads/autoship/issue-210; then
+  fail "merge cleanup deletes the local issue branch"
+fi
+if grep -F -- '--delete-branch' "$MERGE_REPO/gh-args.log" >/dev/null 2>&1; then
+  fail "merge cleanup must not ask gh to delete a branch that is checked out by an issue worktree"
+fi
+
 SETUP_REPO="$TMP_DIR/setup-repo"
 mkdir -p "$SETUP_REPO/bin"
 cp -R "$SCRIPT_DIR/../.." "$SETUP_REPO/autoship"


### PR DESCRIPTION
## Summary
- Add `hooks/opencode/merge-pr.sh` to merge PRs without asking `gh` to delete a checked-out issue branch.
- Run AutoShip cleanup after merge so the issue worktree is removed before local branch deletion.
- Harden cleanup branch matching/deletion and add regression coverage for the merge cleanup sequence.

## Verification
- `bash hooks/opencode/test-policy.sh`
- `bash -n hooks/opencode/*.sh hooks/*.sh`
- `bash hooks/opencode/smoke-test.sh`

Closes #210