### PR TITLE
chore: Add canonical autoship-setup command file (#188)

### DIFF
--- a/commands/autoship-setup.md
+++ b/commands/autoship-setup.md
@@ -1,0 +1,31 @@
+---
+name: autoship-setup
+description: Configure AutoShip for OpenCode model routing and first-run setup
+platform: opencode
+---
+
+# /autoship-setup — Setup Wizard
+
+Configure AutoShip for OpenCode-only workers.
+
+## Run Setup Skill
+
+Invoke the `autoship-setup` skill for the interactive setup wizard.
+
+The setup skill verifies OpenCode and GitHub authentication, discovers live OpenCode models, selects free-first worker routing, and writes `.autoship/model-routing.json` plus `.autoship/config.json`.
+
+## Non-Interactive Mode
+
+For scripted setup, run the setup hook directly:
+
+```bash
+bash hooks/opencode/setup.sh --no-tui \
+  --max-agents 10 \
+  --labels "agent:ready,autoship:in-progress" \
+  --refresh-models \
+  --planner-model openai/gpt-5.5
+```
+
+## Next Step
+
+After setup completes, run `/autoship` to start orchestration.

--- a/hooks/opencode/test-policy.sh
+++ b/hooks/opencode/test-policy.sh
@@ -23,6 +23,11 @@ assert_eq() {
   fi
 }
 
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+test -f "$REPO_ROOT/commands/autoship-setup.md" || fail "canonical /autoship-setup command file is installed"
+grep -F '| `/autoship-setup` |' "$REPO_ROOT/README.md" >/dev/null || fail "README public command table includes /autoship-setup"
+grep -F '| `/autoship-setup` |' "$REPO_ROOT/commands/autoship.md" >/dev/null || fail "/autoship command table includes /autoship-setup"
+
 ISSUES_FILE="$TMP_DIR/issues.json"
 cat > "$ISSUES_FILE" <<'JSON'
 [


### PR DESCRIPTION
## Summary
- Add canonical `/autoship-setup` command file.
- Add policy coverage that requires the command and public command tables to include `/autoship-setup`.

## Verification
- `bash hooks/opencode/test-policy.sh`
- `bash -n hooks/opencode/*.sh hooks/*.sh`
- `bash hooks/opencode/smoke-test.sh`

Closes #188