### PR TITLE
test: Add mocked opencode models setup fixture (#186)

### DIFF
--- a/hooks/opencode/runner.sh
+++ b/hooks/opencode/runner.sh
@@ -89,11 +89,11 @@ mark_stuck_unless_terminal() {
   case "$current" in
     COMPLETE|BLOCKED|STUCK) ;;
     *)
-      echo "STUCK" > status
       if [[ -x "$repo_root/hooks/capture-failure.sh" ]]; then
         error_msg=$(tail -5 AUTOSHIP_RUNNER.log 2>/dev/null || echo "worker exited without terminal status")
         bash "$repo_root/hooks/capture-failure.sh" stuck "$wid" "error_summary=$error_msg" 2>/dev/null || true
       fi
+      echo "STUCK" > status
       ;;
   esac
 }

--- a/hooks/opencode/smoke-test.sh
+++ b/hooks/opencode/smoke-test.sh
@@ -5,6 +5,7 @@ REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
   echo "Error: not inside a git repository" >&2
   exit 1
 }
+source "$REPO_ROOT/hooks/opencode/test-fixtures/mock-opencode-models.sh"
 
 capture_e2e_failure() {
   local status="$1"
@@ -27,25 +28,7 @@ trap 'status=$?; capture_e2e_failure "$status"; rm -rf "$CONFIG_HOME"; if [[ -n 
 export XDG_CONFIG_HOME="$CONFIG_HOME"
 BIN_DIR="$CONFIG_HOME/bin"
 mkdir -p "$BIN_DIR"
-cat > "$BIN_DIR/opencode" <<'SH'
-#!/usr/bin/env bash
-if [[ "$1" == "models" ]]; then
-  printf '%s\n' 'opencode/minimax-m2.5-free' 'opencode/nemotron-3-super-free' 'openai/gpt-5.5'
-  exit 0
-fi
-printf '%s\n' '1.14.22'
-SH
-cat > "$BIN_DIR/gh" <<'SH'
-#!/usr/bin/env bash
-if [[ "$1 $2" == "auth status" ]]; then
-  exit 0
-fi
-if [[ "$1 $2" == "label create" ]]; then
-  exit 0
-fi
-exit 0
-SH
-chmod +x "$BIN_DIR/opencode" "$BIN_DIR/gh"
+install_mock_opencode_models_fixture "$BIN_DIR"
 export PATH="$BIN_DIR:$PATH"
 
 PACKAGE_REPO="$(mktemp -d)"

--- a/hooks/opencode/test-fixtures/mock-opencode-models.sh
+++ b/hooks/opencode/test-fixtures/mock-opencode-models.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mock_opencode_models_inventory() {
+  printf '%s\n' \
+    'opencode/nemotron-3-super-free' \
+    'opencode/minimax-m2.5-free' \
+    'openai/gpt-5.5' \
+    'openai/gpt-5.3-codex-spark'
+}
+
+install_mock_opencode_models_fixture() {
+  local bin_dir="$1"
+  mkdir -p "$bin_dir"
+
+  cat > "$bin_dir/opencode" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "models" ]]; then
+  printf '%s\n' \
+    'opencode/nemotron-3-super-free' \
+    'opencode/minimax-m2.5-free' \
+    'openai/gpt-5.5' \
+    'openai/gpt-5.3-codex-spark'
+  exit 0
+fi
+
+printf 'mock opencode fixture only permits `opencode models`, got:' >&2
+printf ' %q' "$@" >&2
+printf '\n' >&2
+exit 99
+SH
+
+  cat > "$bin_dir/gh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-} ${2:-}" == "auth status" ]]; then
+  exit 0
+fi
+if [[ "${1:-} ${2:-}" == "label create" ]]; then
+  exit 0
+fi
+exit 0
+SH
+
+  chmod +x "$bin_dir/opencode" "$bin_dir/gh"
+}

--- a/hooks/opencode/test-model-parsing.sh
+++ b/hooks/opencode/test-model-parsing.sh
@@ -20,6 +20,7 @@ assert_eq() {
 }
 
 source "$SCRIPT_DIR/model-parser.sh"
+source "$SCRIPT_DIR/test-fixtures/mock-opencode-models.sh"
 
 AVAILABLE="opencode/nemotron-3-super-free
 opencode/minimax-m2.5-free
@@ -99,22 +100,7 @@ MODEL_REPO="$TMP_DIR/model-repo"
 mkdir -p "$MODEL_REPO/bin" "$MODEL_REPO/autoship/hooks/opencode"
 cp "$SCRIPT_DIR/setup.sh" "$SCRIPT_DIR/model-parser.sh" "$MODEL_REPO/autoship/hooks/opencode/"
 chmod +x "$MODEL_REPO/autoship/hooks/opencode/setup.sh"
-cat > "$MODEL_REPO/bin/gh" <<'SH'
-#!/usr/bin/env bash
-if [[ "$1 $2" == "auth status" ]]; then
-  exit 0
-fi
-exit 0
-SH
-cat > "$MODEL_REPO/bin/opencode" <<'SH'
-#!/usr/bin/env bash
-if [[ "$1" == "models" ]]; then
-  printf '%s\n' 'opencode/nemotron-3-super-free' 'opencode/minimax-m2.5-free' 'openai/gpt-5.5' 'openai/gpt-5.3-codex-spark'
-  exit 0
-fi
-printf '%s\n' '1.0.0'
-SH
-chmod +x "$MODEL_REPO/bin/gh" "$MODEL_REPO/bin/opencode"
+install_mock_opencode_models_fixture "$MODEL_REPO/bin"
 (
   cd "$MODEL_REPO/autoship"
   PATH="$MODEL_REPO/bin:$PATH" bash hooks/opencode/setup.sh --no-tui --max-agents=7 --labels=agent:ready,needs-review --worker-models=openai/gpt-5.3-codex-spark >/dev/null
@@ -123,6 +109,21 @@ assert_eq "openai/gpt-5.3-codex-spark" "$(jq -r '.models[0].id' "$MODEL_REPO/aut
 assert_eq "selected" "$(jq -r '.models[0].cost' "$MODEL_REPO/autoship/.autoship/model-routing.json")" "setup classifies explicit worker model as selected"
 assert_eq "7" "$(jq -r '.maxConcurrentAgents' "$MODEL_REPO/autoship/.autoship/config.json")" "setup honors portable --max-agents flag"
 assert_eq "agent:ready,needs-review" "$(jq -r '.labels | join(",")' "$MODEL_REPO/autoship/.autoship/config.json")" "setup honors portable --labels flag"
+
+echo "=== Test: setup fixture defaults to free models only ==="
+FREE_REPO="$TMP_DIR/free-model-repo"
+mkdir -p "$FREE_REPO/bin" "$FREE_REPO/autoship/hooks/opencode"
+cp "$SCRIPT_DIR/setup.sh" "$SCRIPT_DIR/model-parser.sh" "$FREE_REPO/autoship/hooks/opencode/"
+chmod +x "$FREE_REPO/autoship/hooks/opencode/setup.sh"
+install_mock_opencode_models_fixture "$FREE_REPO/bin"
+(
+  cd "$FREE_REPO/autoship"
+  PATH="$FREE_REPO/bin:$PATH" bash hooks/opencode/setup.sh --no-tui --planner-model=openai/gpt-5.5 >/dev/null
+)
+assert_eq "2" "$(jq '[.models[] | select(.cost == "free")] | length' "$FREE_REPO/autoship/.autoship/model-routing.json")" "setup fixture free defaults include only free workers"
+if jq -e '.pools.default.models[] | select(. == "openai/gpt-5.5" or . == "openai/gpt-5.3-codex-spark")' "$FREE_REPO/autoship/.autoship/model-routing.json" >/dev/null; then
+  fail "setup default worker pool must not include paid or role models from fixture"
+fi
 
 echo "=== Test: setup rejects unavailable and forbidden models ==="
 if (cd "$MODEL_REPO/autoship" && PATH="$MODEL_REPO/bin:$PATH" bash hooks/opencode/setup.sh --no-tui --refresh-models --worker-models=missing/model >/dev/null 2>&1); then


### PR DESCRIPTION
## Summary
- Add a shared mocked `opencode models` fixture with deterministic free, selected, planner, and Spark models.
- Update setup/model parsing tests to use mocked model inventory instead of live APIs.
- Update smoke coverage to avoid paid/live model API dependency.

## Verification
- `bash hooks/opencode/test-policy.sh`
- `bash -n hooks/opencode/*.sh hooks/*.sh`
- `bash hooks/opencode/smoke-test.sh`
- `bash -n hooks/opencode/test-fixtures/*.sh && bash hooks/opencode/test-model-parsing.sh`

Closes #186