### PR TITLE
feat: Parse reviewer verdict and record failure evidence (#183)

### DIFF
--- a/hooks/opencode/reviewer.sh
+++ b/hooks/opencode/reviewer.sh
@@ -40,14 +40,36 @@ Required checks:
 Be strict: partial implementation is FAIL.
 EOF
 
-(
+set +e
+reviewer_output=$(
   cd "$WORKTREE_PATH"
-  opencode run --model "$MODEL" "$(cat "$PROMPT_FILE")"
-) || {
-  echo "VERDICT: FAIL — reviewer model failed"
-  REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
-  if [[ -x "$REPO_ROOT/hooks/capture-failure.sh" ]]; then
-    bash "$REPO_ROOT/hooks/capture-failure.sh" reviewer_rejection "$ISSUE_KEY" "error_summary=reviewer model failed with non-zero exit" 2>/dev/null || true
-  fi
-  exit 1
-}
+  opencode run --model "$MODEL" "$(cat "$PROMPT_FILE")" 2>&1
+)
+reviewer_status=$?
+set -e
+
+printf '%s\n' "$reviewer_output"
+
+verdict_line=$(printf '%s\n' "$reviewer_output" | grep -E '^VERDICT: (PASS|FAIL)([^A-Z]|$)' | head -1 || true)
+error_summary=""
+
+if [[ $reviewer_status -ne 0 ]]; then
+  error_summary="reviewer model failed with non-zero exit"
+elif [[ -z "$verdict_line" ]]; then
+  error_summary="missing or malformed reviewer verdict"
+elif [[ "$verdict_line" == VERDICT:\ PASS* ]]; then
+  exit 0
+else
+  error_summary="reviewer returned FAIL verdict"
+fi
+
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+if [[ -x "$REPO_ROOT/hooks/capture-failure.sh" ]]; then
+  tmp_log=$(mktemp)
+  printf '%s\n' "$reviewer_output" > "$tmp_log"
+  AUTOSHIP_FAILURE_LOG="$tmp_log" bash "$REPO_ROOT/hooks/capture-failure.sh" reviewer_rejection "$ISSUE_KEY" "error_summary=$error_summary" 2>/dev/null || true
+  rm -f "$tmp_log"
+fi
+
+echo "VERDICT: FAIL — $error_summary"
+exit 1

--- a/hooks/opencode/test-policy.sh
+++ b/hooks/opencode/test-policy.sh
@@ -438,6 +438,46 @@ grep -F -- '--body-file .autoship/workspaces/issue-184/AUTOSHIP_PR_BODY.md' "$VE
 grep -F 'Reviewer: PASS' "$VERIFY_PASS_REPO/.autoship/workspaces/issue-184/AUTOSHIP_PR_BODY.md" >/dev/null || fail "generated PR body records reviewer pass"
 assert_eq "completed" "$(jq -r '.issues["issue-184"].state' "$VERIFY_PASS_REPO/.autoship/state.json")" "verified PASS completes issue after PR creation"
 
+REVIEWER_REPO="$TMP_DIR/reviewer-repo"
+mkdir -p "$REVIEWER_REPO/hooks/opencode" "$REVIEWER_REPO/hooks" "$REVIEWER_REPO/bin" "$REVIEWER_REPO/.autoship/workspaces/issue-183"
+git init -q "$REVIEWER_REPO"
+cp "$SCRIPT_DIR/reviewer.sh" "$REVIEWER_REPO/hooks/opencode/reviewer.sh"
+cp "$SCRIPT_DIR/select-model.sh" "$REVIEWER_REPO/hooks/opencode/select-model.sh"
+cp "$SCRIPT_DIR/../capture-failure.sh" "$REVIEWER_REPO/hooks/capture-failure.sh"
+chmod +x "$REVIEWER_REPO/hooks/opencode/reviewer.sh" "$REVIEWER_REPO/hooks/opencode/select-model.sh" "$REVIEWER_REPO/hooks/capture-failure.sh"
+cat > "$REVIEWER_REPO/.autoship/state.json" <<'JSON'
+{"repo":"owner/repo","issues":{"issue-183":{"state":"verifying","model":"opencode/test","role":"reviewer","attempt":1}},"stats":{},"config":{"maxConcurrentAgents":15}}
+JSON
+printf 'result\n' > "$REVIEWER_REPO/.autoship/workspaces/issue-183/AUTOSHIP_RESULT.md"
+cat > "$REVIEWER_REPO/bin/opencode" <<'SH'
+#!/usr/bin/env bash
+case "${AUTOSHIP_FAKE_REVIEW:-pass}" in
+  pass) printf 'analysis\nVERDICT: PASS\n' ;;
+  fail) printf 'analysis\nVERDICT: FAIL\n' ;;
+  missing) printf 'analysis without verdict\n' ;;
+esac
+exit 0
+SH
+chmod +x "$REVIEWER_REPO/bin/opencode"
+(
+  cd "$REVIEWER_REPO"
+  PATH="$REVIEWER_REPO/bin:$PATH" AUTOSHIP_FAKE_REVIEW=pass bash hooks/opencode/reviewer.sh issue-183 .autoship/workspaces/issue-183 .autoship/workspaces/issue-183/AUTOSHIP_RESULT.md none >/tmp/reviewer-pass.out
+)
+if (
+  cd "$REVIEWER_REPO"
+  PATH="$REVIEWER_REPO/bin:$PATH" AUTOSHIP_FAKE_REVIEW=fail bash hooks/opencode/reviewer.sh issue-183 .autoship/workspaces/issue-183 .autoship/workspaces/issue-183/AUTOSHIP_RESULT.md none >/tmp/reviewer-fail.out 2>&1
+); then
+  fail "reviewer exits non-zero on explicit FAIL verdict"
+fi
+if (
+  cd "$REVIEWER_REPO"
+  PATH="$REVIEWER_REPO/bin:$PATH" AUTOSHIP_FAKE_REVIEW=missing bash hooks/opencode/reviewer.sh issue-183 .autoship/workspaces/issue-183 .autoship/workspaces/issue-183/AUTOSHIP_RESULT.md none >/tmp/reviewer-missing.out 2>&1
+); then
+  fail "reviewer fails closed when verdict is missing"
+fi
+reviewer_artifacts=$(find "$REVIEWER_REPO/.autoship/failures" -name '*-issue-183.json' 2>/dev/null | wc -l | tr -d '[:space:]')
+[[ "$reviewer_artifacts" -ge 1 ]] || fail "reviewer records failure evidence for rejected and malformed verdicts"
+
 grep -F 'AUTOSHIP_VERSION="1.5.0-opencode"' "$SCRIPT_DIR/init.sh" >/dev/null 2>&1 && fail "init must not hardcode stale 1.5.0-opencode version"
 
 INIT_REPO="$TMP_DIR/init-repo"


### PR DESCRIPTION
## Summary
- Capture reviewer model output and parse explicit `VERDICT: PASS` / `VERDICT: FAIL` lines.
- Fail closed on missing or malformed verdicts.
- Record structured `reviewer_rejection` artifacts with reviewer output for failures.

## Verification
- `bash hooks/opencode/test-policy.sh`
- `bash -n hooks/opencode/*.sh hooks/*.sh`
- `bash hooks/opencode/smoke-test.sh`

Closes #183