### PR TITLE
fix: prevent symlink-based file clobbering in item-record hook

### DIFF
--- a/hooks/opencode/item-record.sh
+++ b/hooks/opencode/item-record.sh
@@ -3,9 +3,39 @@ set -euo pipefail
 
 AUTOSHIP_ITEMS_DIR="${AUTOSHIP_ITEMS_DIR:-.autoship/items}"
 
+die() {
+  echo "$*" >&2
+  exit 1
+}
+
+sanitize_issue_num() {
+  local issue_num="$1"
+  if [[ ! "$issue_num" =~ ^[0-9]+$ ]]; then
+    echo "Invalid issue number: $issue_num" >&2
+    return 1
+  fi
+  printf '%s' "$issue_num"
+}
+
+resolve_items_dir() {
+  local base_dir="${1:-$AUTOSHIP_ITEMS_DIR}"
+  if [[ -L "$base_dir" ]]; then
+    echo "Refusing to operate on symlinked items directory: $base_dir" >&2
+    return 1
+  fi
+  mkdir -p "$base_dir"
+  if [[ -L "$base_dir" ]]; then
+    echo "Refusing to operate on symlinked items directory: $base_dir" >&2
+    return 1
+  fi
+  (cd "$base_dir" && pwd -P)
+}
+
 get_item_path() {
   local issue_num="$1"
   local base_dir="${2:-$AUTOSHIP_ITEMS_DIR}"
+  issue_num=$(sanitize_issue_num "$issue_num") || return 1
+  base_dir=$(resolve_items_dir "$base_dir") || return 1
   printf '%s/%s.md' "$base_dir" "$issue_num"
 }
 
@@ -16,7 +46,9 @@ init_item_record() {
   local item_path
   item_path=$(get_item_path "$issue_num" "$base_dir")
 
-  mkdir -p "$(dirname "$item_path")"
+  if [[ -L "$item_path" ]]; then
+    die "Refusing to write to symlinked item record: $item_path"
+  fi
 
   cat > "$item_path" <<EOF
 # AutoShip Issue Record: #$issue_num
@@ -45,6 +77,10 @@ append_item_event() {
   local base_dir="${6:-$AUTOSHIP_ITEMS_DIR}"
   local item_path
   item_path=$(get_item_path "$issue_num" "$base_dir")
+
+  if [[ -L "$item_path" ]]; then
+    die "Refusing to write to symlinked item record: $item_path"
+  fi
 
   if [[ ! -f "$item_path" ]]; then
     init_item_record "$issue_num" "" "$base_dir"
@@ -89,6 +125,10 @@ update_item_title() {
   local base_dir="${3:-$AUTOSHIP_ITEMS_DIR}"
   local item_path
   item_path=$(get_item_path "$issue_num" "$base_dir")
+
+  if [[ -L "$item_path" ]]; then
+    die "Refusing to write to symlinked item record: $item_path"
+  fi
 
   if [[ ! -f "$item_path" ]]; then
     init_item_record "$issue_num" "$new_title" "$base_dir"


### PR DESCRIPTION
### Motivation
- `hooks/opencode/item-record.sh` previously constructed item file paths directly from `AUTOSHIP_ITEMS_DIR` and the issue number then wrote/`mv`'d over them, which allows a local symlink to cause arbitrary file overwrite. 
- The vulnerability remains present in HEAD and must be mitigated by refusing to follow or write through symlinked AutoShip state paths. 
- The change hardens path handling with minimal behavioral changes so existing workflows that use a real `.autoship/items` directory continue to work.

### Description
- Added `die()`, `sanitize_issue_num()` and `resolve_items_dir()` helpers to validate inputs and canonicalize the items directory. 
- `sanitize_issue_num()` enforces numeric issue IDs before path construction and `resolve_items_dir()` canonicalizes the base directory and refuses to operate on symlinked directories. 
- `get_item_path()` now calls the sanitizers and `init_item_record`, `append_item_event`, and `update_item_title` explicitly refuse to write when the computed item file path is a symlink. 
- Only `hooks/opencode/item-record.sh` was modified to implement these guards and preserve existing file-format and event-append behavior.

### Testing
- Ran `bash -n hooks/opencode/*.sh hooks/*.sh` which succeeded with no syntax errors. 
- Ran `bash hooks/opencode/check.sh` which executed shell checks but the policy/smoke portion failed in this environment due to external `npm` registry `403 Forbidden` errors (environmental, not related to the patch). 
- Executed an automated symlink reproduction test (create symlink `.autoship/items -> /tmp/target` then `bash hooks/opencode/item-record.sh init 42 'Test'`) which confirmed the script now refuses to operate and the symlink target remains unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed79eecf148321b9ec4b42cc3ee857)