### PR TITLE
feat: complete ClawSweeper-inspired AutoShip improvements (#256-#285)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,31 @@ See [AGENT_CATALOG.md](AGENT_CATALOG.md) for the specialized agent roles, inputs
 - `openai/gpt-5.5-fast` is not allowed.
 - Worker models come from live `opencode models` inventory and `.autoship/model-routing.json`.
 - Default active worker cap is 15.
-- Plan `agent:ready` issues in ascending issue-number order.
+- Plan `agent:ready` issues in ascending issue-number order (unless `AUTOSHIP_PLAN_ORDER` is set).
+
+## Available Hooks
+
+Core orchestration hooks in `hooks/opencode/`:
+- `plan-issues.sh` - Plan eligible issues from GitHub
+- `dispatch.sh` - Dispatch workers to issues
+- `runner.sh` - Execute workers
+- `reviewer.sh` - Review worker output
+- `create-pr.sh` - Create PR from approved work
+- `verify-result.sh` - Verify worker results
+- `monitor-agents.sh` - Monitor running workers
+- `reconcile-state.sh` - Reconcile state
+
+Safety hooks:
+- `sanitize-issue.sh` - Prompt-injection guardrails (#271)
+- `diff-size-guard.sh` - Diff size guardrail (#280)
+- `anti-flake.sh` - Anti-flake test retry (#282)
+- `classify-issue.sh` - Protected label guards (#258)
+
+Utilities:
+- `check.sh` - Pre-commit verification umbrella (#269)
+- `gh-retry.sh` - GitHub API retry with backoff (#257)
+- `item-record.sh` - Per-issue durable records (#259)
+- `extract-criteria.sh` - Acceptance criteria extraction (#278)
 
 ## Local State
 
@@ -22,9 +46,8 @@ See [AGENT_CATALOG.md](AGENT_CATALOG.md) for the specialized agent roles, inputs
 Before claiming work is complete, run:
 
 ```bash
-bash hooks/opencode/test-policy.sh
+bash hooks/opencode/check.sh
 bash -n hooks/opencode/*.sh hooks/*.sh
-bash hooks/opencode/smoke-test.sh
 ```
 
 ## Docs

--- a/hooks/opencode/anti-flake.sh
+++ b/hooks/opencode/anti-flake.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FLAME_RETRY_COUNT="${FLAME_RETRY_COUNT:-1}"
+FLAME_RETRY_DELAY="${FLAME_RETRY_DELAY:-5}"
+FLAME_TEST_COMMAND="${FLAME_TEST_COMMAND:-npm test}"
+
+readonly FLAME_RETRY_COUNT
+readonly FLAME_RETRY_DELAY
+
+run_with_anti_flake() {
+  local test_cmd="${1:-$FLAME_TEST_COMMAND}"
+  local attempt=0
+  local last_status=0
+
+  while (( attempt <= FLAME_RETRY_COUNT )); do
+    ((attempt++))
+
+    eval "$test_cmd" 2>&1
+    last_status=$?
+
+    if [[ $last_status -eq 0 ]]; then
+      if [[ $attempt -gt 1 ]]; then
+        echo "[anti-flake] PASS on retry $((attempt-1))/$FLAME_RETRY_COUNT" >&2
+      fi
+      return 0
+    fi
+
+    if [[ $attempt -le $FLAME_RETRY_COUNT ]]; then
+      echo "[anti-flake] FAIL (attempt $attempt/$FLAME_RETRY_COUNT), retrying in ${FLAME_RETRY_DELAY}s..." >&2
+      sleep "$FLAME_RETRY_DELAY"
+    fi
+  done
+
+  echo "[anti-flake] FAIL after $attempt attempts" >&2
+  return $last_status
+}
+
+test_flake_config() {
+  local test_cmd="${1:-$FLAME_TEST_COMMAND}"
+
+  echo "Testing anti-flake configuration..."
+  echo "  retry count: $FLAME_RETRY_COUNT"
+  echo "  retry delay: ${FLAME_RETRY_DELAY}s"
+  echo "  test command: $test_cmd"
+
+  if [[ "$FLAME_RETRY_COUNT" -lt 1 ]]; then
+    echo "ERROR: FLAME_RETRY_COUNT must be >= 1" >&2
+    return 1
+  fi
+
+  echo "Configuration OK"
+  return 0
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  COMMAND="${1:-}"
+  shift || true
+
+  case "$COMMAND" in
+    run)
+      run_with_anti_flake "${1:-$FLAME_TEST_COMMAND}"
+      ;;
+    test-config)
+      test_flake_config "${1:-$FLAME_TEST_COMMAND}"
+      ;;
+    *)
+      echo "Usage: $0 <command> [args...]" >&2
+      echo "Commands:" >&2
+      echo "  run [test-cmd]     - Run test with retry on failure" >&2
+      echo "  test-config        - Verify configuration" >&2
+      echo "" >&2
+      echo "Environment:" >&2
+      echo "  FLAME_RETRY_COUNT   - Number of retries (default: 1)" >&2
+      echo "  FLAME_RETRY_DELAY - Delay between retries in seconds (default: 5)" >&2
+      echo "  FLAME_TEST_COMMAND - Test command (default: npm test)" >&2
+      exit 1
+      ;;
+  esac
+fi

--- a/hooks/opencode/diff-size-guard.sh
+++ b/hooks/opencode/diff-size-guard.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIFF_SIZE_LIMIT="${DIFF_SIZE_LIMIT:-50000}"
+DIFF_FILE_LIMIT="${DIFF_FILE_LIMIT:-20}"
+DIFF_WARN_ONLY="${DIFF_WARN_ONLY:-false}"
+
+readonly DIFF_SIZE_LIMIT
+readonly DIFF_FILE_LIMIT
+
+check_diff_size() {
+  local worktree_dir="${1:-.}"
+  local diff_output
+  local diff_size=0
+  local diff_files=0
+
+  if [[ ! -d "$worktree_dir" ]]; then
+    echo "ERROR: worktree_dir $worktree_dir does not exist" >&2
+    return 1
+  fi
+
+  cd "$worktree_dir"
+
+  diff_output=$(git diff --stat 2>/dev/null || true)
+  if [[ -z "$diff_output" ]]; then
+    diff_output=$(git diff --stat HEAD -- 2>/dev/null || echo "")
+  fi
+
+  if [[ -z "$diff_output" ]]; then
+    echo "clean: no changes detected"
+    return 0
+  fi
+
+  diff_size=$(echo "$diff_output" | awk '{sum+=$4} END {print sum}' || echo "0")
+  diff_files=$(echo "$diff_output" | tail -1 | awk '{print $1}' || echo "0")
+
+  local status="ok"
+  local exit_code=0
+
+  if [[ $diff_size -gt $DIFF_SIZE_LIMIT ]]; then
+    status="oversize: $diff_size bytes (limit: $DIFF_SIZE_LIMIT)"
+    exit_code=1
+  elif [[ $diff_files -gt $DIFF_FILE_LIMIT ]]; then
+    status="toomany_files: $diff_files files (limit: $DIFF_FILE_LIMIT)"
+    exit_code=1
+  fi
+
+  if [[ "$DIFF_WARN_ONLY" == "true" && $exit_code -ne 0 ]]; then
+    echo "WARN: $status" >&2
+    return 0
+  fi
+
+  if [[ $exit_code -ne 0 ]]; then
+    echo "ERROR: $status" >&2
+    return 1
+  fi
+
+  echo "ok: $diff_files files, $diff_size bytes"
+  return 0
+}
+
+get_diff_summary() {
+  local worktree_dir="${1:-.}"
+  cd "$worktree_dir"
+  
+  local stats
+  local has_changes=false
+  
+  if git diff --quiet 2>/dev/null; then
+    stats="no changes"
+  else
+    stats=$(git diff --stat HEAD 2>/dev/null || git diff --stat 2>/dev/null || echo "error reading diff")
+    has_changes=true
+  fi
+  
+  local fileschanged=0
+  if [[ "$has_changes" == "true" ]]; then
+    fileschanged=$(git diff --name-only 2>/dev/null | wc -l | tr -d ' ' || echo "0")
+  fi
+  
+  jq -n \
+    --arg stats "$stats" \
+    --argjson files "$fileschanged" \
+    '{
+      diff_stats: $stats,
+      files_changed: $files
+    }'
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  COMMAND="${1:-}"
+  shift || true
+
+  case "$COMMAND" in
+    check)
+      check_diff_size "${1:-.}"
+      ;;
+    summary)
+      get_diff_summary "${1:-.}"
+      ;;
+    *)
+      echo "Usage: $0 <command> [worktree-dir]" >&2
+      echo "Commands:" >&2
+      echo "  check <dir>     - Check diff size; exit non-zero if over limit" >&2
+      echo "  summary <dir>  - Get diff summary as JSON" >&2
+      exit 1
+      ;;
+  esac
+fi

--- a/hooks/opencode/extract-criteria.sh
+++ b/hooks/opencode/extract-criteria.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+extract_criteria() {
+  local body="$1"
+  local line
+  local in_criteria=false
+  local in_oos=false
+  local criteria_lines=()
+  local oos_lines=()
+  local test_req="false"
+
+  while IFS= read -r line; do
+    local lower
+    lower=$(echo "$line" | tr '[:upper:]' '[:lower:]')
+
+    if echo "$lower" | grep -Eq '^##\s*(acceptance|criteria)'; then
+      in_criteria=true
+      in_oos=false
+      continue
+    fi
+
+    if echo "$lower" | grep -Eq '^##\s*out\s*of\s*scope'; then
+      in_criteria=false
+      in_oos=true
+      continue
+    fi
+
+    if echo "$lower" | grep -Eq '^##\s*'; then
+      in_criteria=false
+      in_oos=false
+    fi
+
+    if [[ "$in_criteria" == "true" ]]; then
+      if echo "$line" | grep -Eq '^\s*-\s+'; then
+        criteria_lines+=("$line")
+      fi
+    fi
+
+    if [[ "$in_oos" == "true" ]]; then
+      if echo "$line" | grep -Eq '^\s*-\s+'; then
+        oos_lines+=("$line")
+      fi
+    fi
+  done <<< "$body"
+
+  if echo "$body" | grep -Ei 'test|verify|evidence|check' >/dev/null 2>&1; then
+    test_req="true"
+  fi
+
+  local criteria_json
+  if [[ ${#criteria_lines[@]} -gt 0 ]]; then
+    criteria_json=$(printf '%s\n' "${criteria_lines[@]}" | jq -R . | jq -s .)
+  else
+    criteria_json='[]'
+  fi
+
+  local oos_json
+  if [[ ${#oos_lines[@]} -gt 0 ]]; then
+    oos_json=$(printf '%s\n' "${oos_lines[@]}" | jq -R . | jq -s .)
+  else
+    oos_json='[]'
+  fi
+
+  jq -n \
+    --argjson criteria "$criteria_json" \
+    --argjson oos "$oos_json" \
+    --argjson test_req "$test_req" \
+    '{
+      criteria: $criteria,
+      out_of_scope: $oos,
+      files_likely_touched: [],
+      test_evidence_required: $test_req
+    }'
+}
+
+criteria_to_prompt() {
+  local json="$1"
+  local prompt="## Acceptance Criteria"
+
+  local criteria_str
+  criteria_str=$(echo "$json" | jq -r '.criteria | join("\n- ")' 2>/dev/null || echo "")
+  if [[ "$criteria_str" != "null" && -n "$criteria_str" ]]; then
+    prompt+="\n- $criteria_str"
+  fi
+
+  local oos_str
+  oos_str=$(echo "$json" | jq -r '.out_of_scope | join("\n- ")' 2>/dev/null || echo "")
+  if [[ "$oos_str" != "null" && -n "$oos_str" ]]; then
+    prompt+="\n\n## Out of Scope\n- $oos_str"
+  fi
+
+  local test_req
+  test_req=$(echo "$json" | jq -r '.test_evidence_required' 2>/dev/null || echo "false")
+  if [[ "$test_req" == "true" ]]; then
+    prompt+="\n\n## Test Evidence Required\nProvide evidence that tests passed."
+  fi
+
+  printf '%s' "$prompt"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  COMMAND="${1:-}"
+  shift || true
+
+  case "$COMMAND" in
+    extract)
+      BODY="${1:-}"
+      [[ -z "$BODY" ]] && { echo "Usage: $0 extract <body>"; exit 1; }
+      extract_criteria "$BODY"
+      ;;
+    prompt)
+      JSON="${1:-}"
+      [[ -z "$JSON" ]] && { echo "Usage: $0 prompt <json>"; exit 1; }
+      criteria_to_prompt "$JSON"
+      ;;
+    *)
+      BODY="${1:-}"
+      [[ -z "$BODY" ]] && { echo "Usage: $0 <command> [args...]"; exit 1; }
+      extract_criteria "$BODY"
+      ;;
+  esac
+fi

--- a/hooks/opencode/sanitize-issue.sh
+++ b/hooks/opencode/sanitize-issue.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SANITIZE_LOG="${SANITIZE_LOG:-.autoship/sanitize.log}"
+SANITIZE_MAX_BODY_SIZE="${SANITIZE_MAX_BODY_SIZE:-8192}"
+SANITIZE_DRY_RUN="${SANITIZE_DRY_RUN:-false}"
+
+readonly SANITIZE_MAX_BODY_SIZE
+
+log_flagged() {
+  local issue_num="$1"
+  local pattern="$2"
+  local timestamp
+  timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  echo "[$timestamp] issue=$issue_num pattern='$pattern'" >> "$SANITIZE_LOG"
+}
+
+sanitize_issue_body() {
+  local issue_num="$1"
+  local body="$2"
+
+  local original_len=${#body}
+  local sanitized="$body"
+
+  log_flagged "$issue_num" "check_start"
+
+  if [[ $original_len -gt $SANITIZE_MAX_BODY_SIZE ]]; then
+    sanitized="${body:0:$SANITIZE_MAX_BODY_SIZE}"
+    sanitized+=$'\n\n[... truncated: original was $original_len bytes, exceeded SANITIZE_MAX_BODY_SIZE limit]'
+    log_flagged "$issue_num" "size_truncation"
+  fi
+
+  local inj_patterns=(
+    'system:' 'assistant:' 'model:' 'ignore previous'
+    '<<SYS>>' '<</sys>>' '<<INST>>' '<</INST>>'
+    '<<USER>>' '<</USER>>' '<</AUTO>>'
+  )
+
+  for pattern in "${inj_patterns[@]}"; do
+    if echo "$sanitized" | grep -Fi "$pattern" >/dev/null 2>&1; then
+      log_flagged "$issue_num" "marker:$pattern"
+      sanitized=$(echo "$sanitized" | sed -E "s|($pattern)|\\\u29FFFD|gi" || true)
+    fi
+  done
+
+  if echo "$sanitized" | grep -P '[\p{C}' >/dev/null 2>&1; then
+    log_flagged "$issue_num" "control_characters"
+    sanitized=$(echo "$sanitized" | tr -cd '[:print:]\n\t' || true)
+  fi
+
+  local base64_pattern='[A-Za-z0-9+/]{100,}={0,2}'
+  if echo "$sanitized" | grep -P "$base64_pattern" >/dev/null 2>&1; then
+    log_flagged "$issue_num" "base64_like"
+  fi
+
+  if [[ "$SANITIZE_DRY_RUN" == "false" ]]; then
+    printf '%s' "$sanitized"
+  else
+    printf '%s' "$body"
+  fi
+}
+
+wrap_issue_body() {
+  local body="$1"
+  printf '<<<USER_ISSUE_BODY>>>\n%s\n<<<END_USER_ISSUE_BODY>>>' "$body"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  COMMAND="${1:-}"
+  shift || true
+
+  case "$COMMAND" in
+    sanitize)
+      ISSUE_NUM="${1:-}" BODY="${2:-}"
+      if [[ -z "$ISSUE_NUM" || -z "$BODY" ]]; then
+        echo "Usage: $0 sanitize <issue-num> <body>" >&2
+        exit 1
+      fi
+      sanitize_issue_body "$ISSUE_NUM" "$BODY"
+      ;;
+    wrap)
+      BODY="${1:-}"
+      if [[ -z "$BODY" ]]; then
+        echo "Usage: $0 wrap <body>" >&2
+        exit 1
+      fi
+      wrap_issue_body "$BODY"
+      ;;
+    check)
+      ISSUE_NUM="${1:-}" BODY="${2:-}"
+      if [[ -z "$ISSUE_NUM" || -z "$BODY" ]]; then
+        echo "Usage: $0 check <issue-num> <body>" >&2
+        exit 1
+      fi
+      SANITIZE_DRY_RUN=true sanitize_issue_body "$ISSUE_NUM" "$BODY"
+      ;;
+    *)
+      echo "Usage: $0 <command> [args...]" >&2
+      echo "Commands:" >&2
+      echo "  sanitize <issue-num> <body>  - Sanitize and output body" >&2
+      echo "  wrap <body>             - Wrap body in delimiters" >&2
+      echo "  check <issue-num> <body> - Check but don't modify" >&2
+      exit 1
+      ;;
+  esac
+fi


### PR DESCRIPTION
## Summary

Completes the ClawSweeper-inspired AutoShip improvement wave.

## Implemented

Foundation and records:
- #257 shared `gh-retry.sh`
- #258 protected label guards
- #259 per-issue records
- #269 `check.sh` umbrella verification
- #272 shellcheck/shfmt wiring
- #277 JSON-lines logging

Worker quality and safety:
- #263 reviewer JSON schema
- #278 acceptance criteria extraction
- #279 structured PR bodies
- #281 failure evidence in retry prompts
- #260 worktree checksum reporting
- #271 prompt-injection sanitizer
- #280 diff-size guardrail
- #282 anti-flake retry
- #283 duplicate PR detection

Workflow and operations:
- #270 CI monitor
- #273 mirror issue labels/milestone onto PRs
- #285 opt-in auto-merge
- #256 audit command
- #262 propose/apply command
- #274 retry/cancel/clean commands
- #275 doctor pre-flight checks
- #276 project test/build command validation
- #284 quota guardrail

Scaling and dashboard:
- #261 cadence-based plan ordering
- #264 policy hash
- #265 GitHub Actions matrix workflow
- #266 dashboard
- #267 checkpoint writes
- #268 workflow concurrency groups by mode

## Verification

```bash
bash hooks/opencode/check.sh --syntax
bash -n hooks/opencode/*.sh hooks/*.sh
bash hooks/opencode/audit.sh
bash hooks/opencode/validate-project.sh
bash hooks/opencode/policy-hash.sh
npm run typecheck
```

Notes:
- `npm run typecheck` passes after `npm install`; generated `node_modules/` and `package-lock.json` were not committed.
- Full `check.sh` may skip shellcheck/shfmt when tools are not installed locally; CI installs them in `.github/workflows/autoship.yml`.

Closes #256
Closes #257
Closes #258
Closes #259
Closes #260
Closes #261
Closes #262
Closes #263
Closes #264
Closes #265
Closes #266
Closes #267
Closes #268
Closes #269
Closes #270
Closes #271
Closes #272
Closes #273
Closes #274
Closes #275
Closes #276
Closes #277
Closes #278
Closes #279
Closes #280
Closes #281
Closes #282
Closes #283
Closes #284
Closes #285