### PR TITLE
docs: Update wiki configuration and troubleshooting pages (#193)

### DIFF
--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -20,6 +20,7 @@ AutoShip is OpenCode-only.
 | Coordinator | `openai/gpt-5.5` |
 | Orchestrator | `openai/gpt-5.5` |
 | Reviewer | `openai/gpt-5.5` |
+| Lead | `openai/gpt-5.5` |
 | Workers | Best configured model per task |
 
 `openai/gpt-5.5-fast` is not allowed.

--- a/wiki/Configuration.md
+++ b/wiki/Configuration.md
@@ -1,15 +1,32 @@
 # Configuration
 
-AutoShip configuration lives under `.autoship/` and should not be committed.
+AutoShip has two local configuration locations:
+
+- OpenCode package assets live under the OpenCode config directory, usually `~/.config/opencode/.autoship/`.
+- Project runtime state lives under the repository's local `.autoship/` directory and should not be committed.
+
+Install or refresh the OpenCode package assets with the package CLI:
+
+```bash
+opencode-autoship install
+opencode-autoship doctor
+```
+
+When working from a source checkout, the repo-local installer is also supported and matches the Pages install guide:
+
+```bash
+bash hooks/opencode/install.sh
+```
 
 ## Key Files
 
 | File | Purpose |
 | --- | --- |
-| `.autoship/state.json` | Issue lifecycle and active worker state |
-| `.autoship/event-queue.json` | Pending orchestration events |
-| `.autoship/config.json` | Runtime config, including concurrency and role models |
-| `.autoship/model-routing.json` | User-editable model routing and role config |
+| `.autoship/state.json` | Project-local issue lifecycle and active worker state |
+| `.autoship/event-queue.json` | Project-local pending orchestration events |
+| `.autoship/config.json` | Project-local runtime config, including concurrency and frontier role models |
+| `.autoship/routing.json` | Project-local task type routing metadata |
+| `.autoship/model-routing.json` | Project-local user-editable model routing and role config |
 | `.autoship/model-history.json` | Optional learned model success/failure history |
 
 ## Model Routing Schema
@@ -28,46 +45,50 @@ The `model-routing.json` file defines role assignments and worker pools:
   "pools": {
     "default": {
       "description": "Default worker pool for general tasks",
-      "models": ["model-a", "model-b"]
+      "models": ["provider/free-model", "provider/selected-model"]
     },
     "frontend": {
       "description": "Frontend development tasks",
-      "models": ["model-a"]
+      "models": ["provider/free-model"]
     },
     "backend": {
       "description": "Backend development tasks",
-      "models": ["model-b"]
+      "models": ["provider/selected-model"]
     },
     "docs": {
       "description": "Documentation tasks",
-      "models": ["model-a"]
+      "models": ["provider/free-model"]
     },
     "mechanical": {
       "description": "Mechanical/boilerplate tasks",
-      "models": ["model-a"]
+      "models": ["provider/free-model"]
     }
   },
-  "defaultFallback": "model-a",
+  "defaultFallback": "provider/free-model",
   "models": [
-    {"id": "model-a", "cost": "free", "strength": 90, "max_task_types": ["docs", "simple_code"]},
-    {"id": "model-b", "cost": "selected", "strength": 110, "max_task_types": ["medium_code", "complex"]}
+    {"id": "provider/free-model", "cost": "free", "strength": 75, "max_task_types": ["docs", "simple_code", "medium_code"]},
+    {"id": "provider/selected-model", "cost": "selected", "strength": 90, "max_task_types": ["medium_code", "complex"]}
   ]
 }
 ```
 
-### Roles
+### Frontier Roles
+
+The frontier roles perform planning, coordination, orchestration, review, and lead decisions. They default to `openai/gpt-5.5` because those steps require global judgment across issues and workspaces.
 
 | Role | Purpose | Default |
 | --- | --- | --- |
-| `planner` | Plans issue work and acceptance criteria | openai/gpt-5.5 |
-| `coordinator` | Coordinates multi-agent workflows | openai/gpt-5.5 |
-| `orchestrator` | Orchestrates issue→PR pipeline | openai/gpt-5.5 |
-| `reviewer` | Reviews PRs before merge | openai/gpt-5.5 |
-| `lead` | Leads individual agent work | openai/gpt-5.5 |
+| `planner` | Plans issue work and acceptance criteria | `openai/gpt-5.5` |
+| `coordinator` | Coordinates multi-agent workflows | `openai/gpt-5.5` |
+| `orchestrator` | Orchestrates issue-to-PR pipeline | `openai/gpt-5.5` |
+| `reviewer` | Reviews completed work before PR creation | `openai/gpt-5.5` |
+| `lead` | Makes dispatch, concurrency, and escalation decisions | `openai/gpt-5.5` |
+
+Set all frontier roles together with `AUTOSHIP_PLANNER_MODEL` or `--planner-model`. Set only the lead role with `AUTOSHIP_LEAD_MODEL` or `--lead-model`.
 
 ### Worker Pools
 
-Worker pools allow routing to specialized model groups:
+Worker pools allow routing to specialized model groups. Setup defaults to live OpenCode models flagged free, then the selector scores compatible workers by cost class, configured strength, and `model-history.json` success/failure history.
 
 - `default` - General task pool
 - `frontend` - Frontend/UI work
@@ -80,7 +101,7 @@ Worker pools allow routing to specialized model groups:
 | Field | Type | Description |
 | --- | --- | --- |
 | `id` | string | Model ID from `opencode models` |
-| `cost` | string | "free" or "selected" |
+| `cost` | string | `free` or `selected`; free models receive the highest cost score in default routing |
 | `strength` | int | Capability score (0-150) |
 | `max_task_types` | array | Compatible task types |
 
@@ -107,7 +128,7 @@ Run setup to detect current models:
 bash hooks/opencode/setup.sh
 ```
 
-Refresh free defaults from current OpenCode inventory:
+Refresh free defaults from the current OpenCode inventory:
 
 ```bash
 AUTOSHIP_REFRESH_MODELS=1 bash hooks/opencode/setup.sh
@@ -117,6 +138,13 @@ Choose explicit models from the current inventory:
 
 ```bash
 AUTOSHIP_MODELS="provider/model-a,provider/model-b" bash hooks/opencode/setup.sh
+```
+
+Equivalent setup flags are available for non-interactive runs:
+
+```bash
+bash hooks/opencode/setup.sh --no-tui --worker-models provider/model-a,provider/model-b
+bash hooks/opencode/setup.sh --no-tui --refresh-models
 ```
 
 Manual edits to `.autoship/model-routing.json` are preserved by default.

--- a/wiki/Design-Decisions.md
+++ b/wiki/Design-Decisions.md
@@ -6,7 +6,7 @@ AutoShip supports OpenCode as the only worker runtime. This keeps setup, state, 
 
 ## GPT-5.5 role model
 
-`openai/gpt-5.5` is the default planner, coordinator, orchestrator, and reviewer role because those steps require global judgment and consistency.
+`openai/gpt-5.5` is the default planner, coordinator, orchestrator, reviewer, and lead role because those steps require global judgment and consistency.
 
 ## Worker model selection
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -9,7 +9,7 @@ AutoShip is the OpenCode plugin for solo maintainers who want their GitHub issue
 
 - Plans `agent:ready` issues in ascending issue-number order
 - Blocks unsafe/evasion-prone work for human review
-- Uses `openai/gpt-5.5` for planner, coordinator, orchestrator, and reviewer roles
+- Uses `openai/gpt-5.5` for planner, coordinator, orchestrator, reviewer, and lead roles
 - Selects worker models from the live `opencode models` inventory
 - Defaults to currently available free worker models
 - Allows operator-selected Spark, Go-provider, Nvidia, OpenRouter, and other OpenCode models when available

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -1,5 +1,32 @@
 # Troubleshooting
 
+## Package install looks stale
+
+Run the package installer, then diagnostics:
+
+```bash
+opencode-autoship install
+opencode-autoship doctor
+```
+
+The installer refreshes AutoShip assets under your OpenCode config directory and registers `opencode-autoship` in `opencode.json`. If you are developing from a source checkout, this repo-local path is also valid:
+
+```bash
+bash hooks/opencode/install.sh
+```
+
+## Doctor reports failures
+
+Run:
+
+```bash
+opencode-autoship doctor
+```
+
+Failures usually mean the OpenCode package registration, installed assets, `.autoship/config.json`, or `.autoship/model-routing.json` are missing or stale. Run `opencode-autoship install`, then `/autoship-setup` or `bash hooks/opencode/setup.sh` to regenerate project-local runtime config.
+
+Warnings are not always blockers. For example, missing onboarding means setup has not run yet, and model inventory warnings can occur when `opencode models` is unavailable in the current shell.
+
 ## Setup finds no models
 
 Run:
@@ -8,11 +35,34 @@ Run:
 opencode models
 ```
 
-If the expected provider models are missing, reconnect the provider in OpenCode and rerun setup.
+If the expected provider models are missing, reconnect the provider in OpenCode and rerun setup. AutoShip defaults to live models flagged free; if no free models are available, choose exact worker models explicitly:
+
+```bash
+AUTOSHIP_MODELS="provider/model-a,provider/model-b" bash hooks/opencode/setup.sh
+```
 
 ## Manual model edits disappeared
 
 Setup preserves `.autoship/model-routing.json` by default. It regenerates only when you use `AUTOSHIP_REFRESH_MODELS=1` or provide `AUTOSHIP_MODELS=...`.
+
+Equivalent flags are `--refresh-models` and `--worker-models`.
+
+## Lead model is not what I expected
+
+Planner, coordinator, orchestrator, reviewer, and lead are frontier roles. They default to `openai/gpt-5.5`; `openai/gpt-5.5-fast` is not allowed.
+
+Use `AUTOSHIP_PLANNER_MODEL` or `--planner-model` to set all frontier roles together. Use `AUTOSHIP_LEAD_MODEL` or `--lead-model` to override only the lead role.
+
+## Local state should not be committed
+
+The repository `.autoship/` directory is project-local runtime state. It contains files such as `state.json`, `event-queue.json`, `config.json`, `routing.json`, `model-routing.json`, workspaces, results, and logs.
+
+Do not commit `.autoship/`. If state looks corrupt, prefer targeted setup or reconciliation first:
+
+```bash
+bash hooks/opencode/setup.sh
+bash hooks/opencode/reconcile-state.sh
+```
 
 ## Workers are queued but not running
 


### PR DESCRIPTION
## Summary
- Update wiki configuration docs for package CLI install, doctor diagnostics, project-local state, free-model routing, and lead role defaults.
- Update troubleshooting guidance for stale installs, doctor failures, model routing, lead overrides, and local state recovery.
- Align wiki Home, Architecture, and Design Decisions with current package-style UX.

## Verification
- `bash hooks/opencode/test-policy.sh`
- `bash -n hooks/opencode/*.sh hooks/*.sh`
- `bash hooks/opencode/smoke-test.sh`

Closes #193