### PR TITLE
fix(verify): enforce policy-verify hook regardless of executable bit

### DIFF
--- a/hooks/opencode/verify-result.sh
+++ b/hooks/opencode/verify-result.sh
@@ -64,6 +64,15 @@ if [[ -n "$TEST_COMMAND" && "$TEST_COMMAND" != "none" ]]; then
   fi
 fi
 
+
+if [[ -f "$SCRIPT_DIR/policy-verify.sh" ]]; then
+  if ! bash "$SCRIPT_DIR/policy-verify.sh" "$GIT_WORKTREE" >> "$LOG_PATH" 2>&1; then
+    fail "policy verification failed"
+  fi
+else
+  fail "policy verification script missing"
+fi
+
 reviewer_output=$(mktemp)
 if ! bash "$SCRIPT_DIR/reviewer.sh" "$ISSUE_KEY" "$WORKTREE_PATH" "$RESULT_PATH" "$TEST_COMMAND" > "$reviewer_output" 2>&1; then
   cp "$reviewer_output" "$LOG_PATH" 2>/dev/null || true


### PR DESCRIPTION
### Motivation
- Policy verification was gated on the script being executable (`-x`), but `hooks/opencode/policy-verify.sh` may be committed non-executable causing the check to be skipped and creating a security-control bypass; the change ensures verification cannot be silently bypassed.

### Description
- Update `hooks/opencode/verify-result.sh` to check for file presence with `-f` and invoke `policy-verify.sh` using `bash`, and to `fail` closed when the script is missing so policy verification always runs when present.

### Testing
- Ran `bash -n hooks/opencode/*.sh hooks/*.sh`, which succeeded.
- Ran `bash hooks/opencode/check.sh`, which failed due to pre-existing environment/repository issues (shell syntax and npm registry/package checks) unrelated to this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f215bfd5dc8321a6c766b34e713db5)