### PR TITLE
fix: disable unverified auto-release sync by default

### DIFF
--- a/hooks/opencode/sync-release.sh
+++ b/hooks/opencode/sync-release.sh
@@ -38,6 +38,12 @@ copy_assets() {
 }
 
 LATEST_TAG=""
+if [[ "${AUTOSHIP_UNVERIFIED_RELEASE_SYNC:-0}" != "1" ]]; then
+  copy_assets "$REPO_ROOT"
+  printf '%s\n' "dev" > "$VERSION_FILE"
+  exit 0
+fi
+
 if command -v gh >/dev/null 2>&1; then
   LATEST_TAG=$(gh api "repos/$REPO_REF/releases/latest" --jq '.tag_name' 2>/dev/null || true)
 fi


### PR DESCRIPTION
### Motivation
- Prevent automatic installation of unverified GitHub release artifacts which could lead to supply-chain code execution by removing the unguarded remote-sync path from normal init/install flows.

### Description
- Add an opt-in guard to `hooks/opencode/sync-release.sh` so the script defaults to installing bundled local assets and writing `dev` to the plugin version unless `AUTOSHIP_UNVERIFIED_RELEASE_SYNC=1` is set, preserving the previous remote-sync logic only when explicitly enabled.

### Testing
- `bash hooks/opencode/test-policy.sh` succeeded.
- `bash -n hooks/opencode/*.sh hooks/*.sh` (syntax check) succeeded.
- `bash hooks/opencode/smoke-test.sh` was not fully runnable in this environment because `gh` is not installed (`Error: gh is required`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eba4c7850c8321ab96a08f7f6e82ed)