### PR TITLE
fix: Fallback on paid model balance errors (#208)

### DIFF
--- a/hooks/opencode/runner.sh
+++ b/hooks/opencode/runner.sh
@@ -38,6 +38,49 @@ run_worker() {
     opencode run --model "$model" "$(cat AUTOSHIP_PROMPT.md)"
 }
 
+is_billing_or_quota_failure() {
+  local log_file="${1:-AUTOSHIP_RUNNER.log}"
+  [[ -f "$log_file" ]] || return 1
+  grep -Eiq 'insufficient balance|billing|quota|rate limit|credit' "$log_file"
+}
+
+record_model_failure() {
+  local model="$1"
+  local log_file="${2:-AUTOSHIP_RUNNER.log}"
+  local history_file="$REPO_ROOT/$AUTOSHIP_DIR/model-history.json"
+  local tmp
+  tmp=$(mktemp)
+  local summary
+  summary=$(tail -5 "$log_file" 2>/dev/null || true)
+  [[ -f "$history_file" ]] || printf '{}\n' > "$history_file"
+  jq --arg model "$model" --arg summary "$summary" --arg now "$(date -u +%Y-%m-%dT%H:%M:%SZ)" '
+    .[$model] = ((.[$model] // {}) + {
+      fail: (((.[$model].fail // 0) | tonumber) + 1),
+      last_error: $summary,
+      last_failed_at: $now
+    })
+  ' "$history_file" > "$tmp" && mv "$tmp" "$history_file"
+}
+
+select_free_fallback_model() {
+  local failed_model="$1"
+  local routing_file="$REPO_ROOT/$AUTOSHIP_DIR/model-routing.json"
+  local task_type="medium_code"
+  if [[ -f "$REPO_ROOT/$STATE_FILE" ]]; then
+    task_type=$(jq -r --arg key "$issue_id" '.issues[$key].task_type // "medium_code"' "$REPO_ROOT/$STATE_FILE" 2>/dev/null || echo "medium_code")
+  fi
+  [[ -f "$routing_file" ]] || return 1
+  jq -r --arg failed "$failed_model" --arg task "$task_type" '
+    [(.models // [])[] |
+      select((.enabled // true) == true) |
+      select(.cost == "free") |
+      select(.id != $failed) |
+      select(((.max_task_types // []) | length == 0) or ((.max_task_types // []) | index($task) != null))]
+    | sort_by(-(.strength // 0), .id)
+    | .[0].id // empty
+  ' "$routing_file"
+}
+
 mark_stuck_unless_terminal() {
   local wid="$1"
   local repo_root="$2"
@@ -89,10 +132,34 @@ for dir in "$WORKSPACES_DIR"/*/; do
         if run_worker "$model" > AUTOSHIP_RUNNER.log 2>&1; then
           mark_stuck_unless_terminal "$issue_id" "$REPO_ROOT"
         else
-          echo "STUCK" > status
-          if [[ -x "$REPO_ROOT/hooks/capture-failure.sh" ]]; then
-            error_msg=$(tail -5 AUTOSHIP_RUNNER.log 2>/dev/null || echo "worker run failed")
-            bash "$REPO_ROOT/hooks/capture-failure.sh" model_failure "$issue_id" "error_summary=$error_msg" 2>/dev/null || true
+          if is_billing_or_quota_failure AUTOSHIP_RUNNER.log; then
+            record_model_failure "$model" AUTOSHIP_RUNNER.log
+            fallback_model=$(select_free_fallback_model "$model" || true)
+            if [[ -n "$fallback_model" ]]; then
+              printf '%s\n' "$fallback_model" > model
+              bash "$REPO_ROOT/hooks/update-state.sh" set-running "$issue_id" agent="$fallback_model" model="$fallback_model" role="$role" 2>/dev/null || true
+              if run_worker "$fallback_model" >> AUTOSHIP_RUNNER.log 2>&1; then
+                mark_stuck_unless_terminal "$issue_id" "$REPO_ROOT"
+              else
+                echo "STUCK" > status
+                if [[ -x "$REPO_ROOT/hooks/capture-failure.sh" ]]; then
+                  error_msg=$(tail -5 AUTOSHIP_RUNNER.log 2>/dev/null || echo "fallback worker run failed")
+                  bash "$REPO_ROOT/hooks/capture-failure.sh" model_failure "$issue_id" "error_summary=$error_msg" 2>/dev/null || true
+                fi
+              fi
+            else
+              echo "STUCK" > status
+              if [[ -x "$REPO_ROOT/hooks/capture-failure.sh" ]]; then
+                error_msg=$(tail -5 AUTOSHIP_RUNNER.log 2>/dev/null || echo "worker run failed")
+                bash "$REPO_ROOT/hooks/capture-failure.sh" model_failure "$issue_id" "error_summary=$error_msg" 2>/dev/null || true
+              fi
+            fi
+          else
+            echo "STUCK" > status
+            if [[ -x "$REPO_ROOT/hooks/capture-failure.sh" ]]; then
+              error_msg=$(tail -5 AUTOSHIP_RUNNER.log 2>/dev/null || echo "worker run failed")
+              bash "$REPO_ROOT/hooks/capture-failure.sh" model_failure "$issue_id" "error_summary=$error_msg" 2>/dev/null || true
+            fi
           fi
         fi
       else

--- a/hooks/opencode/test-policy.sh
+++ b/hooks/opencode/test-policy.sh
@@ -147,6 +147,52 @@ artifact_file=$(find "$RUNNER_REPO/.autoship/failures" -name '*-issue-996.json' 
 jq -e '.issue == "issue-996" and .model == "opencode/test-free" and .role == "implementer" and .workspace != "" and .hook == "hooks/opencode/runner.sh" and .failure_category == "stuck" and (.logs | contains("ok")) and .attempt == 2' "$artifact_file" >/dev/null || fail "failure artifact includes issue, model, workspace, hook, logs, category, role, and attempt"
 test -s "$RUNNER_REPO/.autoship/workspaces/issue-996/worker.pid" || fail "runner records worker pid for lifecycle monitoring"
 
+FALLBACK_REPO="$TMP_DIR/fallback-runner-repo"
+mkdir -p "$FALLBACK_REPO/.autoship/workspaces/issue-208" "$FALLBACK_REPO/hooks/opencode" "$FALLBACK_REPO/hooks" "$FALLBACK_REPO/bin"
+git init -q "$FALLBACK_REPO"
+cp "$SCRIPT_DIR/runner.sh" "$FALLBACK_REPO/hooks/opencode/runner.sh"
+cp "$SCRIPT_DIR/../update-state.sh" "$FALLBACK_REPO/hooks/update-state.sh"
+cp "$SCRIPT_DIR/../capture-failure.sh" "$FALLBACK_REPO/hooks/capture-failure.sh"
+chmod +x "$FALLBACK_REPO/hooks/opencode/runner.sh" "$FALLBACK_REPO/hooks/update-state.sh" "$FALLBACK_REPO/hooks/capture-failure.sh"
+cat > "$FALLBACK_REPO/.autoship/state.json" <<'JSON'
+{"repo":"owner/repo","issues":{"issue-208":{"state":"queued","model":"opencode/paid-model","role":"implementer","attempt":1,"task_type":"medium_code"}},"stats":{},"config":{"maxConcurrentAgents":15}}
+JSON
+cat > "$FALLBACK_REPO/.autoship/model-routing.json" <<'JSON'
+{"models":[{"id":"opencode/paid-model","cost":"selected","strength":100,"max_task_types":["medium_code"]},{"id":"opencode/free-fallback","cost":"free","strength":80,"max_task_types":["medium_code"]}]}
+JSON
+printf 'QUEUED\n' > "$FALLBACK_REPO/.autoship/workspaces/issue-208/status"
+printf 'test prompt\n' > "$FALLBACK_REPO/.autoship/workspaces/issue-208/AUTOSHIP_PROMPT.md"
+printf 'opencode/paid-model\n' > "$FALLBACK_REPO/.autoship/workspaces/issue-208/model"
+cat > "$FALLBACK_REPO/bin/opencode" <<'SH'
+#!/usr/bin/env bash
+model=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --model) model="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+if [[ "$model" == "opencode/paid-model" ]]; then
+  printf 'Error: Insufficient balance. Manage your billing here\n' >&2
+  exit 1
+fi
+printf 'COMPLETE\n' > status
+printf 'fallback succeeded\n' > AUTOSHIP_RESULT.md
+exit 0
+SH
+chmod +x "$FALLBACK_REPO/bin/opencode"
+(
+  cd "$FALLBACK_REPO"
+  PATH="$FALLBACK_REPO/bin:$PATH" bash hooks/opencode/runner.sh >/dev/null
+)
+for _ in 1 2 3 4 5; do
+  [[ "$(tr -d '[:space:]' < "$FALLBACK_REPO/.autoship/workspaces/issue-208/status")" != "RUNNING" ]] && break
+  sleep 1
+done
+assert_eq "COMPLETE" "$(tr -d '[:space:]' < "$FALLBACK_REPO/.autoship/workspaces/issue-208/status")" "runner retries billing failures with a free fallback model"
+assert_eq "opencode/free-fallback" "$(tr -d '[:space:]' < "$FALLBACK_REPO/.autoship/workspaces/issue-208/model")" "runner records fallback model in workspace"
+jq -e '."opencode/paid-model".fail == 1 and (."opencode/paid-model".last_error | test("Insufficient balance"))' "$FALLBACK_REPO/.autoship/model-history.json" >/dev/null || fail "runner records paid model billing failure in model history"
+
 MONITOR_REPO="$TMP_DIR/monitor-repo"
 mkdir -p "$MONITOR_REPO/.autoship/workspaces/issue-997" "$MONITOR_REPO/hooks/opencode" "$MONITOR_REPO/hooks"
 git init -q "$MONITOR_REPO"


### PR DESCRIPTION
## Summary
- Detect billing/quota failures in worker logs instead of leaving the workspace stuck immediately.
- Record failed paid models in `.autoship/model-history.json`.
- Retry once with the strongest compatible configured free fallback model and persist that fallback model in workspace/state.

## Verification
- `bash hooks/opencode/test-policy.sh`
- `bash -n hooks/opencode/*.sh hooks/*.sh`
- `bash hooks/opencode/smoke-test.sh`

Closes #208