### PR TITLE
fix(role-release): avoid shell injection via PR title placeholder

### DIFF
--- a/skills/role-release/SKILL.md
+++ b/skills/role-release/SKILL.md
@@ -27,13 +27,13 @@ git diff main...HEAD --stat
 ### Step 2: Get PR Title
 
 ```bash
-bash hooks/opencode/pr-title.sh --issue <number>
+TITLE="$(bash hooks/opencode/pr-title.sh --issue <number>)"
 ```
 
 ### Step 3: Create PR
 
 ```bash
-gh pr create --title "<title>" --body "$(cat <<'EOF'
+gh pr create --title "$TITLE" --body "$(cat <<'EOF'
 ## Summary
 - <summary>
 


### PR DESCRIPTION
### Motivation
- Prevent command injection from attacker-controlled GitHub issue titles in the release skill by avoiding embedding the raw title into a shell command.

### Description
- Capture the PR title into a shell variable with `TITLE="$(bash hooks/opencode/pr-title.sh --issue <number>)"` and pass it to `gh pr create` as `--title "$TITLE"` instead of inserting a raw placeholder.

### Testing
- Ran `bash -n hooks/opencode/*.sh hooks/*.sh` which succeeded; `bash hooks/opencode/test-policy.sh` failed in this environment due to missing `gh` authentication; `bash hooks/opencode/smoke-test.sh` failed in this environment due to npm registry `403`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebcb4f2abc8321aeb1a3a8c4dc7cb3)