### PR TITLE
ci: Add npm pack dry-run verification (#195)

### DIFF
--- a/hooks/opencode/test-policy.sh
+++ b/hooks/opencode/test-policy.sh
@@ -63,6 +63,30 @@ docs_title=$(bash "$SCRIPT_DIR/pr-title.sh" --issue 2296 --title "mandate poison
 assert_eq "fix: Validate Discord webhook URLs (#2298)" "$fix_title" "bug/security title uses fix prefix"
 assert_eq "docs: mandate poison recovery pattern (#2296)" "$docs_title" "documentation title uses docs prefix"
 
+PACKAGE_VERIFY_REPO="$TMP_DIR/package-verify-repo"
+mkdir -p "$PACKAGE_VERIFY_REPO/dist" "$PACKAGE_VERIFY_REPO/hooks" "$PACKAGE_VERIFY_REPO/commands" "$PACKAGE_VERIFY_REPO/skills" "$PACKAGE_VERIFY_REPO/.autoship"
+cp "$SCRIPT_DIR/../../package.json" "$PACKAGE_VERIFY_REPO/package.json"
+jq '.files += [".autoship", "unintended.tmp"]' "$PACKAGE_VERIFY_REPO/package.json" > "$PACKAGE_VERIFY_REPO/package.json.tmp" && mv "$PACKAGE_VERIFY_REPO/package.json.tmp" "$PACKAGE_VERIFY_REPO/package.json"
+printf 'runtime state\n' > "$PACKAGE_VERIFY_REPO/.autoship/state.json"
+printf 'unintended\n' > "$PACKAGE_VERIFY_REPO/unintended.tmp"
+printf 'built\n' > "$PACKAGE_VERIFY_REPO/dist/index.js"
+printf 'hook\n' > "$PACKAGE_VERIFY_REPO/hooks/init.sh"
+printf 'command\n' > "$PACKAGE_VERIFY_REPO/commands/autoship.md"
+printf 'skill\n' > "$PACKAGE_VERIFY_REPO/skills/autoship-orchestrate.md"
+printf 'agents\n' > "$PACKAGE_VERIFY_REPO/AGENTS.md"
+printf '1.0.0\n' > "$PACKAGE_VERIFY_REPO/VERSION"
+printf 'readme\n' > "$PACKAGE_VERIFY_REPO/README.md"
+printf 'license\n' > "$PACKAGE_VERIFY_REPO/LICENSE"
+(
+  cd "$PACKAGE_VERIFY_REPO"
+  if bash "$SCRIPT_DIR/verify-package.sh" >/dev/null 2>&1; then
+    fail "package verification should reject runtime state and unintended files"
+  fi
+  rm -rf .autoship unintended.tmp
+  cp "$SCRIPT_DIR/../../package.json" package.json
+  bash "$SCRIPT_DIR/verify-package.sh" >/dev/null
+)
+
 STATE_REPO="$TMP_DIR/repo"
 mkdir -p "$STATE_REPO/.autoship/workspaces/issue-746" "$STATE_REPO/.autoship/workspaces/issue-749" "$STATE_REPO/.autoship/workspaces/issue-750"
 mkdir -p "$STATE_REPO/.autoship/workspaces/issue-751"

--- a/hooks/opencode/verify-package.sh
+++ b/hooks/opencode/verify-package.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+PACK_JSON="$TMP_DIR/npm-pack-dry-run.json"
+npm pack --dry-run --json --ignore-scripts > "$PACK_JSON"
+
+node - "$PACK_JSON" <<'NODE'
+const fs = require("fs");
+
+const packJsonPath = process.argv[2];
+const raw = fs.readFileSync(packJsonPath, "utf8");
+const packResult = JSON.parse(raw);
+const entries = Array.isArray(packResult) ? packResult : [packResult];
+const files = entries.flatMap((entry) => Array.isArray(entry.files) ? entry.files : []);
+
+const allowedRoots = new Set(["dist", "hooks", "commands", "skills"]);
+const allowedFiles = new Set(["package.json", "README.md", "LICENSE", "AGENTS.md", "VERSION"]);
+
+function normalizePath(filePath) {
+  return filePath.replace(/^package\//, "");
+}
+
+function isForbidden(filePath) {
+  return filePath === ".autoship" || filePath.startsWith(".autoship/");
+}
+
+function isAllowed(filePath) {
+  if (allowedFiles.has(filePath)) {
+    return true;
+  }
+
+  const [root] = filePath.split("/");
+  return allowedRoots.has(root);
+}
+
+const violations = [];
+for (const file of files) {
+  const filePath = normalizePath(String(file.path || ""));
+  if (!filePath) {
+    continue;
+  }
+
+  if (isForbidden(filePath)) {
+    violations.push(`${filePath} is runtime state and must not be published`);
+  } else if (!isAllowed(filePath)) {
+    violations.push(`${filePath} is not in the package allowlist`);
+  }
+}
+
+if (files.length === 0) {
+  violations.push("npm pack dry-run returned no package files");
+}
+
+if (violations.length > 0) {
+  console.error("FAIL: npm package contains unexpected files:");
+  for (const violation of violations) {
+    console.error(`- ${violation}`);
+  }
+  process.exit(1);
+}
+
+console.log(`Package dry-run verified ${files.length} files`);
+NODE

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "scripts": {
     "build": "tsc",
     "typecheck": "tsc --noEmit",
+    "verify:pack": "bash hooks/opencode/verify-package.sh",
     "prepack": "tsc"
   },
   "keywords": [


### PR DESCRIPTION
## Summary
- Add `hooks/opencode/verify-package.sh` for `npm pack --dry-run` package allowlist verification.
- Add `npm run verify:pack`.
- Add policy coverage that rejects runtime state and unintended package files.

## Verification
- `npm run verify:pack`
- `bash hooks/opencode/test-policy.sh`
- `bash -n hooks/opencode/*.sh hooks/*.sh`
- `bash hooks/opencode/smoke-test.sh`

Closes #195