### PR TITLE
fix: remove eval from verification test execution

### DIFF
--- a/hooks/opencode/anti-flake.sh
+++ b/hooks/opencode/anti-flake.sh
@@ -12,12 +12,21 @@ run_with_anti_flake() {
   local test_cmd="${1:-$FLAME_TEST_COMMAND}"
   local attempt=0
   local last_status=0
+  local -a cmd_parts=()
+
+  # Execute the command directly (no eval) to avoid shell injection when
+  # test_cmd comes from repo-controlled configuration.
+  read -r -a cmd_parts <<< "$test_cmd"
+  if [[ "${#cmd_parts[@]}" -eq 0 ]]; then
+    echo "[anti-flake] FAIL: empty test command" >&2
+    return 1
+  fi
 
   while (( attempt <= FLAME_RETRY_COUNT )); do
     ((attempt++))
 
     set +e
-    eval "$test_cmd" 2>&1
+    "${cmd_parts[@]}" 2>&1
     last_status=$?
     set -e
 

--- a/hooks/opencode/verify-result.sh
+++ b/hooks/opencode/verify-result.sh
@@ -68,11 +68,13 @@ fi
 [[ "$has_diff" == true ]] || fail "git diff is empty"
 
 if [[ -n "$TEST_COMMAND" && "$TEST_COMMAND" != "none" ]]; then
+  read -r -a test_cmd_parts <<< "$TEST_COMMAND"
+  [[ "${#test_cmd_parts[@]}" -gt 0 ]] || fail "test command is empty"
   if [[ -x "$SCRIPT_DIR/anti-flake.sh" ]]; then
     if ! (cd "$GIT_WORKTREE" && bash "$SCRIPT_DIR/anti-flake.sh" run "$TEST_COMMAND") >> "$LOG_PATH" 2>&1; then
       fail "test command failed"
     fi
-  elif ! (cd "$GIT_WORKTREE" && eval "$TEST_COMMAND") >> "$LOG_PATH" 2>&1; then
+  elif ! (cd "$GIT_WORKTREE" && "${test_cmd_parts[@]}") >> "$LOG_PATH" 2>&1; then
     fail "test command failed"
   fi
 fi


### PR DESCRIPTION
### Motivation

- A deterministic verification path executed `test_command` read from `.autoship/config.json` via `eval`, creating a command-injection/RCE vector when the config is attacker-controlled.
- The intent is to preserve verification behavior while eliminating shell-eval of untrusted strings.

### Description

- Updated `hooks/opencode/anti-flake.sh` to tokenize the test command into an argv array and execute it directly instead of using `eval`, preventing shell metacharacter interpretation.
- Updated `hooks/opencode/verify-result.sh` to parse `TEST_COMMAND` into an argv array and use that array for the fallback execution path instead of `eval`, and added a guard for an empty command.
- Kept existing flow that prefers running the `anti-flake.sh` wrapper when present, preserving retry semantics and default test commands like `npm test`/`make test`/`cargo test`/`pytest`/`go test ./...`.

### Testing

- Ran a syntax check with `bash -n hooks/opencode/*.sh hooks/*.sh`, which succeeded.
- Ran `bash hooks/opencode/check.sh` (the repository policy/smoke steps reached remote npm registry and failed with `403 Forbidden` unrelated to the patch, so full check cannot complete in this environment).
- Performed a direct anti-flake probe by running `bash hooks/opencode/anti-flake.sh run "echo SAFE; touch /tmp/autoship_eval_probe"` and verified the probe file was NOT created, demonstrating the removal of `eval` prevented execution of shell metacharacters.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed79ee0a04832192ab1ae47e712d6c)