### PR TITLE
fix: block symlinked event queue state paths

### DIFF
--- a/hooks/opencode/process-event-queue.sh
+++ b/hooks/opencode/process-event-queue.sh
@@ -19,9 +19,19 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 1
 fi
 
+assert_not_symlink() {
+  local path="$1"
+  if [[ -L "$path" ]]; then
+    echo "Error: refusing to operate on symlinked path: $path" >&2
+    exit 1
+  fi
+}
+
 if [[ -z "${AUTOSHIP_QUEUE_LOCKED:-}" ]]; then
   export AUTOSHIP_QUEUE_LOCKED=1
+  assert_not_symlink "$AUTOSHIP_DIR"
   mkdir -p "$AUTOSHIP_DIR"
+  assert_not_symlink "$LOCK_FILE"
   touch "$LOCK_FILE"
   if [[ "$(uname -s 2>/dev/null || true)" == "Darwin" ]] && command -v lockf >/dev/null 2>&1; then
     exec lockf -k "$LOCK_FILE" "$0" "$@"
@@ -38,6 +48,7 @@ make_tmp() { mktemp "$AUTOSHIP_DIR/event-queue.tmp.XXXXXX"; }
 ensure_array_file() {
   local file="$1"
   local tmp
+  assert_not_symlink "$file"
   if [[ ! -f "$file" ]] || ! jq -e 'type == "array"' "$file" >/dev/null 2>&1; then
     tmp=$(make_tmp)
     printf '[]\n' > "$tmp"


### PR DESCRIPTION
### Motivation
- Prevent local file clobbering when the event queue processor follows symlinks inside `.autoship` (lock file and queue files) which could truncate arbitrary targets.  This change closes a symlink safety gap introduced by the processor.

### Description
- Add `assert_not_symlink()` helper to `hooks/opencode/process-event-queue.sh` to detect and refuse symlinked paths.  
- Call `assert_not_symlink` before operating on the `.autoship` directory and the event queue lock file to avoid touching or opening symlink targets.  
- Call `assert_not_symlink` in `ensure_array_file()` to prevent creating/replacing queue files when the destination is a symlink.  
- No behavioral change for normal (non-symlink) paths; existing locking and queue semantics are preserved.

### Testing
- Ran `bash hooks/opencode/check.sh` and the OpenCode policy and smoke checks completed successfully.  
- Ran shell syntax check `bash -n hooks/opencode/*.sh hooks/*.sh` which reported no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed79eed7ec83218dc48f967a1045c7)