### PR TITLE
fix(runner): correct env arg order for cargo isolation

### DIFF
--- a/hooks/opencode/runner.sh
+++ b/hooks/opencode/runner.sh
@@ -109,8 +109,9 @@ run_worker() {
     cargo_target_dir="$PWD/target-isolated"
   fi
   if [[ -n "$cargo_target_dir" ]]; then
-    env CARGO_TARGET_DIR="$cargo_target_dir" \
+    env \
       -u OPENCODE -u OPENCODE_CLIENT -u OPENCODE_PID -u OPENCODE_PROCESS_ROLE -u OPENCODE_RUN_ID -u OPENCODE_SERVER_PASSWORD -u OPENCODE_SERVER_USERNAME \
+      CARGO_TARGET_DIR="$cargo_target_dir" \
       opencode run --model "$model" "$(cat AUTOSHIP_PROMPT.md)"
   else
     env \


### PR DESCRIPTION
### Motivation
- The cargo-isolation branch in `run_worker` invoked `env` with environment assignments before `-u` options, causing `env` to treat `-u` as a command and exit with error which systematically prevented Rust workers from starting. 
- The change aims to restore valid `env` parsing while keeping cargo target isolation behavior unchanged so Rust workspaces are not marked STUCK.

### Description
- Reordered the `env` invocation in `run_worker` so all `-u` unset options appear before the `CARGO_TARGET_DIR=...` assignment. 
- Kept the `cargo_target_dir` gating and the `opencode run --model` invocation intact so behavior is preserved when isolation is enabled. 
- This is a minimal, targeted fix limited to `hooks/opencode/runner.sh` with no other logic modifications.

### Testing
- `bash -n hooks/opencode/*.sh hooks/*.sh` succeeded with no syntax errors for the modified files. 
- `bash -n hooks/opencode/runner.sh` succeeded and shows the corrected `env` ordering. 
- `bash hooks/opencode/check.sh` was run and failed due to pre-existing repository/environment issues unrelated to this change (syntax error in `hooks/opencode/verify-result.sh` and npm smoke/policy test failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f22c052d048321b9c71b534c576319)