### PR TITLE
fix: exclude .autoship from verified PR staging

### DIFF
--- a/hooks/opencode/process-event-queue.sh
+++ b/hooks/opencode/process-event-queue.sh
@@ -193,7 +193,7 @@ create_verified_pr() {
 
   generate_pr_body "$issue"
 
-  git -C "$workspace" add -A -- .
+  git -C "$workspace" add -A -- . ":!.autoship"
   if git -C "$workspace" diff --cached --quiet; then
     return 1
   fi


### PR DESCRIPTION
### Motivation
- Prevent accidental inclusion of local AutoShip runtime state and configuration files into verified PR branches by reinstating a stable path-based exclusion for `.autoship/`, because recent staging changed from `git add -A -- . ':!.autoship'` to `git add -A -- .` and that allows runtime files copied into the workspace to be committed if `.gitignore` is modified.

### Description
- Restore the explicit exclusion in `create_verified_pr` by changing `git -C "$workspace" add -A -- .` to `git -C "$workspace" add -A -- . ":!.autoship"` in `hooks/opencode/process-event-queue.sh`, ensuring `.autoship/` runtime artifacts are not staged for the PR.

### Testing
- Ran `bash -n hooks/opencode/*.sh hooks/*.sh` (syntax check passed) and `bash hooks/opencode/check.sh` (failed due to unrelated pre-existing repo/environment issues including a syntax error in `hooks/opencode/verify-result.sh` and npm policy/network errors), and the change is a single-line modification with no new syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f215c5ce60832198bc2b83935c4025)