### PR TITLE
feat: Implement deterministic verification hook (#182)

### DIFF
--- a/hooks/opencode/process-event-queue.sh
+++ b/hooks/opencode/process-event-queue.sh
@@ -110,22 +110,15 @@ discover_test_command() {
 run_verification() {
   local issue="$1"
   local workspace="$WORKSPACES_DIR/$issue"
-  local result_path="$workspace/AUTOSHIP_RESULT.md"
-  local test_command reviewer_output
+  local test_command
 
   [[ -d "$workspace" ]] || return 2
-  [[ -s "$result_path" ]] || return 1
 
   test_command=$(discover_test_command)
-  reviewer_output=$(mktemp)
-  if bash "$SCRIPT_DIR/reviewer.sh" "$issue" "$workspace" "$result_path" "$test_command" > "$reviewer_output" 2>&1 && grep -F 'VERDICT: PASS' "$reviewer_output" >/dev/null 2>&1; then
-    rm -f "$reviewer_output"
+  if bash "$SCRIPT_DIR/verify-result.sh" "$issue" "$workspace" "$test_command" >/dev/null 2>&1; then
     return 0
   fi
 
-  mkdir -p "$workspace"
-  cp "$reviewer_output" "$workspace/AUTOSHIP_VERIFICATION.log" 2>/dev/null || true
-  rm -f "$reviewer_output"
   return 1
 }
 

--- a/hooks/opencode/test-policy.sh
+++ b/hooks/opencode/test-policy.sh
@@ -334,8 +334,9 @@ git -C "$VERIFY_FAIL_REPO" checkout -q -b autoship/issue-184
 printf 'changed\n' > "$VERIFY_FAIL_REPO/feature.txt"
 cp "$SCRIPT_DIR/process-event-queue.sh" "$VERIFY_FAIL_REPO/hooks/opencode/process-event-queue.sh"
 cp "$SCRIPT_DIR/pr-title.sh" "$VERIFY_FAIL_REPO/hooks/opencode/pr-title.sh"
+cp "$SCRIPT_DIR/verify-result.sh" "$VERIFY_FAIL_REPO/hooks/opencode/verify-result.sh"
 cp "$SCRIPT_DIR/../update-state.sh" "$VERIFY_FAIL_REPO/hooks/update-state.sh"
-chmod +x "$VERIFY_FAIL_REPO/hooks/opencode/process-event-queue.sh" "$VERIFY_FAIL_REPO/hooks/opencode/pr-title.sh" "$VERIFY_FAIL_REPO/hooks/update-state.sh"
+chmod +x "$VERIFY_FAIL_REPO/hooks/opencode/process-event-queue.sh" "$VERIFY_FAIL_REPO/hooks/opencode/pr-title.sh" "$VERIFY_FAIL_REPO/hooks/opencode/verify-result.sh" "$VERIFY_FAIL_REPO/hooks/update-state.sh"
 cat > "$VERIFY_FAIL_REPO/hooks/opencode/reviewer.sh" <<'SH'
 #!/usr/bin/env bash
 printf 'VERDICT: FAIL\n'
@@ -391,8 +392,9 @@ git -C "$VERIFY_PASS_REPO" checkout -q -b autoship/issue-184
 printf 'changed\n' > "$VERIFY_PASS_REPO/feature.txt"
 cp "$SCRIPT_DIR/process-event-queue.sh" "$VERIFY_PASS_REPO/hooks/opencode/process-event-queue.sh"
 cp "$SCRIPT_DIR/pr-title.sh" "$VERIFY_PASS_REPO/hooks/opencode/pr-title.sh"
+cp "$SCRIPT_DIR/verify-result.sh" "$VERIFY_PASS_REPO/hooks/opencode/verify-result.sh"
 cp "$SCRIPT_DIR/../update-state.sh" "$VERIFY_PASS_REPO/hooks/update-state.sh"
-chmod +x "$VERIFY_PASS_REPO/hooks/opencode/process-event-queue.sh" "$VERIFY_PASS_REPO/hooks/opencode/pr-title.sh" "$VERIFY_PASS_REPO/hooks/update-state.sh"
+chmod +x "$VERIFY_PASS_REPO/hooks/opencode/process-event-queue.sh" "$VERIFY_PASS_REPO/hooks/opencode/pr-title.sh" "$VERIFY_PASS_REPO/hooks/opencode/verify-result.sh" "$VERIFY_PASS_REPO/hooks/update-state.sh"
 cat > "$VERIFY_PASS_REPO/hooks/opencode/reviewer.sh" <<'SH'
 #!/usr/bin/env bash
 printf 'VERDICT: PASS\n'
@@ -437,6 +439,97 @@ grep -F 'pr create --title feat: Create PR after verified PASS (#184)' "$VERIFY_
 grep -F -- '--body-file .autoship/workspaces/issue-184/AUTOSHIP_PR_BODY.md' "$VERIFY_PASS_REPO/gh-pr.log" >/dev/null || fail "verified PASS creates PR from generated body file"
 grep -F 'Reviewer: PASS' "$VERIFY_PASS_REPO/.autoship/workspaces/issue-184/AUTOSHIP_PR_BODY.md" >/dev/null || fail "generated PR body records reviewer pass"
 assert_eq "completed" "$(jq -r '.issues["issue-184"].state' "$VERIFY_PASS_REPO/.autoship/state.json")" "verified PASS completes issue after PR creation"
+
+VERIFY_HOOK_PASS_REPO="$TMP_DIR/verify-hook-pass-repo"
+mkdir -p "$VERIFY_HOOK_PASS_REPO/.autoship/workspaces/issue-182" "$VERIFY_HOOK_PASS_REPO/hooks/opencode"
+git init -q "$VERIFY_HOOK_PASS_REPO"
+git -C "$VERIFY_HOOK_PASS_REPO" config user.email autoship@example.invalid
+git -C "$VERIFY_HOOK_PASS_REPO" config user.name AutoShip
+printf 'base\n' > "$VERIFY_HOOK_PASS_REPO/README.md"
+git -C "$VERIFY_HOOK_PASS_REPO" add README.md
+git -C "$VERIFY_HOOK_PASS_REPO" commit -q -m initial
+git -C "$VERIFY_HOOK_PASS_REPO" checkout -q -b autoship/issue-182
+printf 'changed\n' > "$VERIFY_HOOK_PASS_REPO/feature.txt"
+git -C "$VERIFY_HOOK_PASS_REPO" add feature.txt
+git -C "$VERIFY_HOOK_PASS_REPO" commit -q -m 'feat: issue 182'
+cp "$SCRIPT_DIR/verify-result.sh" "$VERIFY_HOOK_PASS_REPO/hooks/opencode/verify-result.sh"
+chmod +x "$VERIFY_HOOK_PASS_REPO/hooks/opencode/verify-result.sh"
+cat > "$VERIFY_HOOK_PASS_REPO/hooks/opencode/reviewer.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'VERDICT: PASS\n'
+SH
+chmod +x "$VERIFY_HOOK_PASS_REPO/hooks/opencode/reviewer.sh"
+printf '2026-04-24T00:00:00Z\n' > "$VERIFY_HOOK_PASS_REPO/.autoship/workspaces/issue-182/started_at"
+printf 'Result summary\n' > "$VERIFY_HOOK_PASS_REPO/.autoship/workspaces/issue-182/AUTOSHIP_RESULT.md"
+touch -t 202604240000 "$VERIFY_HOOK_PASS_REPO/.autoship/workspaces/issue-182/started_at"
+touch -t 202604240001 "$VERIFY_HOOK_PASS_REPO/.autoship/workspaces/issue-182/AUTOSHIP_RESULT.md"
+(
+  cd "$VERIFY_HOOK_PASS_REPO"
+  bash hooks/opencode/verify-result.sh issue-182 "$VERIFY_HOOK_PASS_REPO/.autoship/workspaces/issue-182" true >/tmp/autoship-verify-pass.out
+)
+grep -F 'PASS' /tmp/autoship-verify-pass.out >/dev/null || fail "deterministic verification hook emits PASS"
+
+VERIFY_HOOK_FAIL_REPO="$TMP_DIR/verify-hook-fail-repo"
+mkdir -p "$VERIFY_HOOK_FAIL_REPO/.autoship/workspaces/issue-182" "$VERIFY_HOOK_FAIL_REPO/hooks/opencode"
+git init -q "$VERIFY_HOOK_FAIL_REPO"
+git -C "$VERIFY_HOOK_FAIL_REPO" config user.email autoship@example.invalid
+git -C "$VERIFY_HOOK_FAIL_REPO" config user.name AutoShip
+printf 'base\n' > "$VERIFY_HOOK_FAIL_REPO/README.md"
+git -C "$VERIFY_HOOK_FAIL_REPO" add README.md
+git -C "$VERIFY_HOOK_FAIL_REPO" commit -q -m initial
+git -C "$VERIFY_HOOK_FAIL_REPO" checkout -q -b autoship/issue-182
+printf 'changed\n' > "$VERIFY_HOOK_FAIL_REPO/feature.txt"
+git -C "$VERIFY_HOOK_FAIL_REPO" add feature.txt
+git -C "$VERIFY_HOOK_FAIL_REPO" commit -q -m 'feat: issue 182'
+cp "$SCRIPT_DIR/verify-result.sh" "$VERIFY_HOOK_FAIL_REPO/hooks/opencode/verify-result.sh"
+chmod +x "$VERIFY_HOOK_FAIL_REPO/hooks/opencode/verify-result.sh"
+cat > "$VERIFY_HOOK_FAIL_REPO/hooks/opencode/reviewer.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'VERDICT: PASS\n'
+SH
+chmod +x "$VERIFY_HOOK_FAIL_REPO/hooks/opencode/reviewer.sh"
+printf '2026-04-24T00:00:00Z\n' > "$VERIFY_HOOK_FAIL_REPO/.autoship/workspaces/issue-182/started_at"
+printf 'stale result\n' > "$VERIFY_HOOK_FAIL_REPO/.autoship/workspaces/issue-182/AUTOSHIP_RESULT.md"
+touch -t 202604240001 "$VERIFY_HOOK_FAIL_REPO/.autoship/workspaces/issue-182/started_at"
+touch -t 202604240000 "$VERIFY_HOOK_FAIL_REPO/.autoship/workspaces/issue-182/AUTOSHIP_RESULT.md"
+if (
+  cd "$VERIFY_HOOK_FAIL_REPO"
+  bash hooks/opencode/verify-result.sh issue-182 "$VERIFY_HOOK_FAIL_REPO/.autoship/workspaces/issue-182" true >/tmp/autoship-verify-fail.out 2>&1
+); then
+  fail "deterministic verification hook fails stale results"
+fi
+grep -F 'FAIL' /tmp/autoship-verify-fail.out >/dev/null || fail "deterministic verification hook emits FAIL"
+
+VERIFY_HOOK_TEST_FAIL_REPO="$TMP_DIR/verify-hook-test-fail-repo"
+mkdir -p "$VERIFY_HOOK_TEST_FAIL_REPO/.autoship/workspaces/issue-182" "$VERIFY_HOOK_TEST_FAIL_REPO/hooks/opencode"
+git init -q "$VERIFY_HOOK_TEST_FAIL_REPO"
+git -C "$VERIFY_HOOK_TEST_FAIL_REPO" config user.email autoship@example.invalid
+git -C "$VERIFY_HOOK_TEST_FAIL_REPO" config user.name AutoShip
+printf 'base\n' > "$VERIFY_HOOK_TEST_FAIL_REPO/README.md"
+git -C "$VERIFY_HOOK_TEST_FAIL_REPO" add README.md
+git -C "$VERIFY_HOOK_TEST_FAIL_REPO" commit -q -m initial
+git -C "$VERIFY_HOOK_TEST_FAIL_REPO" checkout -q -b autoship/issue-182
+printf 'changed\n' > "$VERIFY_HOOK_TEST_FAIL_REPO/feature.txt"
+git -C "$VERIFY_HOOK_TEST_FAIL_REPO" add feature.txt
+git -C "$VERIFY_HOOK_TEST_FAIL_REPO" commit -q -m 'feat: issue 182'
+cp "$SCRIPT_DIR/verify-result.sh" "$VERIFY_HOOK_TEST_FAIL_REPO/hooks/opencode/verify-result.sh"
+chmod +x "$VERIFY_HOOK_TEST_FAIL_REPO/hooks/opencode/verify-result.sh"
+cat > "$VERIFY_HOOK_TEST_FAIL_REPO/hooks/opencode/reviewer.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'VERDICT: PASS\n'
+SH
+chmod +x "$VERIFY_HOOK_TEST_FAIL_REPO/hooks/opencode/reviewer.sh"
+printf '2026-04-24T00:00:00Z\n' > "$VERIFY_HOOK_TEST_FAIL_REPO/.autoship/workspaces/issue-182/started_at"
+printf 'Result summary\n' > "$VERIFY_HOOK_TEST_FAIL_REPO/.autoship/workspaces/issue-182/AUTOSHIP_RESULT.md"
+touch -t 202604240000 "$VERIFY_HOOK_TEST_FAIL_REPO/.autoship/workspaces/issue-182/started_at"
+touch -t 202604240001 "$VERIFY_HOOK_TEST_FAIL_REPO/.autoship/workspaces/issue-182/AUTOSHIP_RESULT.md"
+if (
+  cd "$VERIFY_HOOK_TEST_FAIL_REPO"
+  bash hooks/opencode/verify-result.sh issue-182 "$VERIFY_HOOK_TEST_FAIL_REPO/.autoship/workspaces/issue-182" false >/tmp/autoship-verify-test-fail.out 2>&1
+); then
+  fail "deterministic verification hook fails failing test command"
+fi
+grep -F 'test command failed' "$VERIFY_HOOK_TEST_FAIL_REPO/.autoship/workspaces/issue-182/AUTOSHIP_VERIFICATION.log" >/dev/null || fail "deterministic verification hook records failing test command"
 
 grep -F 'AUTOSHIP_VERSION="1.5.0-opencode"' "$SCRIPT_DIR/init.sh" >/dev/null 2>&1 && fail "init must not hardcode stale 1.5.0-opencode version"
 

--- a/hooks/opencode/verify-result.sh
+++ b/hooks/opencode/verify-result.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ISSUE_KEY="${1:?Issue key required}"
+WORKTREE_PATH="${2:?Worktree path required}"
+TEST_COMMAND="${3:-none}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
+  echo "FAIL: not inside a git repository" >&2
+  exit 1
+}
+
+RESULT_PATH="$WORKTREE_PATH/AUTOSHIP_RESULT.md"
+STARTED_PATH="$WORKTREE_PATH/started_at"
+LOG_PATH="$WORKTREE_PATH/AUTOSHIP_VERIFICATION.log"
+
+fail() {
+  mkdir -p "$WORKTREE_PATH" 2>/dev/null || true
+  printf 'FAIL: %s\n' "$1" | tee -a "$LOG_PATH" >&2
+  exit 1
+}
+
+[[ -d "$WORKTREE_PATH" ]] || fail "worktree missing"
+[[ -s "$RESULT_PATH" ]] || fail "AUTOSHIP_RESULT.md missing or empty"
+
+real_worktree=$(cd "$WORKTREE_PATH" && pwd -P) || fail "cannot resolve worktree"
+real_result=$(cd "$(dirname "$RESULT_PATH")" && printf '%s/%s\n' "$(pwd -P)" "$(basename "$RESULT_PATH")") || fail "cannot resolve result path"
+case "$real_result" in
+  "$real_worktree"/*) ;;
+  *) fail "AUTOSHIP_RESULT.md is outside worktree" ;;
+esac
+
+if [[ -f "$STARTED_PATH" && ! "$RESULT_PATH" -nt "$STARTED_PATH" ]]; then
+  fail "AUTOSHIP_RESULT.md is stale"
+fi
+
+GIT_WORKTREE="$WORKTREE_PATH"
+if ! git -C "$GIT_WORKTREE" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  GIT_WORKTREE="$REPO_ROOT"
+fi
+
+git -C "$GIT_WORKTREE" rev-parse --verify HEAD >/dev/null 2>&1 || fail "no git commit to verify"
+
+has_diff=false
+if [[ -n "$(git -C "$GIT_WORKTREE" status --porcelain 2>/dev/null)" ]]; then
+  has_diff=true
+fi
+if ! git -C "$GIT_WORKTREE" diff --quiet -- . 2>/dev/null; then
+  has_diff=true
+fi
+if git -C "$GIT_WORKTREE" rev-parse --verify HEAD~1 >/dev/null 2>&1 && ! git -C "$GIT_WORKTREE" diff --quiet HEAD~1...HEAD -- . 2>/dev/null; then
+  has_diff=true
+fi
+[[ "$has_diff" == true ]] || fail "git diff is empty"
+
+if [[ -n "$TEST_COMMAND" && "$TEST_COMMAND" != "none" ]]; then
+  if ! (cd "$GIT_WORKTREE" && eval "$TEST_COMMAND") >> "$LOG_PATH" 2>&1; then
+    fail "test command failed"
+  fi
+fi
+
+reviewer_output=$(mktemp)
+if ! bash "$SCRIPT_DIR/reviewer.sh" "$ISSUE_KEY" "$WORKTREE_PATH" "$RESULT_PATH" "$TEST_COMMAND" > "$reviewer_output" 2>&1; then
+  cp "$reviewer_output" "$LOG_PATH" 2>/dev/null || true
+  rm -f "$reviewer_output"
+  fail "reviewer failed"
+fi
+
+if ! grep -F 'VERDICT: PASS' "$reviewer_output" >/dev/null 2>&1; then
+  cp "$reviewer_output" "$LOG_PATH" 2>/dev/null || true
+  rm -f "$reviewer_output"
+  fail "reviewer did not pass"
+fi
+
+cp "$reviewer_output" "$LOG_PATH" 2>/dev/null || true
+rm -f "$reviewer_output"
+printf 'PASS\n'


### PR DESCRIPTION
## Summary
- Add `hooks/opencode/verify-result.sh` to validate result freshness, change evidence, test command success, and reviewer PASS.
- Update event processing to delegate verification to the deterministic hook.
- Add PASS and FAIL path policy coverage for stale results and failing test commands.

## Verification
- `bash hooks/opencode/test-policy.sh`
- `bash -n hooks/opencode/*.sh hooks/*.sh`
- `bash hooks/opencode/smoke-test.sh`

Closes #182