### PR TITLE
fix: scope verified PR commits to the issue worktree

### DIFF
--- a/hooks/opencode/process-event-queue.sh
+++ b/hooks/opencode/process-event-queue.sh
@@ -148,25 +148,27 @@ create_verified_pr() {
   local body_path="$workspace/AUTOSHIP_PR_BODY.md"
   local number title labels pr_title pr_url branch
 
+  [[ -d "$workspace" ]] || return 1
+
   number=$(issue_number "$issue")
   title=$(issue_title "$issue")
   labels=$(issue_labels "$issue")
   pr_title=$(bash "$SCRIPT_DIR/pr-title.sh" --issue "$number" --title "$title" --labels "$labels")
-  branch=$(git branch --show-current 2>/dev/null || true)
+  branch=$(git -C "$workspace" branch --show-current 2>/dev/null || true)
   [[ -n "$branch" ]] || branch="autoship/issue-$number"
 
   generate_pr_body "$issue"
 
-  git add -A -- . ':!.autoship'
-  if git diff --cached --quiet; then
+  git -C "$workspace" add -A -- .
+  if git -C "$workspace" diff --cached --quiet; then
     return 1
   fi
-  git commit -m "$pr_title
+  git -C "$workspace" commit -m "$pr_title
 
 Closes #$number
 Dispatched by AutoShip." >/dev/null
 
-  pr_url=$(gh pr create \
+  pr_url=$(cd "$workspace" && gh pr create \
     --title "$pr_title" \
     --body-file "$body_path" \
     --label autoship \


### PR DESCRIPTION
### Motivation
- Close a security gap where `create_verified_pr` staged and committed from the repository root while verification ran in the per-issue worktree, which could cause unreviewed/root changes to be pushed.
- Ensure PR creation only operates on the verified per-issue workspace to prevent leaking unreviewed local changes.

### Description
- Added a workspace existence guard (`[[ -d "$workspace" ]] || return 1`) to `create_verified_pr` in `hooks/opencode/process-event-queue.sh` to avoid accidental root fallbacks.
- Switched branch detection to use the worktree (`git -C "$workspace" branch --show-current`) and default to `autoship/issue-$number` when empty.
- Scoped staging and commit operations to the workspace with `git -C "$workspace" add -A -- .` and `git -C "$workspace" commit ...`, and run `gh pr create` from the workspace via `cd "$workspace"` so only verified worktree changes are committed and pushed.

### Testing
- Ran a shell syntax check with `bash -n hooks/opencode/*.sh hooks/*.sh`; this passed.
- Ran `bash hooks/opencode/check.sh`; this failed in the execution environment due to blocked network access to the npm registry (HTTP 403), not due to the change itself.
- Ran `bash hooks/opencode/test-policy.sh`; this also failed for the same npm registry/network issue in this environment, preventing full policy smoke tests from completing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed79ee650c8321b15956c27d74041c)