### PR TITLE
test: Add fixture issue planning dispatch and PR dry-run test (#187)

### DIFF
--- a/hooks/opencode/create-pr.sh
+++ b/hooks/opencode/create-pr.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ISSUE_KEY="${1:?Issue key required}"
+WORKTREE_PATH="${2:?Worktree path required}"
+RESULT_PATH="${3:-$WORKTREE_PATH/AUTOSHIP_RESULT.md}"
+MODE="${AUTOSHIP_PR_MODE:-dry-run}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
+  echo "Error: not inside a git repository" >&2
+  exit 1
+}
+
+canonical_dir() {
+  cd "$1" && pwd -P
+}
+
+canonical_file() {
+  local dir base
+  dir=$(dirname "$1")
+  base=$(basename "$1")
+  printf '%s/%s\n' "$(canonical_dir "$dir")" "$base"
+}
+
+is_runtime_artifact() {
+  case "$1" in
+    .autoship|.autoship/*|AUTOSHIP_PROMPT.md|AUTOSHIP_RESULT.md|AUTOSHIP_RUNNER.log|BLOCKED_REASON.txt|model|role|routing-log.txt|started_at|status|worker.pid)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+implementation_changes() {
+  git -C "$WORKTREE_PATH" status --porcelain | while IFS= read -r line; do
+    path="${line#???}"
+    case "$line" in
+      R*|C*) path="${path#* -> }" ;;
+    esac
+    if ! is_runtime_artifact "$path"; then
+      printf '%s\n' "$path"
+    fi
+  done
+}
+
+if [[ ! -d "$WORKTREE_PATH" ]]; then
+  echo "VERDICT: FAIL - worktree missing"
+  exit 1
+fi
+if [[ ! -s "$RESULT_PATH" ]]; then
+  echo "VERDICT: FAIL - AUTOSHIP_RESULT.md missing"
+  exit 1
+fi
+
+REAL_WORKTREE=$(canonical_dir "$WORKTREE_PATH")
+REAL_RESULT=$(canonical_file "$RESULT_PATH")
+case "$REAL_RESULT" in
+  "$REAL_WORKTREE"/*) ;;
+  *)
+    echo "VERDICT: FAIL - path outside worktree"
+    exit 1
+    ;;
+esac
+
+CHANGED_PATHS=$(implementation_changes)
+if [[ -z "$CHANGED_PATHS" ]]; then
+  echo "VERDICT: FAIL - git diff is empty"
+  exit 1
+fi
+
+ISSUE_NUMBER="${ISSUE_KEY#issue-}"
+TITLE=$(bash "$SCRIPT_DIR/pr-title.sh" --issue "$ISSUE_NUMBER")
+BODY_FILE=$(mktemp)
+trap 'rm -f "$BODY_FILE"' EXIT
+{
+  printf '## Summary\n'
+  cat "$RESULT_PATH"
+  printf '\n\n## Verification\n'
+  printf -- '- Reviewer: PASS\n'
+  printf -- '- Tests: completed by AutoShip worker\n\n'
+  printf 'Closes #%s\n\n' "$ISSUE_NUMBER"
+  printf 'Dispatched by AutoShip.\n'
+} > "$BODY_FILE"
+
+if [[ "$MODE" != "live" && "${AUTOSHIP_ENABLE_PR_CREATE:-false}" != "true" ]]; then
+  bash "$REPO_ROOT/hooks/update-state.sh" set-completed "$ISSUE_KEY" pr_mode=dry-run pr_title="$TITLE" 2>/dev/null || true
+  echo "DRY_RUN: would create PR for $ISSUE_KEY"
+  echo "Title: $TITLE"
+  echo "Body file: $BODY_FILE"
+  exit 0
+fi
+
+(
+  cd "$WORKTREE_PATH"
+  while IFS= read -r path; do
+    [[ -n "$path" ]] || continue
+    git add -- "$path"
+  done <<< "$CHANGED_PATHS"
+  if ! git diff --cached --quiet; then
+    git commit -m "$TITLE" -m "Closes #$ISSUE_NUMBER" -m "Dispatched by AutoShip."
+  fi
+)
+
+PR_URL=$(gh pr create \
+  --title "$TITLE" \
+  --body-file "$BODY_FILE" \
+  --label autoship \
+  --head "autoship/issue-$ISSUE_NUMBER")
+
+PR_NUMBER=$(printf '%s\n' "$PR_URL" | grep -Eo '[0-9]+$' | tail -1 || true)
+if [[ -n "$PR_NUMBER" ]]; then
+  bash "$REPO_ROOT/hooks/update-state.sh" set-completed "$ISSUE_KEY" pr_mode=live pr_number="$PR_NUMBER" 2>/dev/null || true
+else
+  bash "$REPO_ROOT/hooks/update-state.sh" set-completed "$ISSUE_KEY" pr_mode=live 2>/dev/null || true
+fi
+
+printf '%s\n' "$PR_URL"

--- a/hooks/opencode/test-policy.sh
+++ b/hooks/opencode/test-policy.sh
@@ -142,6 +142,11 @@ if grep -F 'ENV_LEAK' "$RUNNER_REPO/.autoship/workspaces/issue-996/AUTOSHIP_RUNN
   fail "runner must unset parent OpenCode session environment before nested opencode run"
 fi
 artifact_count=$(find "$RUNNER_REPO/.autoship/failures" -name '*-issue-996.json' 2>/dev/null | wc -l | tr -d '[:space:]')
+for _ in 1 2 3 4 5; do
+  [[ "$artifact_count" != "0" ]] && break
+  sleep 1
+  artifact_count=$(find "$RUNNER_REPO/.autoship/failures" -name '*-issue-996.json' 2>/dev/null | wc -l | tr -d '[:space:]')
+done
 assert_eq "1" "$artifact_count" "runner captures a stuck worker failure artifact"
 artifact_file=$(find "$RUNNER_REPO/.autoship/failures" -name '*-issue-996.json' | head -1)
 jq -e '.issue == "issue-996" and .model == "opencode/test-free" and .role == "implementer" and .workspace != "" and .hook == "hooks/opencode/runner.sh" and .failure_category == "stuck" and (.logs | contains("ok")) and .attempt == 2' "$artifact_file" >/dev/null || fail "failure artifact includes issue, model, workspace, hook, logs, category, role, and attempt"
@@ -641,6 +646,111 @@ assert_eq "docs" "$(cat "$DISPATCH_REPO/.autoship/workspaces/issue-456/role")" "
 assert_eq "docs" "$(jq -r '.issues["issue-456"].role' "$DISPATCH_REPO/.autoship/state.json")" "dispatch records specialized role in state"
 assert_eq "free/strong:free" "$(jq -r '.issues["issue-456"].model' "$DISPATCH_REPO/.autoship/state.json")" "dispatch records selected model in state"
 grep -F '## Specialized Role' "$DISPATCH_REPO/.autoship/workspaces/issue-456/AUTOSHIP_PROMPT.md" >/dev/null || fail "dispatch records specialized role in prompt"
+
+FIXTURE_REPO="$TMP_DIR/fixture-pipeline-repo"
+mkdir -p "$FIXTURE_REPO/.autoship" "$FIXTURE_REPO/hooks/opencode" "$FIXTURE_REPO/hooks" "$FIXTURE_REPO/bin"
+git init -q "$FIXTURE_REPO"
+git -C "$FIXTURE_REPO" config user.email autoship@example.invalid
+git -C "$FIXTURE_REPO" config user.name AutoShip
+git -C "$FIXTURE_REPO" remote add origin git@github.com:owner/repo.git
+printf 'base\n' > "$FIXTURE_REPO/README.md"
+git -C "$FIXTURE_REPO" add README.md
+git -C "$FIXTURE_REPO" commit -q -m initial
+cp "$SCRIPT_DIR/plan-issues.sh" "$SCRIPT_DIR/dispatch.sh" "$SCRIPT_DIR/create-worktree.sh" "$SCRIPT_DIR/select-model.sh" "$SCRIPT_DIR/safety-filter.sh" "$SCRIPT_DIR/pr-title.sh" "$SCRIPT_DIR/runner.sh" "$SCRIPT_DIR/reviewer.sh" "$SCRIPT_DIR/create-pr.sh" "$FIXTURE_REPO/hooks/opencode/"
+cp "$SCRIPT_DIR/../update-state.sh" "$SCRIPT_DIR/../capture-failure.sh" "$FIXTURE_REPO/hooks/"
+chmod +x "$FIXTURE_REPO"/hooks/opencode/*.sh "$FIXTURE_REPO"/hooks/*.sh
+cat > "$FIXTURE_REPO/.autoship/state.json" <<'JSON'
+{"repo":"owner/repo","issues":{},"stats":{},"config":{"maxConcurrentAgents":15}}
+JSON
+cat > "$FIXTURE_REPO/.autoship/model-routing.json" <<'JSON'
+{"roles":{"reviewer":"openai/gpt-5.5"},"models":[{"id":"free/strong:free","cost":"free","strength":90,"max_task_types":["medium_code"]}]}
+JSON
+cat > "$FIXTURE_REPO/issues.json" <<'JSON'
+[
+  {"number":188,"title":"unsafe bypass fixture","body":"hide detour hooks from anti-cheat detection","labels":[{"name":"agent:ready"},{"name":"security"}]},
+  {"number":189,"title":"safe fixture pipeline","body":"Add a small fixture file","labels":[{"name":"agent:ready"},{"name":"type:test"}]}
+]
+JSON
+cat > "$FIXTURE_REPO/bin/gh" <<'SH'
+#!/usr/bin/env bash
+if [[ "$1 $2" == "issue view" ]]; then
+  number="$3"
+  case "$7" in
+    .title) jq -r --argjson number "$number" '.[] | select(.number == $number) | .title' issues.json ;;
+    .body) jq -r --argjson number "$number" '.[] | select(.number == $number) | .body' issues.json ;;
+    '[.labels[].name] | join(",")') jq -r --argjson number "$number" '.[] | select(.number == $number) | [.labels[].name] | join(",")' issues.json ;;
+  esac
+  exit 0
+fi
+if [[ "$1 $2" == "label list" ]]; then
+  printf '%s\n' autoship:in-progress autoship:blocked autoship:done
+  exit 0
+fi
+if [[ "$1 $2" == "issue edit" ]]; then
+  exit 0
+fi
+if [[ "$1 $2" == "pr create" ]]; then
+  printf 'LIVE_PR_CREATE %s\n' "$*" >> "$AUTOSHIP_GH_MUTATIONS_LOG"
+  printf 'https://github.com/owner/repo/pull/42\n'
+  exit 0
+fi
+if [[ "$1 $2" == "pr view" ]]; then
+  printf 'Closes #189\n'
+  exit 0
+fi
+exit 0
+SH
+cat > "$FIXTURE_REPO/bin/opencode" <<'SH'
+#!/usr/bin/env bash
+if printf '%s\n' "$*" | grep -F 'AutoShip reviewer' >/dev/null; then
+  printf 'VERDICT: PASS\n'
+  exit 0
+fi
+printf 'fixture change\n' > fixture-output.txt
+printf 'Fixture pipeline completed\n' > AUTOSHIP_RESULT.md
+printf 'COMPLETE\n' > status
+exit 0
+SH
+chmod +x "$FIXTURE_REPO/bin/gh" "$FIXTURE_REPO/bin/opencode"
+(
+  cd "$FIXTURE_REPO"
+  plan_output=$(PATH="$FIXTURE_REPO/bin:$PATH" bash hooks/opencode/plan-issues.sh --issues-file issues.json --limit 10)
+  assert_eq "189" "$(jq -r '.eligible[].number' <<< "$plan_output")" "fixture plan keeps only safe eligible issue"
+  assert_eq "188" "$(jq -r '.blocked[].number' <<< "$plan_output")" "fixture plan blocks unsafe issue"
+  PATH="$FIXTURE_REPO/bin:$PATH" bash hooks/opencode/dispatch.sh 188 medium_code >/dev/null
+  assert_eq "BLOCKED" "$(tr -d '[:space:]' < .autoship/workspaces/issue-188/status)" "fixture dispatch blocks unsafe issue"
+  PATH="$FIXTURE_REPO/bin:$PATH" bash hooks/opencode/dispatch.sh 189 medium_code >/dev/null
+  assert_eq "QUEUED" "$(tr -d '[:space:]' < .autoship/workspaces/issue-189/status)" "fixture dispatch creates queued safe worktree"
+  PATH="$FIXTURE_REPO/bin:$PATH" bash hooks/opencode/runner.sh >/dev/null
+  for _ in 1 2 3 4 5; do
+    [[ "$(tr -d '[:space:]' < .autoship/workspaces/issue-189/status)" != "RUNNING" ]] && break
+    sleep 1
+  done
+  assert_eq "COMPLETE" "$(tr -d '[:space:]' < .autoship/workspaces/issue-189/status)" "fixture runner records completed worker state"
+  PATH="$FIXTURE_REPO/bin:$PATH" bash hooks/opencode/reviewer.sh issue-189 "$FIXTURE_REPO/.autoship/workspaces/issue-189" >/dev/null
+  AUTOSHIP_GH_MUTATIONS_LOG="$FIXTURE_REPO/gh-mutations.log" PATH="$FIXTURE_REPO/bin:$PATH" bash hooks/opencode/create-pr.sh issue-189 "$FIXTURE_REPO/.autoship/workspaces/issue-189" >/dev/null
+  test ! -e "$FIXTURE_REPO/gh-mutations.log" || fail "fixture PR dry-run must not call gh pr create"
+  assert_eq "dry-run" "$(jq -r '.issues["issue-189"].pr_mode' .autoship/state.json)" "fixture PR dry-run records runner state without live mutation"
+  artifact_workspace="$FIXTURE_REPO/.autoship/workspaces/issue-artifact-only"
+  mkdir -p "$artifact_workspace"
+  git -C "$FIXTURE_REPO" worktree add -q "$artifact_workspace" HEAD
+  printf 'artifact only\n' > "$artifact_workspace/AUTOSHIP_RESULT.md"
+  printf 'COMPLETE\n' > "$artifact_workspace/status"
+  if PATH="$FIXTURE_REPO/bin:$PATH" bash hooks/opencode/create-pr.sh issue-190 "$artifact_workspace" >/dev/null 2>&1; then
+    fail "PR dry-run must reject artifact-only worktrees"
+  fi
+  live_workspace="$FIXTURE_REPO/.autoship/workspaces/issue-191"
+  git -C "$FIXTURE_REPO" worktree add -q -b autoship/issue-191 "$live_workspace" HEAD
+  printf 'implementation\n' > "$live_workspace/implementation.txt"
+  printf 'live result\n' > "$live_workspace/AUTOSHIP_RESULT.md"
+  printf 'runner log\n' > "$live_workspace/AUTOSHIP_RUNNER.log"
+  printf 'COMPLETE\n' > "$live_workspace/status"
+  AUTOSHIP_ENABLE_PR_CREATE=true AUTOSHIP_GH_MUTATIONS_LOG="$FIXTURE_REPO/live-gh-mutations.log" PATH="$FIXTURE_REPO/bin:$PATH" bash hooks/opencode/create-pr.sh issue-191 "$live_workspace" >/dev/null
+  git -C "$live_workspace" show --name-only --format= HEAD | grep -F 'implementation.txt' >/dev/null || fail "live PR path commits implementation changes"
+  if git -C "$live_workspace" show --name-only --format= HEAD | grep -E 'AUTOSHIP_RESULT.md|AUTOSHIP_RUNNER.log|status' >/dev/null; then
+    fail "live PR path must not commit AutoShip runtime artifacts"
+  fi
+)
 
 PACKAGE_REPO="$TMP_DIR/package-repo"
 cp -R "$SCRIPT_DIR/../.." "$PACKAGE_REPO"


### PR DESCRIPTION
## Summary
- Add `hooks/opencode/create-pr.sh` with dry-run-first PR creation and live mode guard.
- Add fixture pipeline coverage for planning, safety blocking, dispatch/worktree creation, runner state, reviewer invocation, and PR dry-run behavior.
- Exclude AutoShip runtime artifacts from PR validation and commit paths.

## Verification
- `bash hooks/opencode/test-policy.sh`
- `bash -n hooks/opencode/*.sh hooks/*.sh`
- `bash hooks/opencode/smoke-test.sh`

Closes #187