### PR TITLE
fix: reject symlinked AUTOSHIP_RESULT in create-pr

### DIFF
--- a/hooks/opencode/create-pr.sh
+++ b/hooks/opencode/create-pr.sh
@@ -17,10 +17,7 @@ canonical_dir() {
 }
 
 canonical_file() {
-  local dir base
-  dir=$(dirname "$1")
-  base=$(basename "$1")
-  printf '%s/%s\n' "$(canonical_dir "$dir")" "$base"
+  readlink -f -- "$1"
 }
 
 is_runtime_artifact() {
@@ -52,9 +49,16 @@ if [[ ! -s "$RESULT_PATH" ]]; then
   echo "VERDICT: FAIL - AUTOSHIP_RESULT.md missing"
   exit 1
 fi
+if [[ -L "$RESULT_PATH" ]]; then
+  echo "VERDICT: FAIL - AUTOSHIP_RESULT.md must not be a symlink"
+  exit 1
+fi
 
 REAL_WORKTREE=$(canonical_dir "$WORKTREE_PATH")
-REAL_RESULT=$(canonical_file "$RESULT_PATH")
+REAL_RESULT=$(canonical_file "$RESULT_PATH") || {
+  echo "VERDICT: FAIL - cannot resolve AUTOSHIP_RESULT.md"
+  exit 1
+}
 case "$REAL_RESULT" in
   "$REAL_WORKTREE"/*) ;;
   *)

--- a/hooks/opencode/test-policy.sh
+++ b/hooks/opencode/test-policy.sh
@@ -1236,6 +1236,14 @@ chmod +x "$FIXTURE_REPO/bin/gh" "$FIXTURE_REPO/bin/opencode"
   if PATH="$FIXTURE_REPO/bin:$PATH" bash hooks/opencode/create-pr.sh issue-190 "$artifact_workspace" >/dev/null 2>&1; then
     fail "PR dry-run must reject artifact-only worktrees"
   fi
+  symlink_workspace="$FIXTURE_REPO/.autoship/workspaces/issue-symlink-result"
+  mkdir -p "$symlink_workspace"
+  git -C "$FIXTURE_REPO" worktree add -q "$symlink_workspace" HEAD
+  printf 'implementation\n' > "$symlink_workspace/implementation.txt"
+  ln -s /etc/hosts "$symlink_workspace/AUTOSHIP_RESULT.md"
+  if PATH="$FIXTURE_REPO/bin:$PATH" bash hooks/opencode/create-pr.sh issue-190 "$symlink_workspace" >/dev/null 2>&1; then
+    fail "PR dry-run must reject symlinked AUTOSHIP_RESULT.md"
+  fi
   live_workspace="$FIXTURE_REPO/.autoship/workspaces/issue-191"
   git -C "$FIXTURE_REPO" worktree add -q -b autoship/issue-191 "$live_workspace" HEAD
   printf 'implementation\n' > "$live_workspace/implementation.txt"


### PR DESCRIPTION
### Motivation
- The `create-pr.sh` hook previously resolved only the result file's directory and then blindly read `AUTOSHIP_RESULT.md`, allowing a malicious worker to symlink that file to a sensitive host path and have its contents exfiltrated into a PR body.

### Description
- Replace `canonical_file` implementation with `readlink -f --` so the file path itself is resolved to an absolute realpath using `readlink`.
- Add an explicit guard to reject symlinked `AUTOSHIP_RESULT.md` (`[[ -L "$RESULT_PATH" ]]`) and fail closed if the file cannot be resolved.
- Add a regression fixture in `hooks/opencode/test-policy.sh` that creates a worktree with `AUTOSHIP_RESULT.md` symlinked to `/etc/hosts` and asserts `create-pr.sh` rejects it.

### Testing
- Ran a syntax check with `bash -n hooks/opencode/*.sh hooks/*.sh`, which completed successfully.
- Ran `bash hooks/opencode/check.sh` which exercised policy checks but failed in this environment due to an external `npm` registry `403` when installing `@types/node` (environmental issue), so full checks could not complete here.
- Added the fixture test in `hooks/opencode/test-policy.sh` to assert rejection of symlinked `AUTOSHIP_RESULT.md` (intended to run as part of the test suite).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed78eeace08321a1b88aac37f11e43)