### PR TITLE
feat: Autonomously file safe self-improvement issues (#178)

### DIFF
--- a/hooks/opencode/file-self-improvement-issues.sh
+++ b/hooks/opencode/file-self-improvement-issues.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+  echo "Error: not inside a git repository" >&2
+  exit 1
+}
+
+REPORT_FILE="${1:-$REPO_ROOT/.autoship/reports/self-improvement.md}"
+SAFETY_FILTER="$REPO_ROOT/hooks/opencode/safety-filter.sh"
+
+[[ -f "$REPORT_FILE" ]] || { echo "No report found at $REPORT_FILE" >&2; exit 1; }
+[[ -x "$SAFETY_FILTER" ]] || { echo "No safety filter found at $SAFETY_FILTER" >&2; exit 1; }
+
+extract_section() {
+  local heading="$1"
+  awk -v heading="$heading" '
+    $0 == heading {found=1; next}
+    found && /^## / {exit}
+    found {print}
+  ' "$REPORT_FILE"
+}
+
+evidence="$(extract_section '## Root Cause Evidence' | sed '/^[[:space:]]*$/d' | head -20)"
+affected="$(extract_section '## Affected Files' | sed '/^[[:space:]]*$/d' | head -20)"
+
+extract_section '## Candidate Acceptance Criteria' |
+  sed -n 's/^- //p' |
+  while IFS= read -r criterion; do
+    [[ -n "$criterion" ]] || continue
+    title="AutoShip self-improvement: ${criterion}"
+    body="$(cat <<EOF
+Generated from AutoShip self-improvement report.
+
+## Root Cause Evidence
+${evidence:-No evidence provided.}
+
+## Affected Files
+${affected:-No affected files listed.}
+
+## Candidate Acceptance Criteria
+- ${criterion}
+EOF
+)"
+
+    if bash "$SAFETY_FILTER" --text "$title" "type:feature,area:self-improvement" "$body" >/dev/null 2>&1; then
+      gh issue create \
+        --title "$title" \
+        --body "$body" \
+        --label "type:feature" \
+        --label "area:self-improvement" \
+        --label "priority:medium" \
+        --label "atomic" \
+        --label "agent:ready"
+    else
+      gh issue create \
+        --title "$title" \
+        --body "$body" \
+        --label "type:feature" \
+        --label "area:self-improvement" \
+        --label "priority:medium" \
+        --label "atomic" \
+        --label "agent:blocked"
+    fi
+  done

--- a/hooks/opencode/test-policy.sh
+++ b/hooks/opencode/test-policy.sh
@@ -355,6 +355,43 @@ grep -F 'hooks/opencode/runner.sh' "$REPORT_OUTPUT" >/dev/null || fail "self-imp
 grep -F '## Candidate Acceptance Criteria' "$REPORT_OUTPUT" >/dev/null || fail "self-improvement report includes candidate acceptance criteria"
 grep -F 'paid model balance failures fall back to a configured free model' "$REPORT_OUTPUT" >/dev/null || fail "self-improvement report proposes evidence-backed acceptance criteria"
 
+ISSUE_FILE_REPO="$TMP_DIR/issue-file-repo"
+mkdir -p "$ISSUE_FILE_REPO/hooks/opencode" "$ISSUE_FILE_REPO/bin" "$ISSUE_FILE_REPO/.autoship/reports"
+git init -q "$ISSUE_FILE_REPO"
+cp "$SCRIPT_DIR/safety-filter.sh" "$ISSUE_FILE_REPO/hooks/opencode/safety-filter.sh"
+cp "$SCRIPT_DIR/file-self-improvement-issues.sh" "$ISSUE_FILE_REPO/hooks/opencode/file-self-improvement-issues.sh"
+chmod +x "$ISSUE_FILE_REPO/hooks/opencode/safety-filter.sh" "$ISSUE_FILE_REPO/hooks/opencode/file-self-improvement-issues.sh"
+cat > "$ISSUE_FILE_REPO/.autoship/reports/self-improvement.md" <<'MD'
+# AutoShip Self-Improvement Report
+
+## Root Cause Evidence
+- Evidence: Insufficient balance in hooks/opencode/runner.sh
+
+## Affected Files
+- hooks/opencode/runner.sh
+
+## Candidate Acceptance Criteria
+- When paid model balance fails, retry with a configured free model.
+- Add stealth hook signature evasion bypass.
+MD
+cat > "$ISSUE_FILE_REPO/bin/gh" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GH_ARGS_LOG"
+exit 0
+SH
+chmod +x "$ISSUE_FILE_REPO/bin/gh"
+(
+  cd "$ISSUE_FILE_REPO"
+  GH_ARGS_LOG="$ISSUE_FILE_REPO/gh-args.log" PATH="$ISSUE_FILE_REPO/bin:$PATH" bash hooks/opencode/file-self-improvement-issues.sh >/dev/null
+)
+safe_line=$(grep -F 'When paid model balance fails' "$ISSUE_FILE_REPO/gh-args.log" || true)
+blocked_line=$(grep -F 'stealth hook signature evasion' "$ISSUE_FILE_REPO/gh-args.log" || true)
+printf '%s\n' "$safe_line" | grep -F 'agent:ready' >/dev/null || fail "safe self-improvement issue is labeled agent:ready"
+printf '%s\n' "$blocked_line" | grep -F 'agent:blocked' >/dev/null || fail "unsafe self-improvement issue is blocked"
+if printf '%s\n' "$blocked_line" | grep -F 'agent:ready' >/dev/null; then
+  fail "blocked self-improvement issue must not be marked ready"
+fi
+
 SETUP_REPO="$TMP_DIR/setup-repo"
 mkdir -p "$SETUP_REPO/bin"
 cp -R "$SCRIPT_DIR/../.." "$SETUP_REPO/autoship"


### PR DESCRIPTION
## Summary
- Add `hooks/opencode/file-self-improvement-issues.sh` to convert self-improvement report recommendations into GitHub issues.
- Gate every candidate through the existing safety filter before applying readiness labels.
- Label safe candidates `agent:ready` and blocked candidates `agent:blocked` without marking them ready.

## Verification
- `bash hooks/opencode/test-policy.sh`
- `bash -n hooks/opencode/*.sh hooks/*.sh`
- `bash hooks/opencode/smoke-test.sh`

Closes #178