### PR TITLE
Harden issue monitor watermark path handling

### DIFF
--- a/hooks/monitor-issues.sh
+++ b/hooks/monitor-issues.sh
@@ -47,6 +47,22 @@ AUTOSHIP_MD_LAST_MTIME=$(_autoship_md_mtime)
 
 WATERMARK_FILE="$AUTOSHIP_DIR/.issue-monitor-watermark"
 
+if [[ -L "$AUTOSHIP_DIR" ]]; then
+  echo "Error: $AUTOSHIP_DIR must not be a symlink" >&2
+  exit 1
+fi
+
+if [[ -e "$WATERMARK_FILE" ]]; then
+  if [[ -L "$WATERMARK_FILE" ]]; then
+    echo "Error: $WATERMARK_FILE must not be a symlink" >&2
+    exit 1
+  fi
+  if [[ ! -f "$WATERMARK_FILE" ]]; then
+    echo "Error: $WATERMARK_FILE must be a regular file" >&2
+    exit 1
+  fi
+fi
+
 # Initialize watermark on first run (capture current time, emit nothing on first loop)
 if [[ ! -f "$WATERMARK_FILE" ]]; then
   last_check=$(date -u +"%Y-%m-%dT%H:%M:%SZ")


### PR DESCRIPTION
### Motivation
- The issue monitor read and wrote `.autoship/.issue-monitor-watermark` without validating paths, allowing a local symlink to redirect and clobber arbitrary files; this change prevents that symlink-based overwrite. 

### Description
- Add a check that `.`autoship` is not a symlink and refuse to run if it is. 
- Validate an existing ` .autoship/.issue-monitor-watermark` path and fail fast if it is a symlink or not a regular file. 
- Preserve the original watermark initialization and periodic update behavior after the path is validated so normal operation is unchanged for safe layouts. 

### Testing
- Ran `bash hooks/opencode/test-policy.sh` which completed successfully. 
- Ran `bash -n hooks/opencode/*.sh hooks/*.sh` (shell syntax check) which completed successfully. 
- Ran `bash hooks/opencode/smoke-test.sh` which failed in this environment due to the `gh` CLI being unavailable (expected in CI where `gh` is present).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebac788b388321ae9308fe42dd6a77)