### PR TITLE
feat: foundational hooks for ClawSweeper improvements (#257, #258, #259, #269)

### DIFF
--- a/hooks/opencode/check.sh
+++ b/hooks/opencode/check.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+  echo "Error: not inside a git repository" >&2
+  exit 1
+}
+
+HOOKS_DIR="$REPO_ROOT/hooks"
+
+print_usage() {
+  cat <<EOF
+Usage: bash hooks/opencode/check.sh [OPTIONS]
+
+Run all AutoShip pre-commit verification checks.
+
+Options:
+  --fast       Run only syntax checks (skip full test-policy and smoke-test)
+  --policy     Run only test-policy.sh
+  --smoke      Run only smoke-test.sh
+  --syntax     Run only bash syntax checks
+  -h, --help  Show this help message
+
+Without options, runs all checks: syntax, test-policy, and smoke-test.
+EOF
+}
+
+RUN_ALL=true
+RUN_POLICY=true
+RUN_SMOKE=true
+RUN_SYNTAX=true
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --fast)
+      RUN_ALL=false
+      RUN_POLICY=false
+      RUN_SMOKE=false
+      RUN_SYNTAX=true
+      shift
+      ;;
+    --policy)
+      RUN_ALL=false
+      RUN_SYNTAX=false
+      RUN_SMOKE=false
+      shift
+      ;;
+    --smoke)
+      RUN_ALL=false
+      RUN_SYNTAX=false
+      RUN_POLICY=false
+      shift
+      ;;
+    --syntax)
+      RUN_ALL=false
+      RUN_POLICY=false
+      RUN_SMOKE=false
+      shift
+      ;;
+    -h|--help)
+      print_usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      print_usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+FAILED=0
+
+run_syntax_check() {
+  echo "=== Bash syntax check ==="
+  local syntax_failed=0
+  for script in "$HOOKS_DIR"/*.sh; do
+    [[ -f "$script" ]] || continue
+    local output
+    output=$(bash -n "$script" 2>&1) || true
+    if [[ -n "$output" ]]; then
+      echo "FAIL: syntax check failed for $script" >&2
+      echo "$output" | head -5 >&2
+      syntax_failed=1
+    fi
+  done
+  for script in "$HOOKS_DIR/opencode"/*.sh; do
+    [[ -f "$script" ]] || continue
+    local output
+    output=$(bash -n "$script" 2>&1) || true
+    if [[ -n "$output" ]]; then
+      echo "FAIL: syntax check failed for $script" >&2
+      echo "$output" | head -5 >&2
+      syntax_failed=1
+    fi
+  done
+  if [[ $syntax_failed -ne 0 ]]; then
+    FAILED=1
+  fi
+}
+
+run_policy_check() {
+  echo "=== Policy test ==="
+  (
+    set +e
+    cd "$REPO_ROOT"
+    exec bash "$HOOKS_DIR/opencode/test-policy.sh"
+  ) || {
+    echo "FAIL: policy test failed" >&2
+    FAILED=1
+  }
+}
+
+run_smoke_check() {
+  echo "=== Smoke test ==="
+  (
+    set +e
+    cd "$REPO_ROOT"
+    exec bash "$HOOKS_DIR/opencode/smoke-test.sh"
+  ) || {
+    echo "FAIL: smoke test failed" >&2
+    FAILED=1
+  }
+}
+
+if [[ "$RUN_SYNTAX" == "true" ]]; then
+  run_syntax_check
+fi
+
+if [[ "$RUN_POLICY" == "true" ]]; then
+  run_policy_check
+fi
+
+if [[ "$RUN_SMOKE" == "true" ]]; then
+  run_smoke_check
+fi
+
+if [[ $FAILED -ne 0 ]]; then
+  echo "Verification failed" >&2
+  exit 1
+fi
+
+echo "All checks passed"
+exit 0

--- a/hooks/opencode/classify-issue.sh
+++ b/hooks/opencode/classify-issue.sh
@@ -2,13 +2,62 @@
 
 set -euo pipefail
 
+AUTOSHIP_PROTECTED_LABELS="${AUTOSHIP_PROTECTED_LABELS:-do-not-automate,needs-human,wontfix,discussion,security}"
+AUTOSHIP_SKIP_LABEL="${AUTOSHIP_SKIP_LABEL:-agent:skip}"
+
+readonly AUTOSHIP_PROTECTED_LABELS
+readonly AUTOSHIP_SKIP_LABEL
+
+IFS=',' read -ra PROTECTED_LABEL_ARRAY <<< "$AUTOSHIP_PROTECTED_LABELS"
+
 ISSUE_NUM="${1:-}"
 [[ -z "$ISSUE_NUM" ]] && echo "Usage: $0 <issue-number>" >&2 && exit 1
+
+issue_has_protected_label() {
+  local label="$1"
+  local protected
+  for protected in "${PROTECTED_LABEL_ARRAY[@]}"; do
+    if [[ "$label" == "$protected" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+check_protected_labels() {
+  local labels_json="$1"
+  for label in $(echo "$labels_json" | jq -r '.[]' 2>/dev/null || echo ""); do
+    if issue_has_protected_label "$label"; then
+      echo "protected"
+      return 0
+    fi
+  done
+  return 1
+}
+
+check_skip_label() {
+  local labels_json="$1"
+  if echo "$labels_json" | jq -e '.[] | select(. == "'"$AUTOSHIP_SKIP_LABEL"'")' >/dev/null 2>&1; then
+    echo "skipped"
+    return 0
+  fi
+  return 1
+}
 
 ISSUE_BODY=$(gh issue view "$ISSUE_NUM" --json body --jq '.body' 2>/dev/null || echo "")
 ISSUE_TITLE=$(gh issue view "$ISSUE_NUM" --json title --jq '.title' 2>/dev/null || echo "")
 ISSUE_LABELS=$(gh issue view "$ISSUE_NUM" --json labels --jq '[.labels[].name]' 2>/dev/null || echo "[]")
 LABEL_TEXT=$(echo "$ISSUE_LABELS" | jq -r 'join(",")' 2>/dev/null || echo "")
+
+if check_skip_label "$ISSUE_LABELS"; then
+  echo "skipped"
+  exit 0
+fi
+
+if check_protected_labels "$ISSUE_LABELS"; then
+  echo "protected"
+  exit 0
+fi
 
 # Check for explicit label overrides
 if echo "$ISSUE_LABELS" | jq -e '.[] | test("mode:(research|docs|complex|simple)"; "i")' >/dev/null 2>&1; then

--- a/hooks/opencode/gh-retry.sh
+++ b/hooks/opencode/gh-retry.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GH_RETRY_MAX_ATTEMPTS="${GH_RETRY_MAX_ATTEMPTS:-3}"
+GH_RETRY_BASE_DELAY="${GH_RETRY_BASE_DELAY:-2}"
+GH_RETRY_MAX_DELAY="${GH_RETRY_MAX_DELAY:-30}"
+GH_RETRY_HEARTBEAT="${GH_RETRY_HEARTBEAT:-false}"
+
+readonly GH_RETRY_MAX_ATTEMPTS
+readonly GH_RETRY_BASE_DELAY
+readonly GH_RETRY_MAX_DELAY
+
+log_heartbeat() {
+  if [[ "$GH_RETRY_HEARTBEAT" == "true" ]]; then
+    echo "[gh-retry] attempt $1: $2" >&2
+  fi
+}
+
+exponential_backoff() {
+  local attempt="$1"
+  local delay=$((GH_RETRY_BASE_DELAY * (2 ** (attempt - 1))))
+  if (( delay > GH_RETRY_MAX_DELAY )); then
+    delay=$GH_RETRY_MAX_DELAY
+  fi
+  echo "$delay"
+}
+
+gh_retry() {
+  local attempt=1
+  local exit_code=0
+  local output
+  local error_output
+
+  while (( attempt <= GH_RETRY_MAX_ATTEMPTS )); do
+    log_heartbeat "$attempt" "executing: gh $*"
+
+    set +e
+    output=$(gh "$@" 2>&1)
+    exit_code=$?
+    set -e
+
+    if (( exit_code == 0 )); then
+      echo "$output"
+      return 0
+    fi
+
+    error_output=$(echo "$output" | head -3)
+
+    case "$exit_code" in
+      1)
+        if echo "$output" | grep -qiE "(not found|already exists|permission denied|unauthorized)"; then
+          log_heartbeat "$attempt" "non-retryable error: $error_output"
+          echo "$output" >&2
+          return "$exit_code"
+        fi
+        ;;
+      2)
+        log_heartbeat "$attempt" "positional argument error"
+        echo "$output" >&2
+        return "$exit_code"
+        ;;
+      4)
+        log_heartbeat "$attempt" "invalid flag/option"
+        echo "$output" >&2
+        return "$exit_code"
+        ;;
+    esac
+
+    if (( attempt < GH_RETRY_MAX_ATTEMPTS )); then
+      local delay
+      delay=$(exponential_backoff "$attempt")
+      log_heartbeat "$attempt" "failed with exit $exit_code, retrying in ${delay}s..."
+      sleep "$delay"
+    fi
+
+    ((attempt++))
+  done
+
+  echo "$output" >&2
+  return "$exit_code"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 [--] <gh-command> [args...]" >&2
+    echo "Or: source $0 && gh_retry <gh-command> [args...]" >&2
+    echo "" >&2
+    echo "Environment:" >&2
+    echo "  GH_RETRY_MAX_ATTEMPTS  - max retry attempts (default: 3)" >&2
+    echo "  GH_RETRY_BASE_DELAY   - base delay in seconds (default: 2)" >&2
+    echo "  GH_RETRY_MAX_DELAY   - max delay in seconds (default: 30)" >&2
+    echo "  GH_RETRY_HEARTBEAT   - print retry progress (default: false)" >&2
+    exit 1
+  fi
+
+  if [[ "$1" == "--" ]]; then
+    shift
+  fi
+
+  gh_retry "$@"
+fi

--- a/hooks/opencode/item-record.sh
+++ b/hooks/opencode/item-record.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+AUTOSHIP_ITEMS_DIR="${AUTOSHIP_ITEMS_DIR:-.autoship/items}"
+
+get_item_path() {
+  local issue_num="$1"
+  local base_dir="${2:-$AUTOSHIP_ITEMS_DIR}"
+  printf '%s/%s.md' "$base_dir" "$issue_num"
+}
+
+init_item_record() {
+  local issue_num="$1"
+  local issue_title="${2:-}"
+  local base_dir="${3:-$AUTOSHIP_ITEMS_DIR}"
+  local item_path
+  item_path=$(get_item_path "$issue_num" "$base_dir")
+
+  mkdir -p "$(dirname "$item_path")"
+
+  cat > "$item_path" <<EOF
+# AutoShip Issue Record: #$issue_num
+
+## Metadata
+- **Issue:** $issue_num
+- **Title:** ${issue_title:-Untitled}
+- **Created:** $(date -u +"%Y-%m-%dT%H:%M:%SZ")
+- **Updated:** $(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+## State History
+
+| Timestamp | State | Attempt | Model | Notes |
+|-----------|-------|---------|-------|-------|
+EOF
+
+  printf '%s\n' "$item_path"
+}
+
+append_item_event() {
+  local issue_num="$1"
+  local state="$2"
+  local attempt="${3:-1}"
+  local model="${4:-}"
+  local notes="${5:-}"
+  local base_dir="${6:-$AUTOSHIP_ITEMS_DIR}"
+  local item_path
+  item_path=$(get_item_path "$issue_num" "$base_dir")
+
+  if [[ ! -f "$item_path" ]]; then
+    init_item_record "$issue_num" "" "$base_dir"
+  fi
+
+  local timestamp
+  timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+  local model_cell=""
+  if [[ -n "$model" ]]; then
+    model_cell="$model"
+  fi
+
+  local notes_cell=""
+  if [[ -n "$notes" ]]; then
+    notes_cell="$notes"
+  fi
+
+  local escaped_notes
+  escaped_notes=$(printf '%s' "$notes_cell" | sed 's/|/\\|/g')
+
+  local new_line="| $timestamp | $state | $attempt | $model_cell | $escaped_notes |"
+
+  local tmp_file
+  tmp_file=$(mktemp)
+
+  if grep -q "| Timestamp |" "$item_path" 2>/dev/null; then
+    awk -v line="$new_line" '/\| Timestamp \|.*\|$/ && !done { print; print line; done=1; next } { print }' "$item_path" > "$tmp_file"
+  else
+    cp "$item_path" "$tmp_file"
+    echo "$new_line" >> "$tmp_file"
+  fi
+
+  sed -i '' "s/^## Updated:.*/## Updated: $(date -u +"%Y-%m-%dT%H:%M:%SZ")/" "$tmp_file"
+
+  mv "$tmp_file" "$item_path"
+}
+
+update_item_title() {
+  local issue_num="$1"
+  local new_title="$2"
+  local base_dir="${3:-$AUTOSHIP_ITEMS_DIR}"
+  local item_path
+  item_path=$(get_item_path "$issue_num" "$base_dir")
+
+  if [[ ! -f "$item_path" ]]; then
+    init_item_record "$issue_num" "$new_title" "$base_dir"
+    return
+  fi
+
+  sed -i '' "s/^- \*\*Title:\*\*.*/- **Title:** $new_title/" "$item_path"
+  sed -i '' "s/^## Updated:.*/## Updated: $(date -u +"%Y-%m-%dT%H:%M:%SZ")/" "$item_path"
+}
+
+get_item_state() {
+  local issue_num="$1"
+  local base_dir="${2:-$AUTOSHIP_ITEMS_DIR}"
+  local item_path
+  item_path=$(get_item_path "$issue_num" "$base_dir")
+
+  if [[ -f "$item_path" ]]; then
+    tail -10 "$item_path" | grep -E '^\|' | tail -1 | awk -F'|' '{print $3}' | tr -d ' '
+  fi
+}
+
+list_items() {
+  local base_dir="${1:-$AUTOSHIP_ITEMS_DIR}"
+
+  if [[ ! -d "$base_dir" ]]; then
+    return
+  fi
+
+  for item_file in "$base_dir"/*.md; do
+    [[ -f "$item_file" ]] || continue
+    local issue_num
+    issue_num=$(basename "$item_file" .md)
+    echo "$issue_num"
+  done | sort -n
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  COMMAND="${1:-}"
+  shift || true
+
+  case "$COMMAND" in
+    init)
+      init_item_record "$@"
+      ;;
+    append)
+      append_item_event "$@"
+      ;;
+    title)
+      update_item_title "$@"
+      ;;
+    state)
+      get_item_state "$@"
+      ;;
+    list)
+      list_items "$@"
+      ;;
+    *)
+      echo "Usage: $0 <command> [args...]" >&2
+      echo "Commands:" >&2
+      echo "  init <issue-num> [title]       - Create new item record" >&2
+      echo "  append <issue-num> <state> [attempt] [model] [notes] - Add state event" >&2
+      echo "  title <issue-num> <new-title>  - Update issue title" >&2
+      echo "  state <issue-num>              - Get current state" >&2
+      echo "  list [dir]                     - List all items" >&2
+      exit 1
+      ;;
+  esac
+fi


### PR DESCRIPTION
## Summary

Implements 4 foundational hooks that benefit all later issues in the ClawSweeper improvement wave:

### #257: `gh-retry.sh` - Shared GitHub retry helper
- Exponential backoff (2s base, 30s max)
- Configurable heartbeat logging
- Distinguishes retryable vs non-retryable errors
- Can be sourced or run standalone

### #258: Protected-label guards in `classify-issue.sh`
- Checks for protected labels: `do-not-automate`, `needs-human`, `wontfix`, `discussion`, `security`
- Added skip label: `agent:skip`
- Configurable via environment variables

### #259: `item-record.sh` - Per-issue durable markdown records
- Creates records under `.autoship/items/<n>.md`
- Tracks state history in markdown table format
- Commands: init, append, title, state, list

### #269: `check.sh` - Umbrella verification script
- Runs syntax checks, test-policy, and smoke-test via flags
- Supports: `--fast`, `--syntax`, `--policy`, `--smoke`, `--help`
- Can replace 3 separate verification commands after all issues land

## Verification

```bash
bash hooks/opencode/check.sh --syntax  # Syntax check passes
bash -n hooks/opencode/*.sh hooks/*.sh  # All bash validates
```

Note: `test-policy.sh` and `smoke-test.sh` require npm and fail in environments without it — this is a pre-existing environment constraint.

## Files Changed

- `hooks/opencode/check.sh` (new)
- `hooks/opencode/gh-retry.sh` (new)
- `hooks/opencode/item-record.sh` (new)
- `hooks/opencode/classify-issue.sh` (modified - added label guards)

## Wave Context

This is Wave 0-1 of the ClawSweeper improvements. These hooks form the foundation that later issues depend on:
- #259 (records) → #264, #266, #267, #279, #281
- #260 (checksum) and #263 (schema) cross-reference
- #272 will add shellcheck/shfmt to check.sh