### PR TITLE
feat: Add bounded retry and escalation state (#181)

### DIFF
--- a/hooks/opencode/dispatch.sh
+++ b/hooks/opencode/dispatch.sh
@@ -29,6 +29,15 @@ ROUTING_FILE="$AUTOSHIP_DIR/model-routing.json"
 ISSUE_KEY="issue-${ISSUE_NUM}"
 WORKSPACE_PATH="$AUTOSHIP_DIR/workspaces/$ISSUE_KEY"
 
+if [[ -f "$STATE_FILE" ]] && jq -e --arg key "$ISSUE_KEY" '(.issues[$key].terminal_failure // false) == true or (.issues[$key].retry_eligible // true) == false' "$STATE_FILE" >/dev/null 2>&1; then
+  mkdir -p "$WORKSPACE_PATH"
+  printf 'BLOCKED\n' > "$WORKSPACE_PATH/status"
+  reason=$(jq -r --arg key "$ISSUE_KEY" '.issues[$key].escalation_reason // "retry limit reached"' "$STATE_FILE" 2>/dev/null || echo "retry limit reached")
+  printf '%s\n' "$reason" > "$WORKSPACE_PATH/BLOCKED_REASON.txt"
+  echo "BLOCKED $ISSUE_KEY: $reason"
+  exit 0
+fi
+
 max_agents=$(jq -r '.config.maxConcurrentAgents // .max_concurrent_agents // empty' "$STATE_FILE" 2>/dev/null || true)
 if [[ -z "$max_agents" && -f "$AUTOSHIP_DIR/config.json" ]]; then
   max_agents=$(jq -r '.maxConcurrentAgents // .max_agents // empty' "$AUTOSHIP_DIR/config.json" 2>/dev/null || true)

--- a/hooks/opencode/test-policy.sh
+++ b/hooks/opencode/test-policy.sh
@@ -141,11 +141,57 @@ assert_eq "STUCK" "$(tr -d '[:space:]' < "$RUNNER_REPO/.autoship/workspaces/issu
 if grep -F 'ENV_LEAK' "$RUNNER_REPO/.autoship/workspaces/issue-996/AUTOSHIP_RUNNER.log" >/dev/null 2>&1; then
   fail "runner must unset parent OpenCode session environment before nested opencode run"
 fi
+for _ in 1 2 3 4 5; do
+  artifact_count=$(find "$RUNNER_REPO/.autoship/failures" -name '*-issue-996.json' 2>/dev/null | wc -l | tr -d '[:space:]')
+  [[ "$artifact_count" != "0" ]] && break
+  sleep 1
+done
 artifact_count=$(find "$RUNNER_REPO/.autoship/failures" -name '*-issue-996.json' 2>/dev/null | wc -l | tr -d '[:space:]')
 assert_eq "1" "$artifact_count" "runner captures a stuck worker failure artifact"
 artifact_file=$(find "$RUNNER_REPO/.autoship/failures" -name '*-issue-996.json' | head -1)
 jq -e '.issue == "issue-996" and .model == "opencode/test-free" and .role == "implementer" and .workspace != "" and .hook == "hooks/opencode/runner.sh" and .failure_category == "stuck" and (.logs | contains("ok")) and .attempt == 2' "$artifact_file" >/dev/null || fail "failure artifact includes issue, model, workspace, hook, logs, category, role, and attempt"
 test -s "$RUNNER_REPO/.autoship/workspaces/issue-996/worker.pid" || fail "runner records worker pid for lifecycle monitoring"
+
+RETRY_REPO="$TMP_DIR/retry-limit-repo"
+mkdir -p "$RETRY_REPO/.autoship/workspaces/issue-181" "$RETRY_REPO/.autoship/failures" "$RETRY_REPO/hooks/opencode" "$RETRY_REPO/hooks"
+git init -q "$RETRY_REPO"
+cp "$SCRIPT_DIR/../update-state.sh" "$RETRY_REPO/hooks/update-state.sh"
+cp "$SCRIPT_DIR/dispatch.sh" "$RETRY_REPO/hooks/opencode/dispatch.sh"
+chmod +x "$RETRY_REPO/hooks/update-state.sh" "$RETRY_REPO/hooks/opencode/dispatch.sh"
+cat > "$RETRY_REPO/.autoship/state.json" <<'JSON'
+{"repo":"owner/repo","issues":{"issue-181":{"state":"running","attempt":3,"model":"opencode/test","role":"implementer"}},"stats":{},"config":{"maxConcurrentAgents":15,"maxRetries":3}}
+JSON
+cat > "$RETRY_REPO/.autoship/failures/20260424T010000Z-issue-181.json" <<'JSON'
+{"failure_id":"20260424T010000Z-issue-181","issue":"issue-181","failure_category":"failed_verification","error_summary":"tests failed","attempt":3,"timestamp":"2026-04-24T01:00:00Z"}
+JSON
+(
+  cd "$RETRY_REPO"
+  bash hooks/update-state.sh set-failed issue-181 escalation_reason="failed verification after retry limit" >/dev/null
+)
+jq -e '.issues["issue-181"].state == "blocked"
+  and .issues["issue-181"].retry_count == 3
+  and .issues["issue-181"].retry_limit == 3
+  and .issues["issue-181"].retry_eligible == false
+  and .issues["issue-181"].terminal_failure == true
+  and .issues["issue-181"].escalation_reason == "failed verification after retry limit"
+  and (.issues["issue-181"].failure_evidence.failure_file | endswith("20260424T010000Z-issue-181.json"))
+  and .issues["issue-181"].failure_evidence.failure_category == "failed_verification"
+  and .issues["issue-181"].failure_evidence.error_summary == "tests failed"' "$RETRY_REPO/.autoship/state.json" >/dev/null || fail "set-failed records terminal retry exhaustion evidence"
+dispatch_output=$(cd "$RETRY_REPO" && bash hooks/opencode/dispatch.sh 181 medium_code)
+printf '%s\n' "$dispatch_output" | grep -F 'failed verification after retry limit' >/dev/null || fail "dispatch blocks terminal retry-exhausted issue"
+assert_eq "BLOCKED" "$(tr -d '[:space:]' < "$RETRY_REPO/.autoship/workspaces/issue-181/status")" "terminal retry-exhausted issue remains blocked instead of redispatched"
+
+printf '{broken json' > "$RETRY_REPO/.autoship/failures/20260424T020000Z-issue-182.json"
+jq '.issues["issue-182"] = {"state":"running","attempt":2}' "$RETRY_REPO/.autoship/state.json" > "$RETRY_REPO/.autoship/state.json.tmp" && mv "$RETRY_REPO/.autoship/state.json.tmp" "$RETRY_REPO/.autoship/state.json"
+(
+  cd "$RETRY_REPO"
+  bash hooks/update-state.sh set-failed issue-182 error_summary="malformed artifact fallback" >/dev/null
+)
+jq -e '.issues["issue-182"].retry_count == 2
+  and .issues["issue-182"].retry_limit == 3
+  and .issues["issue-182"].retry_eligible == true
+  and .issues["issue-182"].terminal_failure == false
+  and .issues["issue-182"].failure_evidence.error_summary == "malformed artifact fallback"' "$RETRY_REPO/.autoship/state.json" >/dev/null || fail "set-failed falls back to synthesized evidence before retry limit"
 
 FALLBACK_REPO="$TMP_DIR/fallback-runner-repo"
 mkdir -p "$FALLBACK_REPO/.autoship/workspaces/issue-208" "$FALLBACK_REPO/hooks/opencode" "$FALLBACK_REPO/hooks" "$FALLBACK_REPO/bin"
@@ -185,7 +231,7 @@ chmod +x "$FALLBACK_REPO/bin/opencode"
   cd "$FALLBACK_REPO"
   PATH="$FALLBACK_REPO/bin:$PATH" bash hooks/opencode/runner.sh >/dev/null
 )
-for _ in 1 2 3 4 5; do
+for _ in 1 2 3 4 5 6 7 8 9 10; do
   [[ "$(tr -d '[:space:]' < "$FALLBACK_REPO/.autoship/workspaces/issue-208/status")" != "RUNNING" ]] && break
   sleep 1
 done

--- a/hooks/update-state.sh
+++ b/hooks/update-state.sh
@@ -226,6 +226,87 @@ trap cleanup EXIT
 
 make_tmp() { local t; t=$(mktemp); TMP_FILES+=("$t"); echo "$t"; }
 
+arg_value() {
+  local wanted="$1"
+  local pair
+  shift
+  for pair in "$@"; do
+    if [[ "$pair" == "$wanted="* ]]; then
+      printf '%s\n' "${pair#*=}"
+      return 0
+    fi
+  done
+  return 1
+}
+
+record_failure_retry_state() {
+  local issue_id="$1"
+  shift
+  local attempt retry_limit terminal retry_eligible escalation_reason error_summary latest_failure evidence_json tmp
+
+  attempt=$(jq -r --arg id "$issue_id" '.issues[$id].attempt // 1' "$STATE_FILE" 2>/dev/null || echo 1)
+  retry_limit=$(jq -r '.config.maxRetries // .config.max_retries // .config.retryLimit // .config.retry_limit // 3' "$STATE_FILE" 2>/dev/null || echo 3)
+  if [[ ! "$attempt" =~ ^[0-9]+$ ]]; then
+    attempt=1
+  fi
+  if [[ ! "$retry_limit" =~ ^[0-9]+$ ]] || [[ "$retry_limit" -lt 1 ]]; then
+    retry_limit=3
+  fi
+
+  terminal=false
+  retry_eligible=true
+  escalation_reason=$(arg_value escalation_reason "$@" || true)
+  if (( attempt >= retry_limit )); then
+    terminal=true
+    retry_eligible=false
+    escalation_reason="${escalation_reason:-retry limit reached}"
+  else
+    escalation_reason="${escalation_reason:-failure recorded; retry eligible}"
+  fi
+
+  error_summary=$(arg_value error_summary "$@" || true)
+  latest_failure=""
+  if [[ -d "$REPO_ROOT/.autoship/failures" ]]; then
+    latest_failure=$(find "$REPO_ROOT/.autoship/failures" -type f -name "*-${issue_id}.json" 2>/dev/null | sort | tail -1 || true)
+  fi
+  if [[ -n "$latest_failure" && -f "$latest_failure" ]]; then
+    evidence_json=$(jq -c --arg file "$latest_failure" '{
+      failure_file: $file,
+      failure_id: (.failure_id // ""),
+      failure_category: (.failure_category // ""),
+      error_summary: (.error_summary // ""),
+      attempt: (.attempt // null),
+      timestamp: (.timestamp // "")
+    }' "$latest_failure" 2>/dev/null || true)
+  fi
+  if [[ -z "${evidence_json:-}" ]]; then
+    evidence_json=$(jq -n -c \
+      --arg hook "hooks/update-state.sh" \
+      --arg error "$error_summary" \
+      --arg now "$NOW" \
+      --argjson attempt "$attempt" \
+      '{hook: $hook, error_summary: $error, attempt: $attempt, timestamp: $now}')
+  fi
+
+  tmp=$(make_tmp)
+  jq --arg id "$issue_id" \
+    --arg reason "$escalation_reason" \
+    --arg now "$NOW" \
+    --argjson attempt "$attempt" \
+    --argjson limit "$retry_limit" \
+    --argjson terminal "$terminal" \
+    --argjson eligible "$retry_eligible" \
+    --argjson evidence "$evidence_json" \
+    '.issues[$id].retry_count = $attempt |
+     .issues[$id].retry_limit = $limit |
+     .issues[$id].retry_eligible = $eligible |
+     .issues[$id].terminal_failure = $terminal |
+     .issues[$id].escalation_reason = $reason |
+     .issues[$id].failure_evidence = $evidence |
+     if $terminal then .issues[$id].terminal_failed_at = $now else . end' \
+    "$STATE_FILE" > "$tmp" && mv "$tmp" "$STATE_FILE"
+}
+
 # Map action to state, stat counter, and GitHub labels
 case "$ACTION" in
   set-claimed)
@@ -419,5 +500,9 @@ for pair in "$@"; do
   fi
 
 done
+
+if [[ "$ACTION" == "set-failed" ]]; then
+  record_failure_retry_state "$ISSUE_ID" "$@"
+fi
 
 echo "Updated issue $ISSUE_ID: state=$NEW_STATE"


### PR DESCRIPTION
## Summary
- Record retry count, retry limits, retry eligibility, terminal failure state, escalation reason, and failure evidence when issues fail.
- Block redispatch after retry exhaustion.
- Add regression coverage for retry-limit exhaustion and structured failure evidence.

## Verification
- `bash hooks/opencode/test-policy.sh`
- `bash -n hooks/opencode/*.sh hooks/*.sh`
- `bash hooks/opencode/smoke-test.sh`

Closes #181