### PR TITLE
fix: restore safety filtering for issue dispatch

### DIFF
--- a/hooks/opencode/dispatch.sh
+++ b/hooks/opencode/dispatch.sh
@@ -53,6 +53,16 @@ TITLE=$(gh issue view "$ISSUE_NUM" --json title --jq '.title' 2>/dev/null || ech
 BODY=$(gh issue view "$ISSUE_NUM" --json body --jq '.body' 2>/dev/null || echo "")
 LABELS=$(gh issue view "$ISSUE_NUM" --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
 
+safety=$(bash "$SCRIPT_DIR/safety-filter.sh" --text "$TITLE" "$LABELS" "$BODY" || true)
+if [[ "$safety" == BLOCKED:* ]]; then
+  mkdir -p "$WORKSPACE_PATH"
+  printf 'BLOCKED\n' > "$WORKSPACE_PATH/status"
+  printf '%s\n' "$safety" > "$WORKSPACE_PATH/BLOCKED_REASON.txt"
+  bash "$REPO_ROOT/hooks/update-state.sh" set-blocked "$ISSUE_KEY" reason="$safety" 2>/dev/null || true
+  echo "BLOCKED $ISSUE_KEY: $safety"
+  exit 0
+fi
+
 resolve_model() {
   local task_type="$1"
   local issue_num="$2"

--- a/hooks/opencode/file-self-improvement-issues.sh
+++ b/hooks/opencode/file-self-improvement-issues.sh
@@ -48,5 +48,5 @@ EOF
       --label "area:self-improvement" \
       --label "priority:medium" \
       --label "atomic" \
-      --label "agent:ready"
+      --label "human:required"
   done

--- a/hooks/opencode/plan-issues.sh
+++ b/hooks/opencode/plan-issues.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ISSUES_FILE=""
 CREATED_ISSUES_FILE=false
 LIMIT=""
@@ -35,10 +36,20 @@ cleanup() {
 trap cleanup EXIT
 
 jq -c '.[]' "$ISSUES_FILE" | while IFS= read -r issue; do
+  title=$(jq -r '.title // ""' <<< "$issue")
+  body=$(jq -r '.body // ""' <<< "$issue")
+  labels=$(jq -r '[.labels[].name] | join(",")' <<< "$issue")
+
   if ! jq -e 'any(.labels[].name; . == "agent:ready")' <<< "$issue" >/dev/null; then
     continue
   fi
   if jq -e 'any(.labels[].name; . == "agent:running" or . == "agent:blocked" or . == "human:required")' <<< "$issue" >/dev/null; then
+    continue
+  fi
+
+  safety=$(bash "$SCRIPT_DIR/safety-filter.sh" --text "$title" "$labels" "$body" || true)
+  if [[ "$safety" == BLOCKED:* ]]; then
+    jq -c --arg reason "$safety" '. + {blocked_reason: $reason}' <<< "$issue" >> "$blocked_tmp"
     continue
   fi
 

--- a/hooks/opencode/safety-filter.sh
+++ b/hooks/opencode/safety-filter.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 --text <title> <labels> <body> | <issue-number>" >&2
+}
+
+normalize_labels() {
+  printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]'
+}
+
+check_text() {
+  local title="$1"
+  local labels="$2"
+  local body="$3"
+  local haystack
+  haystack="$(printf '%s\n%s\n%s' "$title" "$(normalize_labels "$labels")" "$body" | tr '[:upper:]' '[:lower:]')"
+
+  if printf '%s' "$haystack" | grep -Eq '(^|[^a-z0-9])unsafe([^a-z0-9]|$)|anti[- ]?cheat|stealth|fingerprint(ing)?|vm[ -]?detect|virtual machine|shellcode|polymorphic|detour hiding|hide[ -]?(detour|hook)|hook signature|signature evasion|evasion|bypass detection|undetectable|anti[- ]?debug'; then
+    echo "BLOCKED: abuse-prone evasion or stealth content requires human review"
+    return 1
+  fi
+
+  echo "SAFE"
+}
+
+if [[ "${1:-}" == "--text" ]]; then
+  [[ $# -eq 4 ]] || { usage; exit 2; }
+  check_text "$2" "$3" "$4"
+  exit $?
+fi
+
+ISSUE_NUM="${1:-}"
+[[ -n "$ISSUE_NUM" ]] || { usage; exit 2; }
+
+TITLE=$(gh issue view "$ISSUE_NUM" --json title --jq '.title' 2>/dev/null || echo "")
+BODY=$(gh issue view "$ISSUE_NUM" --json body --jq '.body' 2>/dev/null || echo "")
+LABELS=$(gh issue view "$ISSUE_NUM" --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
+
+check_text "$TITLE" "$LABELS" "$BODY"

--- a/hooks/opencode/test-policy.sh
+++ b/hooks/opencode/test-policy.sh
@@ -90,11 +90,11 @@ bash "$SCRIPT_DIR/plan-issues.sh" --issues-file "$ISSUES_FILE" --limit 10 > "$PL
 
 eligible_numbers=$(jq -r '.eligible[].number' "$PLAN_OUTPUT" | paste -sd ' ' -)
 blocked_numbers=$(jq -r '.blocked[].number' "$PLAN_OUTPUT" | paste -sd ' ' -)
-assert_eq "746 748 749 2301" "$eligible_numbers" "eligible issues are sorted ascending and exclude only terminal/manual labels"
-assert_eq "" "$blocked_numbers" "content-based safety filter does not block issues"
+assert_eq "746 749 2301" "$eligible_numbers" "eligible issues are sorted ascending and exclude terminal/manual and unsafe content"
+assert_eq "748" "$blocked_numbers" "content-based safety filter blocks abuse-prone issue content"
 
 limited_numbers=$(bash "$SCRIPT_DIR/plan-issues.sh" --issues-file "$ISSUES_FILE" --limit 2 | jq -r '.eligible[].number' | paste -sd ' ' -)
-assert_eq "746 748" "$limited_numbers" "plan limit caps eligible queue"
+assert_eq "746 749" "$limited_numbers" "plan limit caps eligible queue after safety filtering"
 
 fix_title=$(bash "$SCRIPT_DIR/pr-title.sh" --issue 2298 --title "Validate Discord webhook URLs" --labels "bug,security,agent:ready")
 docs_title=$(bash "$SCRIPT_DIR/pr-title.sh" --issue 2296 --title "mandate poison recovery pattern" --labels "documentation,agent:ready")
@@ -230,8 +230,8 @@ RETRY_REPO="$TMP_DIR/retry-limit-repo"
 mkdir -p "$RETRY_REPO/.autoship/workspaces/issue-181" "$RETRY_REPO/.autoship/failures" "$RETRY_REPO/hooks/opencode" "$RETRY_REPO/hooks"
 git init -q "$RETRY_REPO"
 cp "$SCRIPT_DIR/../update-state.sh" "$RETRY_REPO/hooks/update-state.sh"
-cp "$SCRIPT_DIR/dispatch.sh" "$RETRY_REPO/hooks/opencode/dispatch.sh"
-chmod +x "$RETRY_REPO/hooks/update-state.sh" "$RETRY_REPO/hooks/opencode/dispatch.sh"
+cp "$SCRIPT_DIR/dispatch.sh" "$SCRIPT_DIR/safety-filter.sh" "$RETRY_REPO/hooks/opencode/"
+chmod +x "$RETRY_REPO/hooks/update-state.sh" "$RETRY_REPO/hooks/opencode/dispatch.sh" "$RETRY_REPO/hooks/opencode/safety-filter.sh"
 cat > "$RETRY_REPO/.autoship/state.json" <<'JSON'
 {"repo":"owner/repo","issues":{"issue-181":{"state":"running","attempt":3,"model":"opencode/test","role":"implementer"}},"stats":{},"config":{"maxConcurrentAgents":15,"maxRetries":3}}
 JSON
@@ -820,8 +820,8 @@ chmod +x "$ISSUE_FILE_REPO/bin/gh"
 )
 safe_line=$(grep -F 'When paid model balance fails' "$ISSUE_FILE_REPO/gh-args.log" || true)
 formerly_blocked_line=$(grep -F 'stealth hook signature evasion' "$ISSUE_FILE_REPO/gh-args.log" || true)
-printf '%s\n' "$safe_line" | grep -F 'agent:ready' >/dev/null || fail "safe self-improvement issue is labeled agent:ready"
-printf '%s\n' "$formerly_blocked_line" | grep -F 'agent:ready' >/dev/null || fail "self-improvement issue with evasion terms is labeled agent:ready"
+printf '%s\n' "$safe_line" | grep -F 'human:required' >/dev/null || fail "safe self-improvement issue requires human review"
+printf '%s\n' "$formerly_blocked_line" | grep -F 'human:required' >/dev/null || fail "self-improvement issue with evasion terms requires human review"
 
 SETUP_REPO="$TMP_DIR/setup-repo"
 mkdir -p "$SETUP_REPO/bin"
@@ -1005,7 +1005,7 @@ git -C "$DISPATCH_REPO" remote add origin git@github.com:owner/repo.git
 printf 'base\n' > "$DISPATCH_REPO/README.md"
 git -C "$DISPATCH_REPO" add README.md
 git -C "$DISPATCH_REPO" commit -q -m initial
-cp "$SCRIPT_DIR/dispatch.sh" "$SCRIPT_DIR/create-worktree.sh" "$SCRIPT_DIR/select-model.sh" "$SCRIPT_DIR/pr-title.sh" "$DISPATCH_REPO/hooks/opencode/"
+cp "$SCRIPT_DIR/dispatch.sh" "$SCRIPT_DIR/safety-filter.sh" "$SCRIPT_DIR/create-worktree.sh" "$SCRIPT_DIR/select-model.sh" "$SCRIPT_DIR/pr-title.sh" "$DISPATCH_REPO/hooks/opencode/"
 cp "$SCRIPT_DIR/../update-state.sh" "$DISPATCH_REPO/hooks/update-state.sh"
 cat > "$DISPATCH_REPO/.autoship/state.json" <<'JSON'
 {"repo":"owner/repo","issues":{},"stats":{},"config":{"maxConcurrentAgents":15}}
@@ -1032,7 +1032,7 @@ if [[ "$1 $2" == "issue edit" ]]; then
 fi
 exit 0
 SH
-chmod +x "$DISPATCH_REPO/bin/gh" "$DISPATCH_REPO/hooks/opencode/dispatch.sh" "$DISPATCH_REPO/hooks/opencode/create-worktree.sh" "$DISPATCH_REPO/hooks/opencode/select-model.sh" "$DISPATCH_REPO/hooks/opencode/pr-title.sh" "$DISPATCH_REPO/hooks/update-state.sh"
+chmod +x "$DISPATCH_REPO/bin/gh" "$DISPATCH_REPO/hooks/opencode/dispatch.sh" "$DISPATCH_REPO/hooks/opencode/safety-filter.sh" "$DISPATCH_REPO/hooks/opencode/create-worktree.sh" "$DISPATCH_REPO/hooks/opencode/select-model.sh" "$DISPATCH_REPO/hooks/opencode/pr-title.sh" "$DISPATCH_REPO/hooks/update-state.sh"
 (
   cd "$DISPATCH_REPO"
   PATH="$DISPATCH_REPO/bin:$PATH" bash hooks/opencode/dispatch.sh 456 docs >/dev/null
@@ -1051,7 +1051,7 @@ git -C "$FIXTURE_REPO" remote add origin git@github.com:owner/repo.git
 printf 'base\n' > "$FIXTURE_REPO/README.md"
 git -C "$FIXTURE_REPO" add README.md
 git -C "$FIXTURE_REPO" commit -q -m initial
-cp "$SCRIPT_DIR/plan-issues.sh" "$SCRIPT_DIR/dispatch.sh" "$SCRIPT_DIR/create-worktree.sh" "$SCRIPT_DIR/select-model.sh" "$SCRIPT_DIR/pr-title.sh" "$SCRIPT_DIR/runner.sh" "$SCRIPT_DIR/reviewer.sh" "$SCRIPT_DIR/create-pr.sh" "$FIXTURE_REPO/hooks/opencode/"
+cp "$SCRIPT_DIR/plan-issues.sh" "$SCRIPT_DIR/dispatch.sh" "$SCRIPT_DIR/safety-filter.sh" "$SCRIPT_DIR/create-worktree.sh" "$SCRIPT_DIR/select-model.sh" "$SCRIPT_DIR/pr-title.sh" "$SCRIPT_DIR/runner.sh" "$SCRIPT_DIR/reviewer.sh" "$SCRIPT_DIR/create-pr.sh" "$FIXTURE_REPO/hooks/opencode/"
 cp "$SCRIPT_DIR/../update-state.sh" "$SCRIPT_DIR/../capture-failure.sh" "$FIXTURE_REPO/hooks/"
 chmod +x "$FIXTURE_REPO"/hooks/opencode/*.sh "$FIXTURE_REPO"/hooks/*.sh
 cat > "$FIXTURE_REPO/.autoship/state.json" <<'JSON'
@@ -1110,10 +1110,10 @@ chmod +x "$FIXTURE_REPO/bin/gh" "$FIXTURE_REPO/bin/opencode"
 (
   cd "$FIXTURE_REPO"
   plan_output=$(PATH="$FIXTURE_REPO/bin:$PATH" bash hooks/opencode/plan-issues.sh --issues-file issues.json --limit 10)
-  assert_eq "188 189" "$(jq -r '.eligible[].number' <<< "$plan_output" | paste -sd ' ' -)" "fixture plan includes content formerly blocked by safety filter"
-  assert_eq "" "$(jq -r '.blocked[].number' <<< "$plan_output" | paste -sd ' ' -)" "fixture plan has no content-based safety blocks"
+  assert_eq "189" "$(jq -r '.eligible[].number' <<< "$plan_output" | paste -sd ' ' -)" "fixture plan excludes unsafe content from eligible queue"
+  assert_eq "188" "$(jq -r '.blocked[].number' <<< "$plan_output" | paste -sd ' ' -)" "fixture plan reports content-based safety blocks"
   PATH="$FIXTURE_REPO/bin:$PATH" bash hooks/opencode/dispatch.sh 188 medium_code >/dev/null
-  assert_eq "QUEUED" "$(tr -d '[:space:]' < .autoship/workspaces/issue-188/status)" "fixture dispatch queues content formerly blocked by safety filter"
+  assert_eq "BLOCKED" "$(tr -d '[:space:]' < .autoship/workspaces/issue-188/status)" "fixture dispatch blocks unsafe content via safety filter"
   PATH="$FIXTURE_REPO/bin:$PATH" bash hooks/opencode/dispatch.sh 189 medium_code >/dev/null
   assert_eq "QUEUED" "$(tr -d '[:space:]' < .autoship/workspaces/issue-189/status)" "fixture dispatch creates queued safe worktree"
   PATH="$FIXTURE_REPO/bin:$PATH" bash hooks/opencode/runner.sh >/dev/null


### PR DESCRIPTION
### Motivation
- A prior change removed the content-based safety gate allowing any `agent:ready` issue (including self-improvement reports) to be queued and its text embedded verbatim into worker prompts, exposing the host to prompt-injection / evasion / shellcode risks.
- The goal is to reintroduce minimal, robust safeguards so untrusted issue text cannot be dispatched to OpenCode workers without human review.

### Description
- Reintroduced `hooks/opencode/safety-filter.sh` which scans issue title/labels/body for abuse-prone/evasion patterns and returns `BLOCKED: ...` for matches.
- Restored content-based checks in `hooks/opencode/plan-issues.sh` so issues flagged unsafe are recorded in the `blocked` output with a `blocked_reason` instead of entering the eligible queue.
- Added the same safety gate to `hooks/opencode/dispatch.sh` to mark unsafe issues `BLOCKED` and prevent embedding untrusted text into `AUTOSHIP_PROMPT.md`.
- Changed `hooks/opencode/file-self-improvement-issues.sh` to label generated self-improvement issues `human:required` instead of `agent:ready` so they require manual review before being queued.
- Updated fixtures/tests to copy/run `safety-filter.sh` in test repos and to assert the expected blocked/eligible behavior.

### Testing
- Ran a static shell check with `bash -n hooks/opencode/*.sh hooks/*.sh`, which completed successfully.
- Executed the smoke test `bash hooks/opencode/smoke-test.sh`, which passed in this environment and exercised the safety filter path in fixture mode.
- Ran targeted script checks: `bash hooks/opencode/plan-issues.sh --issues-file <tmp>` with crafted issues confirmed unsafe items are moved to `blocked`; `dispatch.sh` with a stubbed `gh` confirmed unsafe issues are marked `BLOCKED`; `file-self-improvement-issues.sh` with a stubbed `gh` confirmed generated issues are labeled `human:required` (all succeeded).
- `bash hooks/opencode/test-policy.sh` could not fully complete in this environment due to missing GitHub authentication (`GH_TOKEN`/`gh auth login` required), so some higher-level tests that perform live GH operations were not run to completion.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed0c76757483218f5b118deccdc68e)