### PR TITLE
fix(security): fail-closed when repo root is unresolved

### DIFF
--- a/hooks/opencode/lib/common.sh
+++ b/hooks/opencode/lib/common.sh
@@ -6,7 +6,10 @@ set -euo pipefail
 
 # ── Repo root detection ──────────────────────────────────────────
 autoship_repo_root() {
-  git rev-parse --show-toplevel 2>/dev/null || pwd
+  git rev-parse --show-toplevel 2>/dev/null || {
+    echo "Error: not inside a git repository" >&2
+    return 1
+  }
 }
 
 # ── Script directory detection ───────────────────────────────────


### PR DESCRIPTION
### Motivation
- Prevent execution of attacker-controlled hook scripts by restoring fail-closed behavior when the repository root cannot be determined so wrapper functions do not resolve to the current working directory.

### Description
- Replace the `git rev-parse ... || pwd` fallback with an explicit error and non-zero return in `autoship_repo_root()` in `hooks/opencode/lib/common.sh`, so callers like `autoship_state_set` and `autoship_capture_failure` fail instead of using `pwd`.

### Testing
- Ran `bash -n hooks/opencode/*.sh hooks/*.sh` which passed, and ran `bash hooks/opencode/check.sh` which failed due to pre-existing unrelated issues (a syntax error in `hooks/opencode/verify-result.sh` and policy/smoke check failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f21354ed5c83218a5f063d7c59c9dc)