### PR TITLE
fix: harden worker completion checks

### DIFF
--- a/hooks/opencode/create-worktree.sh
+++ b/hooks/opencode/create-worktree.sh
@@ -14,6 +14,8 @@ cd "$REPO_ROOT"
 
 mkdir -p "$(dirname "$WORKSPACE")"
 
+git fetch origin master --quiet 2>/dev/null || git fetch origin main --quiet 2>/dev/null || true
+
 BASE_REF="origin/master"
 if ! git rev-parse --verify "$BASE_REF" >/dev/null 2>&1; then
   BASE_REF="origin/main"
@@ -21,8 +23,6 @@ fi
 if ! git rev-parse --verify "$BASE_REF" >/dev/null 2>&1; then
   BASE_REF="HEAD"
 fi
-
-git fetch origin master --quiet 2>/dev/null || git fetch origin main --quiet 2>/dev/null || true
 
 if ! git worktree add -B "$TARGET_BRANCH" "$WORKSPACE" "$BASE_REF" >/dev/null 2>&1; then
   git worktree remove --force "$WORKSPACE" >/dev/null 2>&1 || true

--- a/hooks/opencode/runner.sh
+++ b/hooks/opencode/runner.sh
@@ -56,6 +56,80 @@ EOF
   fi
 }
 
+base_ref_for_workspace() {
+  for ref in origin/master origin/main master main HEAD~1; do
+    if git rev-parse --verify "$ref" >/dev/null 2>&1; then
+      printf '%s\n' "$ref"
+      return 0
+    fi
+  done
+  return 1
+}
+
+auto_commit_workspace_changes() {
+  local issue_key="$1"
+  if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    return 0
+  fi
+
+  if git diff --quiet && git diff --cached --quiet && [[ -z "$(git ls-files --others --exclude-standard)" ]]; then
+    return 0
+  fi
+
+  git add -A
+  if git diff --cached --quiet; then
+    return 0
+  fi
+
+  git \
+    -c user.name="AutoShip" \
+    -c user.email="autoship@local" \
+    commit -m "autoship: ${issue_key} auto-commit" >> AUTOSHIP_RUNNER.log 2>&1 || true
+}
+
+is_test_path() {
+  case "$1" in
+    tests/*|test/*|*/tests/*|*/test/*|__tests__/*|*/__tests__/*|*.test.*|*.spec.*|*_test.*|*.snap|snapshots/*|*/snapshots/*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+production_additions_count() {
+  local base_ref="$1"
+  local count=0 file
+  while IFS= read -r file; do
+    [[ -n "$file" ]] || continue
+    if ! is_test_path "$file"; then
+      count=$((count + 1))
+    fi
+  done < <(git diff --name-only "$base_ref"...HEAD 2>/dev/null || git diff --name-only "$base_ref" HEAD 2>/dev/null || true)
+  printf '%s\n' "$count"
+}
+
+reject_tests_only_complete() {
+  local issue_key="$1"
+  local repo_root="$2"
+  local current base_ref prod_changes
+  current=$(tr -d '[:space:]' < status 2>/dev/null || true)
+  [[ "$current" == "COMPLETE" ]] || return 0
+  if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    return 0
+  fi
+  base_ref=$(base_ref_for_workspace || true)
+  [[ -n "$base_ref" ]] || return 0
+  if git diff --quiet "$base_ref"...HEAD 2>/dev/null || git diff --quiet "$base_ref" HEAD 2>/dev/null; then
+    return 0
+  fi
+  prod_changes=$(production_additions_count "$base_ref")
+  if [[ "$prod_changes" == "0" ]]; then
+    printf '%s\n' "REJECT: tests-only diff" >> AUTOSHIP_RUNNER.log
+    printf 'STUCK\n' > status
+    if [[ -x "$repo_root/hooks/capture-failure.sh" ]]; then
+      bash "$repo_root/hooks/capture-failure.sh" tests_only "$issue_key" "error_summary=worker reported COMPLETE with tests-only diff" 2>/dev/null || true
+    fi
+  fi
+}
+
 record_model_failure() {
   local model="$1"
   local log_file="${2:-AUTOSHIP_RUNNER.log}"
@@ -142,6 +216,8 @@ for dir in "$WORKSPACES_DIR"/*/; do
       cd "$dir"
       if command -v opencode >/dev/null 2>&1; then
         if run_worker "$model" > AUTOSHIP_RUNNER.log 2>&1; then
+          auto_commit_workspace_changes "$issue_id"
+          reject_tests_only_complete "$issue_id" "$REPO_ROOT"
           mark_stuck_unless_terminal "$issue_id" "$REPO_ROOT"
         else
           if is_billing_or_quota_failure AUTOSHIP_RUNNER.log; then
@@ -151,6 +227,8 @@ for dir in "$WORKSPACES_DIR"/*/; do
               printf '%s\n' "$fallback_model" > model
               bash "$REPO_ROOT/hooks/update-state.sh" set-running "$issue_id" agent="$fallback_model" model="$fallback_model" role="$role" 2>/dev/null || true
               if run_worker "$fallback_model" >> AUTOSHIP_RUNNER.log 2>&1; then
+                auto_commit_workspace_changes "$issue_id"
+                reject_tests_only_complete "$issue_id" "$REPO_ROOT"
                 mark_stuck_unless_terminal "$issue_id" "$REPO_ROOT"
               else
                 echo "STUCK" > status

--- a/hooks/opencode/test-policy.sh
+++ b/hooks/opencode/test-policy.sh
@@ -313,6 +313,86 @@ assert_eq "COMPLETE" "$(tr -d '[:space:]' < "$FALLBACK_REPO/.autoship/workspaces
 assert_eq "opencode/free-fallback" "$(tr -d '[:space:]' < "$FALLBACK_REPO/.autoship/workspaces/issue-208/model")" "runner records fallback model in workspace"
 jq -e '."opencode/paid-model".fail == 1 and (."opencode/paid-model".last_error | test("Insufficient balance"))' "$FALLBACK_REPO/.autoship/model-history.json" >/dev/null || fail "runner records paid model billing failure in model history"
 
+AUTOCOMMIT_REPO="$TMP_DIR/autocommit-runner-repo"
+mkdir -p "$AUTOCOMMIT_REPO/.autoship/workspaces/issue-253" "$AUTOCOMMIT_REPO/hooks/opencode" "$AUTOCOMMIT_REPO/hooks" "$AUTOCOMMIT_REPO/bin"
+git init -q "$AUTOCOMMIT_REPO"
+cp "$SCRIPT_DIR/runner.sh" "$AUTOCOMMIT_REPO/hooks/opencode/runner.sh"
+cp "$SCRIPT_DIR/../update-state.sh" "$AUTOCOMMIT_REPO/hooks/update-state.sh"
+cp "$SCRIPT_DIR/../capture-failure.sh" "$AUTOCOMMIT_REPO/hooks/capture-failure.sh"
+chmod +x "$AUTOCOMMIT_REPO/hooks/opencode/runner.sh" "$AUTOCOMMIT_REPO/hooks/update-state.sh" "$AUTOCOMMIT_REPO/hooks/capture-failure.sh"
+git -C "$AUTOCOMMIT_REPO/.autoship/workspaces/issue-253" init -q
+git -C "$AUTOCOMMIT_REPO/.autoship/workspaces/issue-253" config user.email autoship@example.invalid
+git -C "$AUTOCOMMIT_REPO/.autoship/workspaces/issue-253" config user.name AutoShip
+mkdir -p "$AUTOCOMMIT_REPO/.autoship/workspaces/issue-253/src"
+printf 'base\n' > "$AUTOCOMMIT_REPO/.autoship/workspaces/issue-253/src/lib.rs"
+git -C "$AUTOCOMMIT_REPO/.autoship/workspaces/issue-253" add src/lib.rs
+git -C "$AUTOCOMMIT_REPO/.autoship/workspaces/issue-253" commit -q -m initial
+cat > "$AUTOCOMMIT_REPO/.autoship/state.json" <<'JSON'
+{"repo":"owner/repo","issues":{"issue-253":{"state":"queued","model":"opencode/test-free","role":"implementer","attempt":1,"task_type":"medium_code"}},"stats":{},"config":{"maxConcurrentAgents":15}}
+JSON
+printf 'QUEUED\n' > "$AUTOCOMMIT_REPO/.autoship/workspaces/issue-253/status"
+printf 'test prompt\n' > "$AUTOCOMMIT_REPO/.autoship/workspaces/issue-253/AUTOSHIP_PROMPT.md"
+printf 'opencode/test-free\n' > "$AUTOCOMMIT_REPO/.autoship/workspaces/issue-253/model"
+cat > "$AUTOCOMMIT_REPO/bin/opencode" <<'SH'
+#!/usr/bin/env bash
+printf 'impl\n' >> src/lib.rs
+printf 'COMPLETE\n' > status
+printf 'implemented\n' > AUTOSHIP_RESULT.md
+exit 0
+SH
+chmod +x "$AUTOCOMMIT_REPO/bin/opencode"
+(
+  cd "$AUTOCOMMIT_REPO"
+  PATH="$AUTOCOMMIT_REPO/bin:$PATH" bash hooks/opencode/runner.sh >/dev/null
+)
+for _ in 1 2 3 4 5; do
+  [[ "$(tr -d '[:space:]' < "$AUTOCOMMIT_REPO/.autoship/workspaces/issue-253/status")" != "RUNNING" ]] && break
+  sleep 1
+done
+assert_eq "COMPLETE" "$(tr -d '[:space:]' < "$AUTOCOMMIT_REPO/.autoship/workspaces/issue-253/status")" "runner keeps complete status after auto-committing production changes"
+assert_eq "2" "$(git -C "$AUTOCOMMIT_REPO/.autoship/workspaces/issue-253" rev-list --count HEAD)" "runner auto-commits worker changes before completion"
+git -C "$AUTOCOMMIT_REPO/.autoship/workspaces/issue-253" diff --quiet || fail "runner leaves no unstaged worker changes after auto-commit"
+
+TESTS_ONLY_REPO="$TMP_DIR/tests-only-runner-repo"
+mkdir -p "$TESTS_ONLY_REPO/.autoship/workspaces/issue-254" "$TESTS_ONLY_REPO/hooks/opencode" "$TESTS_ONLY_REPO/hooks" "$TESTS_ONLY_REPO/bin"
+git init -q "$TESTS_ONLY_REPO"
+cp "$SCRIPT_DIR/runner.sh" "$TESTS_ONLY_REPO/hooks/opencode/runner.sh"
+cp "$SCRIPT_DIR/../update-state.sh" "$TESTS_ONLY_REPO/hooks/update-state.sh"
+cp "$SCRIPT_DIR/../capture-failure.sh" "$TESTS_ONLY_REPO/hooks/capture-failure.sh"
+chmod +x "$TESTS_ONLY_REPO/hooks/opencode/runner.sh" "$TESTS_ONLY_REPO/hooks/update-state.sh" "$TESTS_ONLY_REPO/hooks/capture-failure.sh"
+git -C "$TESTS_ONLY_REPO/.autoship/workspaces/issue-254" init -q
+git -C "$TESTS_ONLY_REPO/.autoship/workspaces/issue-254" config user.email autoship@example.invalid
+git -C "$TESTS_ONLY_REPO/.autoship/workspaces/issue-254" config user.name AutoShip
+mkdir -p "$TESTS_ONLY_REPO/.autoship/workspaces/issue-254/src"
+printf 'base\n' > "$TESTS_ONLY_REPO/.autoship/workspaces/issue-254/src/lib.rs"
+git -C "$TESTS_ONLY_REPO/.autoship/workspaces/issue-254" add src/lib.rs
+git -C "$TESTS_ONLY_REPO/.autoship/workspaces/issue-254" commit -q -m initial
+cat > "$TESTS_ONLY_REPO/.autoship/state.json" <<'JSON'
+{"repo":"owner/repo","issues":{"issue-254":{"state":"queued","model":"opencode/test-free","role":"implementer","attempt":1,"task_type":"medium_code"}},"stats":{},"config":{"maxConcurrentAgents":15}}
+JSON
+printf 'QUEUED\n' > "$TESTS_ONLY_REPO/.autoship/workspaces/issue-254/status"
+printf 'test prompt\n' > "$TESTS_ONLY_REPO/.autoship/workspaces/issue-254/AUTOSHIP_PROMPT.md"
+printf 'opencode/test-free\n' > "$TESTS_ONLY_REPO/.autoship/workspaces/issue-254/model"
+cat > "$TESTS_ONLY_REPO/bin/opencode" <<'SH'
+#!/usr/bin/env bash
+mkdir -p tests
+printf 'test only\n' > tests/new.test.ts
+printf 'COMPLETE\n' > status
+printf 'tests only\n' > AUTOSHIP_RESULT.md
+exit 0
+SH
+chmod +x "$TESTS_ONLY_REPO/bin/opencode"
+(
+  cd "$TESTS_ONLY_REPO"
+  PATH="$TESTS_ONLY_REPO/bin:$PATH" bash hooks/opencode/runner.sh >/dev/null
+)
+for _ in 1 2 3 4 5; do
+  [[ "$(tr -d '[:space:]' < "$TESTS_ONLY_REPO/.autoship/workspaces/issue-254/status")" != "RUNNING" ]] && break
+  sleep 1
+done
+assert_eq "STUCK" "$(tr -d '[:space:]' < "$TESTS_ONLY_REPO/.autoship/workspaces/issue-254/status")" "runner rejects tests-only complete results"
+grep -F 'REJECT: tests-only diff' "$TESTS_ONLY_REPO/.autoship/workspaces/issue-254/AUTOSHIP_RUNNER.log" >/dev/null || fail "runner records tests-only rejection reason"
+
 SESSION_REPO="$TMP_DIR/session-runner-repo"
 mkdir -p "$SESSION_REPO/.autoship/workspaces/issue-997" "$SESSION_REPO/hooks/opencode" "$SESSION_REPO/hooks" "$SESSION_REPO/bin"
 git init -q "$SESSION_REPO"


### PR DESCRIPTION
## Summary
- Auto-commit worker changes after successful `opencode run` before accepting terminal status.
- Reject worker-reported `COMPLETE` results when the diff is tests-only, marking the workspace `STUCK` with evidence.
- Fetch the remote base before selecting the worktree base ref to avoid stale branch dispatch.

Closes #253

## Test Plan
- bash hooks/opencode/test-policy.sh
- bash -n hooks/opencode/*.sh hooks/*.sh
- bash hooks/opencode/smoke-test.sh