### PR TITLE
fix: prevent awk injection in quota guard

### DIFF
--- a/hooks/opencode/quota-guard.sh
+++ b/hooks/opencode/quota-guard.sh
@@ -6,11 +6,23 @@ QUOTA_FILE="$REPO_ROOT/.autoship/quota.json"
 STATE_FILE="$REPO_ROOT/.autoship/state.json"
 THRESHOLD="${AUTOSHIP_QUOTA_PAUSE_THRESHOLD:-95}"
 
-quota=$(jq -r '.quota_pct // .usage_pct // -1' "$QUOTA_FILE" 2>/dev/null || echo -1)
-if awk "BEGIN { exit !($quota >= $THRESHOLD && $quota >= 0) }"; then
+quota_raw=$(jq -r '.quota_pct // .usage_pct // -1' "$QUOTA_FILE" 2>/dev/null || echo -1)
+if [[ "$quota_raw" =~ ^-?[0-9]+([.][0-9]+)?$ ]]; then
+  quota="$quota_raw"
+else
+  quota="-1"
+fi
+
+if [[ "$THRESHOLD" =~ ^-?[0-9]+([.][0-9]+)?$ ]]; then
+  threshold="$THRESHOLD"
+else
+  threshold="95"
+fi
+
+if awk -v quota="$quota" -v threshold="$threshold" 'BEGIN { exit !(quota >= threshold && quota >= 0) }'; then
   tmp=$(mktemp)
   jq '.paused = true | .pause_reason = "quota guardrail"' "$STATE_FILE" > "$tmp" && mv "$tmp" "$STATE_FILE"
-  echo "AutoShip paused: quota ${quota}% >= ${THRESHOLD}%"
+  echo "AutoShip paused: quota ${quota}% >= ${threshold}%"
   exit 1
 fi
 echo "Quota OK: ${quota}%"


### PR DESCRIPTION
### Motivation
- The quota guard previously interpolated the `quota_pct` value from `.autoship/quota.json` directly into an `awk` program, which could be exploited to execute arbitrary commands via `awk`'s `system()` if the file was tampered with. 
- The goal is to remove the injection primitive while preserving the guard behavior that pauses AutoShip when quota crosses the threshold. 
- Provide a minimal, defense-in-depth fix that validates inputs and avoids embedding untrusted data into awk source code.

### Description
- Updated `hooks/opencode/quota-guard.sh` to read `quota_raw` and validate it as a numeric value with a regex, falling back to `-1` for non-numeric values. 
- Added numeric validation for `AUTOSHIP_QUOTA_PAUSE_THRESHOLD` with a safe default of `95` when malformed. 
- Changed the `awk` invocation to pass `quota` and `threshold` via `-v` variables instead of interpolating them into the awk program, eliminating the command-injection vector. 
- Preserves existing behavior of updating `state.json` (`.paused` and `pause_reason`) and emitting the same pause/ok messages.

### Testing
- Ran a shell syntax check with `bash -n hooks/opencode/*.sh hooks/*.sh`, which passed. 
- Ran the repository verification `bash hooks/opencode/check.sh`, which failed in this environment due to an external `npm` registry `403` and missing local tooling and is unrelated to this change. 
- Performed an automated regression test that writes a crafted payload to `.autoship/quota.json` and runs `bash hooks/opencode/quota-guard.sh`, which resulted in `INJECTION_BLOCKED` and did not create the marker file, confirming the injection path is closed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed79ee148483219f859a0d6890be6f)