### PR TITLE
chore: Remove stale colon command syntax from public docs (#189)

### DIFF
--- a/commands/plan.md
+++ b/commands/plan.md
@@ -3,6 +3,6 @@ name: plan
 description: Dry-run AutoShip OpenCode issue planning
 ---
 
-# /autoship:plan
+# /autoship-plan
 
 Use `commands/autoship-plan.md`. Planning sorts eligible issues by ascending issue number and blocks unsafe work.

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -3,7 +3,7 @@ name: setup
 description: Configure AutoShip for OpenCode-first-party routing
 ---
 
-# /autoship:setup
+# /autoship-setup
 
 Configure AutoShip for OpenCode-only workers.
 

--- a/commands/start.md
+++ b/commands/start.md
@@ -3,6 +3,6 @@ name: start
 description: Start AutoShip OpenCode orchestration
 ---
 
-# /autoship:start
+# /autoship
 
 Use `commands/autoship-start.md`. AutoShip dispatches OpenCode workers only.

--- a/commands/status.md
+++ b/commands/status.md
@@ -5,6 +5,6 @@ allowed-tools: ["Bash", "Read", "Skill", "ToolSearch"]
 
 <autoship-status-cmd>
 
-Invoke the `autoship:status` skill via the Skill tool to display current AutoShip orchestration status.
+Invoke the `autoship-status` skill via the Skill tool to display current AutoShip orchestration status.
 
 </autoship-status-cmd>

--- a/commands/stop.md
+++ b/commands/stop.md
@@ -3,6 +3,6 @@ name: stop
 description: Stop AutoShip OpenCode orchestration
 ---
 
-# /autoship:stop
+# /autoship-stop
 
 Stop queued/running AutoShip OpenCode workspaces and preserve `.autoship/state.json` for recovery.


### PR DESCRIPTION
## Summary
- Replace stale `/autoship:*` references in public command docs with canonical slash commands.
- Leave archived plan references untouched.

## Verification
- `bash hooks/opencode/test-policy.sh`
- `bash -n hooks/opencode/*.sh hooks/*.sh`
- `bash hooks/opencode/smoke-test.sh`

Closes #189