### PR TITLE
fix: preserve anti-flake retries under set -e

### DIFF
--- a/hooks/opencode/anti-flake.sh
+++ b/hooks/opencode/anti-flake.sh
@@ -14,7 +14,7 @@ run_with_anti_flake() {
   local last_status=0
 
   while (( attempt <= FLAME_RETRY_COUNT )); do
-    ((attempt++))
+    ((++attempt))
 
     set +e
     eval "$test_cmd" 2>&1


### PR DESCRIPTION
### Motivation
- Fix a bug where the anti-flake retry loop could exit immediately under `set -e` because `((attempt++))` evaluates to zero on the first iteration and produces a non-zero exit status, preventing the intended retry behavior.

### Description
- Replace `((attempt++))` with `((++attempt))` in `hooks/opencode/anti-flake.sh` so the loop increments without triggering `set -e` and the retry logic records test failures and retries as intended.

### Testing
- Reproduced and validated with `FLAME_RETRY_COUNT=2 FLAME_RETRY_DELAY=0 bash hooks/opencode/anti-flake.sh run 'echo attempt; false'` which now prints the expected retry attempts and exits with the final test status; `bash -n hooks/opencode/*.sh hooks/*.sh` passed; `bash hooks/opencode/check.sh` failed in this environment due to npm registry auth (`403`) and missing `gh`, which are unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed7bf5395c8321a6f158385df25a09)