### PR TITLE
fix(runner): correct env argument ordering for cargo isolation

### DIFF
--- a/hooks/opencode/runner.sh
+++ b/hooks/opencode/runner.sh
@@ -109,8 +109,9 @@ run_worker() {
     cargo_target_dir="$PWD/target-isolated"
   fi
   if [[ -n "$cargo_target_dir" ]]; then
-    env CARGO_TARGET_DIR="$cargo_target_dir" \
+    env \
       -u OPENCODE -u OPENCODE_CLIENT -u OPENCODE_PID -u OPENCODE_PROCESS_ROLE -u OPENCODE_RUN_ID -u OPENCODE_SERVER_PASSWORD -u OPENCODE_SERVER_USERNAME \
+      CARGO_TARGET_DIR="$cargo_target_dir" \
       opencode run --model "$model" "$(cat AUTOSHIP_PROMPT.md)"
   else
     env \


### PR DESCRIPTION
### Motivation
- Fix the broken `env` invocation in `run_worker()` where environment variable assignment appeared before `env` options, causing GNU `env` to treat `-u` as a command and preventing `opencode run` from starting when cargo target isolation is enabled.

### Description
- Update `run_worker()` to pass `-u` unset options to `env` before the `CARGO_TARGET_DIR=...` assignment so the isolated cargo branch invokes `opencode run` correctly without changing runtime logic.

### Testing
- Ran shell syntax check with `bash -n hooks/opencode/runner.sh` which succeeded. 
- Ran the verification umbrella `bash hooks/opencode/check.sh` which failed due to unrelated pre-existing repository issues (`hooks/opencode/verify-result.sh` syntax error, missing package files, and npm registry errors). 
- Ran policy tests with `bash hooks/opencode/test-policy.sh` which failed due to missing required policy files in the repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2272782b88321bc041823cdb8ce8b)