### PR TITLE
chore: Validate version alignment across release surfaces (#196)

### DIFF
--- a/hooks/opencode/test-policy.sh
+++ b/hooks/opencode/test-policy.sh
@@ -1136,6 +1136,56 @@ SH
   grep -F 'asset version' "$TMP_DIR/doctor-version-fail.txt" >/dev/null || fail "doctor reports mismatched asset version"
 )
 
+VERSION_ALIGNMENT_DIR="$TMP_DIR/version-alignment"
+mkdir -p "$VERSION_ALIGNMENT_DIR/installed" "$VERSION_ALIGNMENT_DIR/plugins"
+cp VERSION package.json CHANGELOG.md "$VERSION_ALIGNMENT_DIR/"
+cp VERSION "$VERSION_ALIGNMENT_DIR/installed/VERSION"
+printf '%s\n' "$(tr -d '[:space:]' < VERSION)" > "$VERSION_ALIGNMENT_DIR/plugins/autoship.version"
+bash "$SCRIPT_DIR/validate-version-alignment.sh" \
+  --repo "$VERSION_ALIGNMENT_DIR" \
+  --installed-version "$VERSION_ALIGNMENT_DIR/installed/VERSION" \
+  --release-tag "$VERSION_ALIGNMENT_DIR/plugins/autoship.version" >/dev/null
+
+assert_version_alignment_fails() {
+  local fixture_dir="$1"
+  local expected_message="$2"
+  local output_file="$TMP_DIR/version-alignment-fail.txt"
+  if bash "$SCRIPT_DIR/validate-version-alignment.sh" \
+    --repo "$fixture_dir" \
+    --installed-version "$fixture_dir/installed/VERSION" \
+    --release-tag "$fixture_dir/plugins/autoship.version" >"$output_file" 2>&1; then
+    fail "version alignment validation fails for $expected_message"
+  fi
+  grep -F "$expected_message" "$output_file" >/dev/null || fail "version alignment validation reports $expected_message"
+}
+
+printf 'v0.0.0\n' > "$VERSION_ALIGNMENT_DIR/installed/VERSION"
+assert_version_alignment_fails "$VERSION_ALIGNMENT_DIR" 'installed asset marker'
+
+VERSION_ALIGNMENT_DIR="$TMP_DIR/version-alignment-package"
+mkdir -p "$VERSION_ALIGNMENT_DIR/installed" "$VERSION_ALIGNMENT_DIR/plugins"
+cp VERSION package.json CHANGELOG.md "$VERSION_ALIGNMENT_DIR/"
+jq '.version = "0.0.0"' "$VERSION_ALIGNMENT_DIR/package.json" > "$VERSION_ALIGNMENT_DIR/package.tmp"
+mv "$VERSION_ALIGNMENT_DIR/package.tmp" "$VERSION_ALIGNMENT_DIR/package.json"
+cp VERSION "$VERSION_ALIGNMENT_DIR/installed/VERSION"
+printf '%s\n' "$(tr -d '[:space:]' < VERSION)" > "$VERSION_ALIGNMENT_DIR/plugins/autoship.version"
+assert_version_alignment_fails "$VERSION_ALIGNMENT_DIR" 'package.json version'
+
+VERSION_ALIGNMENT_DIR="$TMP_DIR/version-alignment-changelog"
+mkdir -p "$VERSION_ALIGNMENT_DIR/installed" "$VERSION_ALIGNMENT_DIR/plugins"
+cp VERSION package.json CHANGELOG.md "$VERSION_ALIGNMENT_DIR/"
+perl -0pi -e 's/^## v[0-9][^\n]*/## v0.0.0/m' "$VERSION_ALIGNMENT_DIR/CHANGELOG.md"
+cp VERSION "$VERSION_ALIGNMENT_DIR/installed/VERSION"
+printf '%s\n' "$(tr -d '[:space:]' < VERSION)" > "$VERSION_ALIGNMENT_DIR/plugins/autoship.version"
+assert_version_alignment_fails "$VERSION_ALIGNMENT_DIR" 'CHANGELOG release heading'
+
+VERSION_ALIGNMENT_DIR="$TMP_DIR/version-alignment-tag"
+mkdir -p "$VERSION_ALIGNMENT_DIR/installed" "$VERSION_ALIGNMENT_DIR/plugins"
+cp VERSION package.json CHANGELOG.md "$VERSION_ALIGNMENT_DIR/"
+cp VERSION "$VERSION_ALIGNMENT_DIR/installed/VERSION"
+printf 'v0.0.0\n' > "$VERSION_ALIGNMENT_DIR/plugins/autoship.version"
+assert_version_alignment_fails "$VERSION_ALIGNMENT_DIR" 'GitHub release tag marker'
+
 bash "$SCRIPT_DIR/test-model-parsing.sh" >/dev/null
 
 echo "OpenCode policy tests passed"

--- a/hooks/opencode/validate-version-alignment.sh
+++ b/hooks/opencode/validate-version-alignment.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+INSTALLED_VERSION_FILE=""
+RELEASE_TAG_FILE=""
+
+failures=()
+
+usage() {
+  cat <<'EOF'
+Usage: validate-version-alignment.sh [--repo DIR] [--installed-version FILE] [--release-tag FILE]
+
+Validates that release version surfaces agree:
+  - VERSION
+  - package.json version
+  - CHANGELOG release heading
+  - optional installed asset marker file
+  - optional GitHub release tag marker file
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      REPO_ROOT="$2"
+      shift 2
+      ;;
+    --installed-version)
+      INSTALLED_VERSION_FILE="$2"
+      shift 2
+      ;;
+    --release-tag)
+      RELEASE_TAG_FILE="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      printf 'Unknown argument: %s\n' "$1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+trim_file() {
+  tr -d '[:space:]' < "$1"
+}
+
+record_mismatch() {
+  failures+=("$1")
+}
+
+VERSION_FILE="$REPO_ROOT/VERSION"
+PACKAGE_FILE="$REPO_ROOT/package.json"
+CHANGELOG_FILE="$REPO_ROOT/CHANGELOG.md"
+
+if [[ ! -f "$VERSION_FILE" ]]; then
+  record_mismatch "VERSION file is missing"
+else
+  expected_version="$(trim_file "$VERSION_FILE")"
+fi
+
+if [[ -z "${expected_version:-}" ]]; then
+  record_mismatch "VERSION file is empty"
+else
+  if [[ ! -f "$PACKAGE_FILE" ]]; then
+    record_mismatch "package.json is missing"
+  else
+    package_version="v$(jq -r '.version // empty' "$PACKAGE_FILE")"
+    if [[ "$package_version" != "$expected_version" ]]; then
+      record_mismatch "package.json version $package_version does not match VERSION $expected_version"
+    fi
+  fi
+
+  if [[ ! -f "$CHANGELOG_FILE" ]]; then
+    record_mismatch "CHANGELOG.md is missing"
+  elif ! grep -Eq "^## ${expected_version//./\\.}$" "$CHANGELOG_FILE"; then
+    record_mismatch "CHANGELOG release heading for $expected_version is missing"
+  fi
+
+  if [[ -n "$INSTALLED_VERSION_FILE" ]]; then
+    if [[ ! -f "$INSTALLED_VERSION_FILE" ]]; then
+      record_mismatch "installed asset marker $INSTALLED_VERSION_FILE is missing"
+    else
+      installed_version="$(trim_file "$INSTALLED_VERSION_FILE")"
+      if [[ "$installed_version" != "$expected_version" ]]; then
+        record_mismatch "installed asset marker $installed_version does not match VERSION $expected_version"
+      fi
+    fi
+  fi
+
+  if [[ -n "$RELEASE_TAG_FILE" ]]; then
+    if [[ ! -f "$RELEASE_TAG_FILE" ]]; then
+      record_mismatch "GitHub release tag marker $RELEASE_TAG_FILE is missing"
+    else
+      release_tag="$(trim_file "$RELEASE_TAG_FILE")"
+      if [[ "$release_tag" != "$expected_version" ]]; then
+        record_mismatch "GitHub release tag marker $release_tag does not match VERSION $expected_version"
+      fi
+    fi
+  fi
+fi
+
+if [[ ${#failures[@]} -gt 0 ]]; then
+  printf 'Version alignment validation failed:\n' >&2
+  for failure in "${failures[@]}"; do
+    printf -- '- %s\n' "$failure" >&2
+  done
+  exit 1
+fi
+
+printf 'Version alignment validation passed for %s\n' "$expected_version"


### PR DESCRIPTION
## Summary
- Add `hooks/opencode/validate-version-alignment.sh`.
- Validate `VERSION`, `package.json`, `CHANGELOG.md`, installed asset marker, and GitHub release tag marker alignment.
- Add mismatch policy coverage for release version surfaces.

## Verification
- `bash hooks/opencode/test-policy.sh`
- `bash -n hooks/opencode/*.sh hooks/*.sh`
- `bash hooks/opencode/smoke-test.sh`

Closes #196