### PR TITLE
fix: validate lead model in forbidden-model guard

### DIFF
--- a/hooks/opencode/setup.sh
+++ b/hooks/opencode/setup.sh
@@ -214,7 +214,7 @@ if [[ -z "$SELECTED_MODELS" ]]; then
   SELECTED_MODELS=$(default_free_models "$available_model_ids")
 fi
 
-reject_forbidden_models "$SELECTED_MODELS,$PLANNER_MODEL,$COORDINATOR_MODEL,$ORCHESTRATOR_MODEL,$REVIEWER_MODEL"
+reject_forbidden_models "$SELECTED_MODELS,$PLANNER_MODEL,$COORDINATOR_MODEL,$ORCHESTRATOR_MODEL,$REVIEWER_MODEL,$LEAD_MODEL"
 
 if [[ -z "$SELECTED_MODELS" ]]; then
   echo "Error: no free OpenCode models found. Set AUTOSHIP_MODELS to choose models explicitly." >&2


### PR DESCRIPTION
### Motivation
- The `LEAD_MODEL` role was made configurable but was omitted from the forbidden-model validation, allowing a banned model like `openai/gpt-5.5-fast` to be selected for the lead role and bypass safety checks.

### Description
- Add `LEAD_MODEL` to the call to `reject_forbidden_models` in `hooks/opencode/setup.sh` so the lead-role configuration is validated alongside planner/coordinator/orchestrator/reviewer models.

### Testing
- Ran `bash -n hooks/opencode/*.sh hooks/*.sh`, which succeeded with no syntax errors; `bash hooks/opencode/test-policy.sh` failed in this environment due to missing/authenticated `gh` CLI; and `bash hooks/opencode/smoke-test.sh` failed due to an external `npm` registry `403` in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebfd00cf8c8321a128905e7910890e)