### PR TITLE
security: remove issue-title interpolation from commit commands

### DIFF
--- a/skills/autoship-dispatch/SKILL.md
+++ b/skills/autoship-dispatch/SKILL.md
@@ -149,7 +149,7 @@ echo "RUNNING" > .autoship/workspaces/<issue-key>/status
 
 1. Commit all work to git:
    ```bash
-   git add -A && git commit -m 'feat: <issue-title> (#<number>)'
+   git add -A && git commit -m "feat: issue #<number>"
    ```
 
 2. Write `AUTOSHIP_RESULT.md`:

--- a/skills/autoship-verify/SKILL.md
+++ b/skills/autoship-verify/SKILL.md
@@ -108,7 +108,7 @@ CHANGED_FILES=$(git diff --name-only -z main...HEAD)
 git add -- ${CHANGED_FILES}
 
 # Create commit
-git commit -m "feat: <issue-title> (#<number>)
+git commit -m "feat: issue #<number>
 
 Closes #<number>
 Dispatched by AutoShip."


### PR DESCRIPTION
### Motivation
- Prevent command-injection from attacker-controlled GitHub issue titles by removing direct interpolation of `<issue-title>` into required `git commit -m` commands in agent prompts.

### Description
- Replace the unsafe commit subject that embedded `<issue-title>` with an issue-number-only subject in `skills/autoship-dispatch/SKILL.md` and `skills/autoship-verify/SKILL.md` so agents no longer receive a prompt that can produce shell injection (`git add -A && git commit -m "feat: issue #<number>"`).

### Testing
- Ran `bash hooks/opencode/test-policy.sh` which passed; ran `bash -n hooks/opencode/*.sh hooks/*.sh` which passed; ran `bash hooks/opencode/smoke-test.sh` which failed in this environment because `gh` is not installed; and scanned for the vulnerable pattern with `rg`, which found no remaining instances.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eba50ec2ec8321a6b32dbbc34d1995)