### PR TITLE
feat: Handle complete blocked and stuck workspace events (#180)

### DIFF
--- a/hooks/opencode/process-event-queue.sh
+++ b/hooks/opencode/process-event-queue.sh
@@ -99,11 +99,11 @@ process_event() {
       ;;
     stuck)
       [[ -n "$issue" ]] || return 1
-      apply_state_once "$issue" set-failed blocked
+      apply_state_once "$issue" set-stuck stuck
       ;;
     verify)
       [[ -n "$issue" ]] || return 1
-      apply_state_once "$issue" set-completed completed
+      apply_state_once "$issue" set-verifying verifying
       ;;
     force_dispatch)
       [[ -n "$issue" ]] || return 1

--- a/hooks/opencode/process-event-queue.sh
+++ b/hooks/opencode/process-event-queue.sh
@@ -191,7 +191,6 @@ verify_and_create_pr() {
   run_verification "$issue"
   verification_status=$?
   if [[ $verification_status -eq 2 ]]; then
-    apply_state_once "$issue" set-completed completed
     return 0
   fi
   if [[ $verification_status -ne 0 ]]; then

--- a/hooks/opencode/reconcile-state.sh
+++ b/hooks/opencode/reconcile-state.sh
@@ -27,9 +27,9 @@ for dir in "$WORKSPACES_DIR"/*/; do
   [[ -f "$status_file" ]] || continue
   status=$(tr -d '[:space:]' < "$status_file")
   case "$status" in
-    COMPLETE) new_state="completed"; action="set-completed" ;;
+    COMPLETE) new_state="verifying"; action="set-verifying" ;;
     BLOCKED) new_state="blocked"; action="set-blocked" ;;
-    STUCK) new_state="stuck"; action="set-failed" ;;
+    STUCK) new_state="stuck"; action="set-stuck" ;;
     RUNNING) new_state="running"; action="set-running" ;;
     QUEUED) new_state="queued"; action="set-queued" ;;
     *) continue ;;

--- a/hooks/opencode/runner.sh
+++ b/hooks/opencode/runner.sh
@@ -89,11 +89,11 @@ mark_stuck_unless_terminal() {
   case "$current" in
     COMPLETE|BLOCKED|STUCK) ;;
     *)
-      echo "STUCK" > status
       if [[ -x "$repo_root/hooks/capture-failure.sh" ]]; then
         error_msg=$(tail -5 AUTOSHIP_RUNNER.log 2>/dev/null || echo "worker exited without terminal status")
         bash "$repo_root/hooks/capture-failure.sh" stuck "$wid" "error_summary=$error_msg" 2>/dev/null || true
       fi
+      echo "STUCK" > status
       ;;
   esac
 }

--- a/hooks/opencode/test-policy.sh
+++ b/hooks/opencode/test-policy.sh
@@ -82,18 +82,20 @@ touch -t 202604230000 "$STATE_REPO/.autoship/workspaces/issue-752/AUTOSHIP_RESUL
 touch -t 202604240000 "$STATE_REPO/.autoship/workspaces/issue-752/started_at"
 
 bash "$SCRIPT_DIR/reconcile-state.sh" --repo "$STATE_REPO" >/dev/null
-assert_eq "completed" "$(jq -r '.issues["issue-746"].state' "$STATE_REPO/.autoship/state.json")" "COMPLETE workspace reconciles to completed"
+assert_eq "verifying" "$(jq -r '.issues["issue-746"].state' "$STATE_REPO/.autoship/state.json")" "COMPLETE workspace reconciles to verifying"
 assert_eq "blocked" "$(jq -r '.issues["issue-749"].state' "$STATE_REPO/.autoship/state.json")" "BLOCKED workspace reconciles to blocked"
 assert_eq "running" "$(jq -r '.issues["issue-750"].state' "$STATE_REPO/.autoship/state.json")" "RUNNING workspace remains running"
 assert_eq "queued" "$(jq -r '.issues["issue-751"].state' "$STATE_REPO/.autoship/state.json")" "QUEUED workspace remains queued"
+assert_eq "stuck" "$(jq -r '.issues["issue-752"].state' "$STATE_REPO/.autoship/state.json")" "STUCK workspace reconciles to stuck"
 assert_eq "false" "$(jq -r '.issues["issue-752"].has_result' "$STATE_REPO/.autoship/state.json")" "stale result older than started_at is ignored"
-assert_eq "1" "$(jq -r '.stats.session_completed' "$STATE_REPO/.autoship/state.json")" "reconcile increments completion stats"
+assert_eq "0" "$(jq -r '.stats.session_completed // 0' "$STATE_REPO/.autoship/state.json")" "reconcile does not count completion before review"
 assert_eq "1" "$(jq -r '.stats.blocked' "$STATE_REPO/.autoship/state.json")" "reconcile increments blocked stats"
+assert_eq "1" "$(jq -r '.stats.failed' "$STATE_REPO/.autoship/state.json")" "reconcile increments failed stats for stuck workspaces"
 
 STATUS_OUTPUT=$(bash "$SCRIPT_DIR/status.sh" --repo "$STATE_REPO")
 printf '%s\n' "$STATUS_OUTPUT" | grep -F 'AGENTS (1 active / 15 max)' >/dev/null || fail "status shows active/max concurrency"
 printf '%s\n' "$STATUS_OUTPUT" | grep -F 'Queued:    1' >/dev/null || fail "status shows queued count"
-printf '%s\n' "$STATUS_OUTPUT" | grep -F 'Completed: 1' >/dev/null || fail "status shows completed count"
+printf '%s\n' "$STATUS_OUTPUT" | grep -F 'Completed: 0' >/dev/null || fail "status shows completed count"
 printf '%s\n' "$STATUS_OUTPUT" | grep -F 'Blocked:   1' >/dev/null || fail "status shows blocked count"
 
 NO_RUNNING_REPO="$TMP_DIR/no-running-repo"
@@ -248,7 +250,7 @@ cp "$SCRIPT_DIR/process-event-queue.sh" "$QUEUE_REPO/hooks/opencode/process-even
 cp "$SCRIPT_DIR/../update-state.sh" "$QUEUE_REPO/hooks/update-state.sh"
 chmod +x "$QUEUE_REPO/hooks/opencode/process-event-queue.sh" "$QUEUE_REPO/hooks/update-state.sh"
 cat > "$QUEUE_REPO/.autoship/state.json" <<'JSON'
-{"repo":"owner/repo","issues":{"issue-991":{"state":"running"},"issue-992":{"state":"running"}},"stats":{}}
+{"repo":"owner/repo","issues":{"issue-991":{"state":"running"},"issue-992":{"state":"running"},"issue-993":{"state":"running"}},"stats":{}}
 JSON
 printf '{"sessions":[]}' > "$QUEUE_REPO/.autoship/token-ledger.json"
 cat > "$QUEUE_REPO/.autoship/event-queue.json" <<'JSON'
@@ -256,7 +258,9 @@ cat > "$QUEUE_REPO/.autoship/event-queue.json" <<'JSON'
   {"type":"blocked","issue":"issue-991","priority":2,"data":{"status":"BLOCKED"},"queued_at":"2026-04-24T00:00:00Z"},
   {"type":"blocked","issue":"issue-991","priority":2,"data":{"status":"BLOCKED"},"queued_at":"2026-04-24T00:00:01Z"},
   {"type":"verify","issue":"issue-992","priority":2,"data":{"status":"COMPLETE"},"queued_at":"2026-04-24T00:00:02Z"},
-  {"type":"verify","issue":"issue-992","priority":2,"data":{"status":"COMPLETE"},"queued_at":"2026-04-24T00:00:03Z"}
+  {"type":"verify","issue":"issue-992","priority":2,"data":{"status":"COMPLETE"},"queued_at":"2026-04-24T00:00:03Z"},
+  {"type":"stuck","issue":"issue-993","priority":2,"data":{"status":"STUCK"},"queued_at":"2026-04-24T00:00:04Z"},
+  {"type":"stuck","issue":"issue-993","priority":2,"data":{"status":"STUCK"},"queued_at":"2026-04-24T00:00:05Z"}
 ]
 JSON
 (
@@ -264,11 +268,13 @@ JSON
   bash hooks/opencode/process-event-queue.sh >/dev/null
 )
 assert_eq "blocked" "$(jq -r '.issues["issue-991"].state' "$QUEUE_REPO/.autoship/state.json")" "event processor applies blocked event"
-assert_eq "completed" "$(jq -r '.issues["issue-992"].state' "$QUEUE_REPO/.autoship/state.json")" "event processor applies verify event"
+assert_eq "verifying" "$(jq -r '.issues["issue-992"].state' "$QUEUE_REPO/.autoship/state.json")" "event processor advances COMPLETE event to verification"
+assert_eq "stuck" "$(jq -r '.issues["issue-993"].state' "$QUEUE_REPO/.autoship/state.json")" "event processor applies stuck event"
 assert_eq "1" "$(jq -r '.stats.blocked' "$QUEUE_REPO/.autoship/state.json")" "duplicate blocked events do not double-update stats"
-assert_eq "1" "$(jq -r '.stats.session_completed' "$QUEUE_REPO/.autoship/state.json")" "duplicate verify events do not double-update completion stats"
+assert_eq "0" "$(jq -r '.stats.session_completed // 0' "$QUEUE_REPO/.autoship/state.json")" "verify events do not count completion before review"
+assert_eq "1" "$(jq -r '.stats.failed' "$QUEUE_REPO/.autoship/state.json")" "duplicate stuck events do not double-update failed stats"
 assert_eq "0" "$(jq 'length' "$QUEUE_REPO/.autoship/event-queue.json")" "event processor drains processed duplicate events"
-assert_eq "2" "$(jq 'length' "$QUEUE_REPO/.autoship/processed-events.json")" "event processor records only unique semantic events"
+assert_eq "3" "$(jq 'length' "$QUEUE_REPO/.autoship/processed-events.json")" "event processor records only unique semantic events"
 
 grep -F 'AUTOSHIP_VERSION="1.5.0-opencode"' "$SCRIPT_DIR/init.sh" >/dev/null 2>&1 && fail "init must not hardcode stale 1.5.0-opencode version"
 

--- a/hooks/update-state.sh
+++ b/hooks/update-state.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # update-state.sh — Update .autoship/state.json for a given issue.
 # Usage: update-state.sh <action> <issue-id> [key=value ...]
-# Actions: set-claimed, set-queued, set-running, set-verifying, set-completed, set-blocked, set-merged, set-failed, set-paused
+# Actions: set-claimed, set-queued, set-running, set-verifying, set-completed, set-blocked, set-stuck, set-merged, set-failed, set-paused
 
 AUTOSHIP_DIR=".autoship"
 STATE_FILE="$AUTOSHIP_DIR/state.json"
@@ -50,7 +50,7 @@ fi
 
 if [[ $# -lt 2 ]]; then
   echo "Usage: $0 <action> <issue-id> [key=value ...]" >&2
-  echo "Actions: set-claimed, set-queued, set-running, set-verifying, set-completed, set-blocked, set-merged, set-failed, set-paused" >&2
+  echo "Actions: set-claimed, set-queued, set-running, set-verifying, set-completed, set-blocked, set-stuck, set-merged, set-failed, set-paused" >&2
   exit 1
 fi
 
@@ -264,6 +264,12 @@ case "$ACTION" in
     ADD_LABEL="autoship:blocked"
     REMOVE_LABELS=("autoship:in-progress" "autoship:paused" "autoship:done")
     ;;
+  set-stuck)
+    NEW_STATE="stuck"
+    STAT_KEY="failed"
+    ADD_LABEL="autoship:blocked"
+    REMOVE_LABELS=("autoship:in-progress" "autoship:paused" "autoship:done")
+    ;;
   set-merged)
     NEW_STATE="merged"
     STAT_KEY="completed"  # signals: increment session_completed + total_completed_all_time
@@ -284,7 +290,7 @@ case "$ACTION" in
     ;;
   *)
     echo "Error: unknown action '$ACTION'" >&2
-    echo "Valid actions: set-claimed, set-running, set-verifying, set-completed, set-blocked, set-merged, set-failed, set-paused" >&2
+    echo "Valid actions: set-claimed, set-queued, set-running, set-verifying, set-completed, set-blocked, set-stuck, set-merged, set-failed, set-paused" >&2
     exit 1
     ;;
 esac


### PR DESCRIPTION
## Summary
- Advance COMPLETE workspaces to verifying and keep verify events at verifying until result artifacts exist.
- Add explicit stuck state handling and stats for STUCK workspaces/events.
- Cover BLOCKED, COMPLETE, and STUCK terminal workspace statuses in policy tests.

## Verification
- `bash hooks/opencode/test-policy.sh`
- `bash -n hooks/opencode/*.sh hooks/*.sh`
- `bash hooks/opencode/smoke-test.sh`

Closes #180