### PR TITLE
docs: update release publishing guidance

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -101,10 +101,17 @@ git tag -a "$VERSION" -m "$VERSION"
 Publish the npm package from the same commit used for the tag. This is the canonical package for the long-term global install path documented as `npm install -g opencode-autoship`.
 
 ```bash
+npm install --package-lock=false
 npm publish --access public
 ```
 
-If npm publish fails, do not move the tag. Fix the release commit, retag only if the failed tag has not been pushed, and rerun verification.
+If npm prompts with a browser authentication URL, complete the npm CLI auth flow and rerun `npm publish --access public`. If npm publish fails for any other reason, do not move the tag. Fix the release commit, retag only if the failed tag has not been pushed, and rerun verification.
+
+Remove local publish artifacts after publishing if they were created only for the release:
+
+```bash
+rm -rf node_modules dist package-lock.json
+```
 
 `bunx opencode-autoship install` is the one-time/no-global path. It resolves the same npm package but does not leave the CLI installed on PATH.
 
@@ -158,6 +165,7 @@ Confirm the tag, GitHub release, and npm package agree.
 git rev-parse "$VERSION"
 gh release view "$VERSION"
 npm view "opencode-autoship@$PACKAGE_VERSION" version
+npm view opencode-autoship dist-tags --json
 ```
 
 The release is complete when all final checks report `$VERSION` or `$PACKAGE_VERSION` as appropriate.

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -12,7 +12,7 @@ AutoShip is the OpenCode plugin for solo maintainers who want their GitHub issue
 - Selects role models from live OpenCode inventory instead of requiring one fixed provider
 - Selects worker models from the live `opencode models` inventory
 - Defaults to ranked free worker models from the live OpenCode inventory and rotates compatible workers by issue number
-- Allows operator-selected Spark, Go-provider, Nvidia, OpenRouter, and other OpenCode models when available
+- Includes OpenCode Go models as allowed low-cost subscription fallbacks and allows explicitly selected Spark, Nvidia, OpenRouter, Zen, and other provider models when available
 - Runs up to 15 active workers by default
 
 ## Pages

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -50,7 +50,7 @@ Equivalent flags are `--refresh-models` and `--worker-models`.
 
 ## Role model is not what I expected
 
-Planner, coordinator, orchestrator, reviewer, and lead are frontier roles selected from the live `opencode models` inventory. AutoShip prefers capable free role models when available; `openai/gpt-5.5-fast` is not allowed.
+Planner, coordinator, orchestrator, reviewer, and lead are frontier roles selected from the live `opencode models` inventory. AutoShip prefers capable free models first, then OpenCode Go models when available; `openai/gpt-5.5-fast` is not allowed.
 
 Use `AUTOSHIP_PLANNER_MODEL` or `--planner-model` to set all frontier roles together. Use `AUTOSHIP_ORCHESTRATOR_MODEL` / `--orchestrator-model` or `AUTOSHIP_REVIEWER_MODEL` / `--reviewer-model` for first-run role choices, and `AUTOSHIP_LEAD_MODEL` or `--lead-model` to override only the lead role.
 


### PR DESCRIPTION
## Summary
- Document npm browser-auth handling during release publishing.
- Add release cleanup and npm dist-tag verification steps.
- Clarify wiki model routing language for free-first and OpenCode Go fallback behavior.

## Test Plan
- git diff --check
- bash hooks/opencode/check.sh --syntax