### PR TITLE
feat: Create PR after verified PASS (#184)

### DIFF
--- a/hooks/opencode/process-event-queue.sh
+++ b/hooks/opencode/process-event-queue.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 AUTOSHIP_DIR=".autoship"
+WORKSPACES_DIR="$AUTOSHIP_DIR/workspaces"
 EVENT_QUEUE="$AUTOSHIP_DIR/event-queue.json"
 PROCESSED_EVENTS="$AUTOSHIP_DIR/processed-events.json"
 LOCK_FILE="$AUTOSHIP_DIR/event-queue.lock"
@@ -70,6 +71,142 @@ current_state() {
   jq -r --arg issue "$issue" '.issues[$issue].state // empty' "$AUTOSHIP_DIR/state.json" 2>/dev/null || true
 }
 
+issue_number() {
+  printf '%s' "${1#issue-}"
+}
+
+issue_title() {
+  local issue="$1"
+  jq -r --arg issue "$issue" '.issues[$issue].title // empty' "$AUTOSHIP_DIR/state.json" 2>/dev/null || true
+}
+
+issue_labels() {
+  local issue="$1"
+  jq -r --arg issue "$issue" '.issues[$issue].labels // empty' "$AUTOSHIP_DIR/state.json" 2>/dev/null || true
+}
+
+discover_test_command() {
+  if [[ -f "$AUTOSHIP_DIR/config.json" ]]; then
+    local configured
+    configured=$(jq -r '.test_command // empty' "$AUTOSHIP_DIR/config.json" 2>/dev/null || true)
+    [[ -n "$configured" ]] && { printf '%s\n' "$configured"; return 0; }
+  fi
+
+  if [[ -f package.json ]]; then
+    printf 'npm test\n'
+  elif [[ -f Makefile ]]; then
+    printf 'make test\n'
+  elif [[ -f Cargo.toml ]]; then
+    printf 'cargo test\n'
+  elif [[ -f pyproject.toml ]]; then
+    printf 'pytest\n'
+  elif [[ -f go.mod ]]; then
+    printf 'go test ./...\n'
+  else
+    printf 'none\n'
+  fi
+}
+
+run_verification() {
+  local issue="$1"
+  local workspace="$WORKSPACES_DIR/$issue"
+  local result_path="$workspace/AUTOSHIP_RESULT.md"
+  local test_command reviewer_output
+
+  [[ -d "$workspace" ]] || return 2
+  [[ -s "$result_path" ]] || return 1
+
+  test_command=$(discover_test_command)
+  reviewer_output=$(mktemp)
+  if bash "$SCRIPT_DIR/reviewer.sh" "$issue" "$workspace" "$result_path" "$test_command" > "$reviewer_output" 2>&1 && grep -F 'VERDICT: PASS' "$reviewer_output" >/dev/null 2>&1; then
+    rm -f "$reviewer_output"
+    return 0
+  fi
+
+  mkdir -p "$workspace"
+  cp "$reviewer_output" "$workspace/AUTOSHIP_VERIFICATION.log" 2>/dev/null || true
+  rm -f "$reviewer_output"
+  return 1
+}
+
+generate_pr_body() {
+  local issue="$1"
+  local workspace="$WORKSPACES_DIR/$issue"
+  local result_path="$workspace/AUTOSHIP_RESULT.md"
+  local body_path="$workspace/AUTOSHIP_PR_BODY.md"
+  local number
+  number=$(issue_number "$issue")
+
+  {
+    printf '## Summary\n'
+    sed 's/^/- /' "$result_path"
+    printf '\n## Verification\n'
+    printf -- '- Reviewer: PASS\n'
+    printf -- '- Tests: passing or not configured\n'
+    printf '\nCloses #%s\n\nDispatched by AutoShip.\n' "$number"
+  } > "$body_path"
+}
+
+create_verified_pr() {
+  local issue="$1"
+  local workspace="$WORKSPACES_DIR/$issue"
+  local body_path="$workspace/AUTOSHIP_PR_BODY.md"
+  local number title labels pr_title pr_url branch
+
+  number=$(issue_number "$issue")
+  title=$(issue_title "$issue")
+  labels=$(issue_labels "$issue")
+  pr_title=$(bash "$SCRIPT_DIR/pr-title.sh" --issue "$number" --title "$title" --labels "$labels")
+  branch=$(git branch --show-current 2>/dev/null || true)
+  [[ -n "$branch" ]] || branch="autoship/issue-$number"
+
+  generate_pr_body "$issue"
+
+  git add -A -- . ':!.autoship'
+  if git diff --cached --quiet; then
+    return 1
+  fi
+  git commit -m "$pr_title
+
+Closes #$number
+Dispatched by AutoShip." >/dev/null
+
+  pr_url=$(gh pr create \
+    --title "$pr_title" \
+    --body-file "$body_path" \
+    --label autoship \
+    --head "$branch")
+
+  if [[ -n "$pr_url" ]]; then
+    local pr_number
+    pr_number=$(printf '%s\n' "$pr_url" | grep -Eo '[0-9]+$' | tail -1 || true)
+    [[ -n "$pr_number" ]] && printf '%s\n' "$pr_number"
+  fi
+}
+
+verify_and_create_pr() {
+  local issue="$1"
+  local verification_status pr_number
+
+  run_verification "$issue"
+  verification_status=$?
+  if [[ $verification_status -eq 2 ]]; then
+    apply_state_once "$issue" set-completed completed
+    return 0
+  fi
+  if [[ $verification_status -ne 0 ]]; then
+    apply_state_once "$issue" set-failed blocked
+    return 0
+  fi
+
+  pr_number=$(create_verified_pr "$issue" || true)
+  if [[ -n "$pr_number" ]]; then
+    apply_state_once "$issue" set-completed completed pr_number="$pr_number"
+  else
+    apply_state_once "$issue" set-blocked blocked
+  fi
+}
+
 apply_state_once() {
   local issue="$1"
   local action="$2"
@@ -103,7 +240,7 @@ process_event() {
       ;;
     verify)
       [[ -n "$issue" ]] || return 1
-      apply_state_once "$issue" set-completed completed
+      verify_and_create_pr "$issue"
       ;;
     force_dispatch)
       [[ -n "$issue" ]] || return 1

--- a/hooks/opencode/test-policy.sh
+++ b/hooks/opencode/test-policy.sh
@@ -270,6 +270,122 @@ assert_eq "1" "$(jq -r '.stats.session_completed' "$QUEUE_REPO/.autoship/state.j
 assert_eq "0" "$(jq 'length' "$QUEUE_REPO/.autoship/event-queue.json")" "event processor drains processed duplicate events"
 assert_eq "2" "$(jq 'length' "$QUEUE_REPO/.autoship/processed-events.json")" "event processor records only unique semantic events"
 
+VERIFY_FAIL_REPO="$TMP_DIR/verify-fail-repo"
+mkdir -p "$VERIFY_FAIL_REPO/.autoship/workspaces/issue-184" "$VERIFY_FAIL_REPO/hooks/opencode" "$VERIFY_FAIL_REPO/hooks" "$VERIFY_FAIL_REPO/bin"
+git init -q "$VERIFY_FAIL_REPO"
+git -C "$VERIFY_FAIL_REPO" config user.email autoship@example.invalid
+git -C "$VERIFY_FAIL_REPO" config user.name AutoShip
+printf 'base\n' > "$VERIFY_FAIL_REPO/README.md"
+git -C "$VERIFY_FAIL_REPO" add README.md
+git -C "$VERIFY_FAIL_REPO" commit -q -m initial
+git -C "$VERIFY_FAIL_REPO" checkout -q -b autoship/issue-184
+printf 'changed\n' > "$VERIFY_FAIL_REPO/feature.txt"
+cp "$SCRIPT_DIR/process-event-queue.sh" "$VERIFY_FAIL_REPO/hooks/opencode/process-event-queue.sh"
+cp "$SCRIPT_DIR/pr-title.sh" "$VERIFY_FAIL_REPO/hooks/opencode/pr-title.sh"
+cp "$SCRIPT_DIR/../update-state.sh" "$VERIFY_FAIL_REPO/hooks/update-state.sh"
+chmod +x "$VERIFY_FAIL_REPO/hooks/opencode/process-event-queue.sh" "$VERIFY_FAIL_REPO/hooks/opencode/pr-title.sh" "$VERIFY_FAIL_REPO/hooks/update-state.sh"
+cat > "$VERIFY_FAIL_REPO/hooks/opencode/reviewer.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'VERDICT: FAIL\n'
+exit 1
+SH
+chmod +x "$VERIFY_FAIL_REPO/hooks/opencode/reviewer.sh"
+cat > "$VERIFY_FAIL_REPO/bin/gh" <<'SH'
+#!/usr/bin/env bash
+if [[ "$1 $2" == "pr create" ]]; then
+  printf 'pr create called\n' >> "$GH_PR_LOG"
+  exit 0
+fi
+if [[ "$1 $2" == "issue view" && "$*" == *"title"* ]]; then
+  printf 'Create PR after verified PASS\n'
+  exit 0
+fi
+if [[ "$1 $2" == "issue view" && "$*" == *"labels"* ]]; then
+  printf 'type:feature\n'
+  exit 0
+fi
+if [[ "$1 $2" == "label list" ]]; then
+  printf '%s\n' autoship:blocked autoship:in-progress autoship:done autoship:paused
+  exit 0
+fi
+exit 0
+SH
+chmod +x "$VERIFY_FAIL_REPO/bin/gh"
+cat > "$VERIFY_FAIL_REPO/.autoship/state.json" <<'JSON'
+{"repo":"owner/repo","issues":{"issue-184":{"state":"running","title":"Create PR after verified PASS","labels":"type:feature"}},"stats":{},"config":{"maxConcurrentAgents":15}}
+JSON
+printf '[]\n' > "$VERIFY_FAIL_REPO/.autoship/processed-events.json"
+cat > "$VERIFY_FAIL_REPO/.autoship/event-queue.json" <<'JSON'
+[{"type":"verify","issue":"issue-184","priority":2,"data":{"status":"COMPLETE"},"queued_at":"2026-04-24T00:00:00Z"}]
+JSON
+printf 'Result\n' > "$VERIFY_FAIL_REPO/.autoship/workspaces/issue-184/AUTOSHIP_RESULT.md"
+(
+  cd "$VERIFY_FAIL_REPO"
+  GH_PR_LOG="$VERIFY_FAIL_REPO/gh-pr.log" PATH="$VERIFY_FAIL_REPO/bin:$PATH" bash hooks/opencode/process-event-queue.sh >/dev/null
+)
+test ! -e "$VERIFY_FAIL_REPO/gh-pr.log" || fail "failed verification must not call gh pr create"
+assert_eq "blocked" "$(jq -r '.issues["issue-184"].state' "$VERIFY_FAIL_REPO/.autoship/state.json")" "failed verification blocks issue instead of completing it"
+
+VERIFY_PASS_REPO="$TMP_DIR/verify-pass-repo"
+mkdir -p "$VERIFY_PASS_REPO/.autoship/workspaces/issue-184" "$VERIFY_PASS_REPO/hooks/opencode" "$VERIFY_PASS_REPO/hooks" "$VERIFY_PASS_REPO/bin"
+git init -q "$VERIFY_PASS_REPO"
+git -C "$VERIFY_PASS_REPO" config user.email autoship@example.invalid
+git -C "$VERIFY_PASS_REPO" config user.name AutoShip
+git -C "$VERIFY_PASS_REPO" remote add origin git@github.com:owner/repo.git
+printf 'base\n' > "$VERIFY_PASS_REPO/README.md"
+git -C "$VERIFY_PASS_REPO" add README.md
+git -C "$VERIFY_PASS_REPO" commit -q -m initial
+git -C "$VERIFY_PASS_REPO" checkout -q -b autoship/issue-184
+printf 'changed\n' > "$VERIFY_PASS_REPO/feature.txt"
+cp "$SCRIPT_DIR/process-event-queue.sh" "$VERIFY_PASS_REPO/hooks/opencode/process-event-queue.sh"
+cp "$SCRIPT_DIR/pr-title.sh" "$VERIFY_PASS_REPO/hooks/opencode/pr-title.sh"
+cp "$SCRIPT_DIR/../update-state.sh" "$VERIFY_PASS_REPO/hooks/update-state.sh"
+chmod +x "$VERIFY_PASS_REPO/hooks/opencode/process-event-queue.sh" "$VERIFY_PASS_REPO/hooks/opencode/pr-title.sh" "$VERIFY_PASS_REPO/hooks/update-state.sh"
+cat > "$VERIFY_PASS_REPO/hooks/opencode/reviewer.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'VERDICT: PASS\n'
+exit 0
+SH
+chmod +x "$VERIFY_PASS_REPO/hooks/opencode/reviewer.sh"
+cat > "$VERIFY_PASS_REPO/bin/gh" <<'SH'
+#!/usr/bin/env bash
+if [[ "$1 $2" == "pr create" ]]; then
+  printf '%s\n' "$*" >> "$GH_PR_LOG"
+  printf 'https://github.com/owner/repo/pull/184\n'
+  exit 0
+fi
+if [[ "$1 $2" == "issue view" && "$*" == *"title"* ]]; then
+  printf 'Create PR after verified PASS\n'
+  exit 0
+fi
+if [[ "$1 $2" == "issue view" && "$*" == *"labels"* ]]; then
+  printf 'type:feature\n'
+  exit 0
+fi
+if [[ "$1 $2" == "label list" ]]; then
+  printf '%s\n' autoship:blocked autoship:in-progress autoship:done autoship:paused
+  exit 0
+fi
+exit 0
+SH
+chmod +x "$VERIFY_PASS_REPO/bin/gh"
+cat > "$VERIFY_PASS_REPO/.autoship/state.json" <<'JSON'
+{"repo":"owner/repo","issues":{"issue-184":{"state":"running","title":"Create PR after verified PASS","labels":"type:feature"}},"stats":{},"config":{"maxConcurrentAgents":15}}
+JSON
+printf '[]\n' > "$VERIFY_PASS_REPO/.autoship/processed-events.json"
+cat > "$VERIFY_PASS_REPO/.autoship/event-queue.json" <<'JSON'
+[{"type":"verify","issue":"issue-184","priority":2,"data":{"status":"COMPLETE"},"queued_at":"2026-04-24T00:00:00Z"}]
+JSON
+printf 'Result summary\n' > "$VERIFY_PASS_REPO/.autoship/workspaces/issue-184/AUTOSHIP_RESULT.md"
+(
+  cd "$VERIFY_PASS_REPO"
+  GH_PR_LOG="$VERIFY_PASS_REPO/gh-pr.log" PATH="$VERIFY_PASS_REPO/bin:$PATH" bash hooks/opencode/process-event-queue.sh >/dev/null
+)
+grep -F 'pr create --title feat: Create PR after verified PASS (#184)' "$VERIFY_PASS_REPO/gh-pr.log" >/dev/null || fail "verified PASS creates PR with conventional title"
+grep -F -- '--body-file .autoship/workspaces/issue-184/AUTOSHIP_PR_BODY.md' "$VERIFY_PASS_REPO/gh-pr.log" >/dev/null || fail "verified PASS creates PR from generated body file"
+grep -F 'Reviewer: PASS' "$VERIFY_PASS_REPO/.autoship/workspaces/issue-184/AUTOSHIP_PR_BODY.md" >/dev/null || fail "generated PR body records reviewer pass"
+assert_eq "completed" "$(jq -r '.issues["issue-184"].state' "$VERIFY_PASS_REPO/.autoship/state.json")" "verified PASS completes issue after PR creation"
+
 grep -F 'AUTOSHIP_VERSION="1.5.0-opencode"' "$SCRIPT_DIR/init.sh" >/dev/null 2>&1 && fail "init must not hardcode stale 1.5.0-opencode version"
 
 INIT_REPO="$TMP_DIR/init-repo"


### PR DESCRIPTION
## Summary
- Run reviewer verification before creating PRs from verify events.
- Block failed verification without calling `gh pr create`.
- Generate conventional PR title/body, commit changes, create PR, and record PR number after PASS.

## Verification
- `bash hooks/opencode/test-policy.sh`
- `bash -n hooks/opencode/*.sh hooks/*.sh`
- `bash hooks/opencode/smoke-test.sh`

Closes #184