### PR TITLE
fix: Snapshot runtime config into worktrees

### DIFF
--- a/hooks/opencode/create-worktree.sh
+++ b/hooks/opencode/create-worktree.sh
@@ -39,4 +39,11 @@ rm -f \
   "$WORKSPACE/started_at" \
   "$WORKSPACE/status"
 
+mkdir -p "$WORKSPACE/.autoship"
+for runtime_file in model-routing.json config.json state.json routing.json; do
+  if [[ -f "$AUTOSHIP_DIR/$runtime_file" ]]; then
+    cp "$AUTOSHIP_DIR/$runtime_file" "$WORKSPACE/.autoship/$runtime_file"
+  fi
+done
+
 printf '%s\n' "$REPO_ROOT/$WORKSPACE"

--- a/hooks/opencode/test-policy.sh
+++ b/hooks/opencode/test-policy.sh
@@ -264,6 +264,8 @@ mkdir -p "$WORKTREE_REPO"
 git init -q "$WORKTREE_REPO"
 git -C "$WORKTREE_REPO" config user.email autoship@example.invalid
 git -C "$WORKTREE_REPO" config user.name AutoShip
+mkdir -p "$WORKTREE_REPO/.autoship"
+printf '{"models":[]}\n' > "$WORKTREE_REPO/.autoship/model-routing.json"
 printf 'base\n' > "$WORKTREE_REPO/README.md"
 git -C "$WORKTREE_REPO" add README.md
 git -C "$WORKTREE_REPO" commit -q -m initial
@@ -277,6 +279,7 @@ printf 'stale\n' > "$WORKTREE_REPO/.autoship/workspaces/issue-156/AUTOSHIP_RESUL
 )
 test -d "$WORKTREE_REPO/.autoship/workspaces/issue-156/.git" || test -f "$WORKTREE_REPO/.autoship/workspaces/issue-156/.git" || fail "create-worktree replaces stale existing workspace directory"
 test ! -e "$WORKTREE_REPO/.autoship/workspaces/issue-156/AUTOSHIP_RESULT.md" || fail "create-worktree clears stale AutoShip artifacts after recovery"
+test -f "$WORKTREE_REPO/.autoship/workspaces/issue-156/.autoship/model-routing.json" || fail "create-worktree copies runtime routing into the workspace"
 
 MERGE_REPO="$TMP_DIR/merge-repo"
 mkdir -p "$MERGE_REPO/bin"


### PR DESCRIPTION
## Summary
- Copy runtime AutoShip config/state files into each worker worktree under `.autoship/`.
- Keep workers inside their sandbox boundary when they need routing/state context.
- Add regression coverage for runtime routing snapshots during worktree creation.

## Verification
- `bash hooks/opencode/test-policy.sh`
- `bash -n hooks/opencode/*.sh hooks/*.sh`
- `bash hooks/opencode/smoke-test.sh`