### PR TITLE
fix: Detect exited workers that leave RUNNING status (#209)

### DIFF
--- a/hooks/opencode/monitor-agents.sh
+++ b/hooks/opencode/monitor-agents.sh
@@ -24,14 +24,22 @@ emit_event() {
     --arg issue "$issue" \
     --arg status "$status" \
     --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-    '{type: $type, issue: $issue, priority: 2, data: {status: $status}, queued_at: $ts}')
+      '{type: $type, issue: $issue, priority: 2, data: {status: $status}, queued_at: $ts}')
 
-  (
-    flock -x 200 || exit 1
+  write_event() {
     jq --argjson evt "$event" '. + [$evt]' "$EVENT_QUEUE" > "${EVENT_QUEUE}.tmp" 2>/dev/null
     mv "${EVENT_QUEUE}.tmp" "$EVENT_QUEUE" 2>/dev/null || true
     touch "$marker" 2>/dev/null || true
-  ) 200>"$LOCK_FILE"
+  }
+
+  if command -v flock >/dev/null 2>&1; then
+    (
+      flock -x 200 || exit 1
+      write_event
+    ) 200>"$LOCK_FILE"
+  else
+    write_event
+  fi
 }
 
 check_stalled() {
@@ -59,6 +67,40 @@ check_stalled() {
   fi
 }
 
+is_worker_live() {
+  local pid_file="$1/worker.pid"
+  [[ -s "$pid_file" ]] || return 0
+  local pid
+  pid=$(tr -d '[:space:]' < "$pid_file")
+  [[ "$pid" =~ ^[0-9]+$ ]] || return 1
+  kill -0 "$pid" 2>/dev/null
+}
+
+has_fresh_result() {
+  local dir="$1"
+  local result_file="$dir/AUTOSHIP_RESULT.md"
+  local started_file="$dir/started_at"
+  [[ -s "$result_file" ]] || return 1
+  [[ ! -f "$started_file" || "$result_file" -nt "$started_file" ]]
+}
+
+reconcile_exited_worker() {
+  local dir="$1"
+  local key
+  key=$(basename "$dir")
+  local status_file="$dir/status"
+
+  is_worker_live "$dir" && return 0
+
+  if has_fresh_result "$dir"; then
+    echo "COMPLETE" > "$status_file"
+    emit_event "verify" "$key" "COMPLETE"
+  else
+    echo "STUCK" > "$status_file"
+    emit_event "stuck" "$key" "STUCK"
+  fi
+}
+
 for dir in "$WORKSPACES_DIR"/*/; do
   [[ -d "$dir" ]] || continue
   key=$(basename "$dir")
@@ -79,6 +121,7 @@ for dir in "$WORKSPACES_DIR"/*/; do
       emit_event "stuck" "$key" "STUCK"
       ;;
     RUNNING)
+      reconcile_exited_worker "$dir"
       check_stalled "$dir"
       ;;
   esac

--- a/hooks/opencode/runner.sh
+++ b/hooks/opencode/runner.sh
@@ -103,6 +103,7 @@ for dir in "$WORKSPACES_DIR"/*/; do
         fi
       fi
     ) &
+    printf '%s\n' "$!" > "$dir/worker.pid"
     echo "Started $(basename "$dir") with $model"
   fi
   started=$((started + 1))

--- a/hooks/opencode/test-policy.sh
+++ b/hooks/opencode/test-policy.sh
@@ -145,6 +145,55 @@ artifact_count=$(find "$RUNNER_REPO/.autoship/failures" -name '*-issue-996.json'
 assert_eq "1" "$artifact_count" "runner captures a stuck worker failure artifact"
 artifact_file=$(find "$RUNNER_REPO/.autoship/failures" -name '*-issue-996.json' | head -1)
 jq -e '.issue == "issue-996" and .model == "opencode/test-free" and .role == "implementer" and .workspace != "" and .hook == "hooks/opencode/runner.sh" and .failure_category == "stuck" and (.logs | contains("ok")) and .attempt == 2' "$artifact_file" >/dev/null || fail "failure artifact includes issue, model, workspace, hook, logs, category, role, and attempt"
+test -s "$RUNNER_REPO/.autoship/workspaces/issue-996/worker.pid" || fail "runner records worker pid for lifecycle monitoring"
+
+MONITOR_REPO="$TMP_DIR/monitor-repo"
+mkdir -p "$MONITOR_REPO/.autoship/workspaces/issue-997" "$MONITOR_REPO/hooks/opencode" "$MONITOR_REPO/hooks"
+git init -q "$MONITOR_REPO"
+cp "$SCRIPT_DIR/monitor-agents.sh" "$MONITOR_REPO/hooks/opencode/monitor-agents.sh"
+cp "$SCRIPT_DIR/reconcile-state.sh" "$MONITOR_REPO/hooks/opencode/reconcile-state.sh"
+cp "$SCRIPT_DIR/../update-state.sh" "$MONITOR_REPO/hooks/update-state.sh"
+chmod +x "$MONITOR_REPO/hooks/opencode/monitor-agents.sh" "$MONITOR_REPO/hooks/opencode/reconcile-state.sh" "$MONITOR_REPO/hooks/update-state.sh"
+cat > "$MONITOR_REPO/.autoship/state.json" <<'JSON'
+{"repo":"owner/repo","issues":{"issue-997":{"state":"running"}},"stats":{},"config":{"maxConcurrentAgents":15}}
+JSON
+printf '[]\n' > "$MONITOR_REPO/.autoship/event-queue.json"
+printf 'RUNNING\n' > "$MONITOR_REPO/.autoship/workspaces/issue-997/status"
+printf '999999\n' > "$MONITOR_REPO/.autoship/workspaces/issue-997/worker.pid"
+(
+  cd "$MONITOR_REPO"
+  bash hooks/opencode/monitor-agents.sh >/dev/null
+)
+assert_eq "STUCK" "$(tr -d '[:space:]' < "$MONITOR_REPO/.autoship/workspaces/issue-997/status")" "monitor marks RUNNING workspace stuck when worker pid is no longer live"
+assert_eq "stuck" "$(jq -r '.issues["issue-997"].state' "$MONITOR_REPO/.autoship/state.json")" "monitor reconciles stale RUNNING workspace state"
+
+MONITOR_COMPLETE_REPO="$TMP_DIR/monitor-complete-repo"
+mkdir -p "$MONITOR_COMPLETE_REPO/.autoship/workspaces/issue-998" "$MONITOR_COMPLETE_REPO/hooks/opencode" "$MONITOR_COMPLETE_REPO/hooks"
+git init -q "$MONITOR_COMPLETE_REPO"
+git -C "$MONITOR_COMPLETE_REPO" config user.email autoship@example.invalid
+git -C "$MONITOR_COMPLETE_REPO" config user.name AutoShip
+printf 'base\n' > "$MONITOR_COMPLETE_REPO/README.md"
+git -C "$MONITOR_COMPLETE_REPO" add README.md
+git -C "$MONITOR_COMPLETE_REPO" commit -q -m initial
+cp "$SCRIPT_DIR/monitor-agents.sh" "$MONITOR_COMPLETE_REPO/hooks/opencode/monitor-agents.sh"
+cp "$SCRIPT_DIR/reconcile-state.sh" "$MONITOR_COMPLETE_REPO/hooks/opencode/reconcile-state.sh"
+cp "$SCRIPT_DIR/../update-state.sh" "$MONITOR_COMPLETE_REPO/hooks/update-state.sh"
+chmod +x "$MONITOR_COMPLETE_REPO/hooks/opencode/monitor-agents.sh" "$MONITOR_COMPLETE_REPO/hooks/opencode/reconcile-state.sh" "$MONITOR_COMPLETE_REPO/hooks/update-state.sh"
+cat > "$MONITOR_COMPLETE_REPO/.autoship/state.json" <<'JSON'
+{"repo":"owner/repo","issues":{"issue-998":{"state":"running"}},"stats":{},"config":{"maxConcurrentAgents":15}}
+JSON
+printf '[]\n' > "$MONITOR_COMPLETE_REPO/.autoship/event-queue.json"
+printf 'RUNNING\n' > "$MONITOR_COMPLETE_REPO/.autoship/workspaces/issue-998/status"
+printf '999999\n' > "$MONITOR_COMPLETE_REPO/.autoship/workspaces/issue-998/worker.pid"
+printf '2026-04-24T00:00:00Z\n' > "$MONITOR_COMPLETE_REPO/.autoship/workspaces/issue-998/started_at"
+printf 'result\n' > "$MONITOR_COMPLETE_REPO/.autoship/workspaces/issue-998/AUTOSHIP_RESULT.md"
+touch -t 202604240001 "$MONITOR_COMPLETE_REPO/.autoship/workspaces/issue-998/AUTOSHIP_RESULT.md"
+touch -t 202604240000 "$MONITOR_COMPLETE_REPO/.autoship/workspaces/issue-998/started_at"
+(
+  cd "$MONITOR_COMPLETE_REPO"
+  bash hooks/opencode/monitor-agents.sh >/dev/null
+)
+assert_eq "COMPLETE" "$(tr -d '[:space:]' < "$MONITOR_COMPLETE_REPO/.autoship/workspaces/issue-998/status")" "monitor marks dead worker complete when fresh result artifact exists"
 
 grep -F 'AUTOSHIP_VERSION="1.5.0-opencode"' "$SCRIPT_DIR/init.sh" >/dev/null 2>&1 && fail "init must not hardcode stale 1.5.0-opencode version"
 


### PR DESCRIPTION
## Summary
- Record background worker PIDs in each workspace for monitor reconciliation.
- Mark dead RUNNING workers COMPLETE when a fresh result artifact exists, or STUCK otherwise.
- Keep event writes portable when `flock` is unavailable.

## Verification
- `bash hooks/opencode/test-policy.sh`
- `bash -n hooks/opencode/*.sh hooks/*.sh`
- `bash hooks/opencode/smoke-test.sh`

Closes #209