### PR TITLE
fix(policy): tolerate malformed .autoship/config.json and add regression tests

### DIFF
--- a/hooks/opencode/policy.sh
+++ b/hooks/opencode/policy.sh
@@ -40,7 +40,13 @@ policy_json() {
 effective_policy_json() {
   local config_filter='with_entries(select(.key as $key | ["cargoConcurrencyCap", "cargoTargetIsolationThreshold", "cargoTimeoutSeconds", "mergeStrategy", "quotaRouting", "workerCwdLock", "truncationSalvage", "workflowRunnerDefault"] | index($key)))'
   if [[ -f "$CONFIG_FILE" ]]; then
-    policy_json | jq --slurpfile config "$CONFIG_FILE" ". * (\$config[0] | $config_filter)"
+    local config_override
+    config_override=$(jq -c "$config_filter" "$CONFIG_FILE" 2>/dev/null || true)
+    if [[ -n "$config_override" ]]; then
+      policy_json | jq --argjson config "$config_override" '. * $config'
+    else
+      policy_json
+    fi
   else
     policy_json
   fi

--- a/hooks/opencode/test-policy.sh
+++ b/hooks/opencode/test-policy.sh
@@ -56,6 +56,22 @@ assert_canonical_inventory() {
 assert_canonical_inventory
 
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+POLICY_REPO="$TMP_DIR/policy-repo"
+mkdir -p "$POLICY_REPO/.autoship" "$POLICY_REPO/hooks/opencode" "$POLICY_REPO/policies"
+git init -q "$POLICY_REPO"
+cp "$SCRIPT_DIR/policy.sh" "$POLICY_REPO/hooks/opencode/policy.sh"
+cp "$REPO_ROOT/policies/default.json" "$POLICY_REPO/policies/default.json"
+(
+  cd "$POLICY_REPO"
+  printf '{broken json\n' > .autoship/config.json
+  bash hooks/opencode/policy.sh json >/dev/null || fail "policy json falls back when config is malformed"
+  assert_eq "8" "$(bash hooks/opencode/policy.sh value cargoConcurrencyCap)" "policy value falls back when config is malformed"
+  printf '"bad-type"\n' > .autoship/config.json
+  bash hooks/opencode/policy.sh json >/dev/null || fail "policy json falls back when config is non-object"
+  assert_eq "8" "$(bash hooks/opencode/policy.sh value cargoConcurrencyCap)" "policy value falls back when config is non-object"
+)
+
 test -f "$REPO_ROOT/commands/autoship-setup.md" || fail "canonical /autoship-setup command file is installed"
 grep -F '| `/autoship-setup` |' "$REPO_ROOT/README.md" >/dev/null || fail "README public command table includes /autoship-setup"
 grep -F '| `/autoship-setup` |' "$REPO_ROOT/commands/autoship.md" >/dev/null || fail "/autoship command table includes /autoship-setup"


### PR DESCRIPTION
### Motivation
- A recent change made `hooks/opencode/policy.sh` attempt to `jq --slurpfile` the `.autoship/config.json` unconditionally, causing `policy.sh json` and `policy.sh value` to hard-fail when the config file is malformed or a non-object.
- The intent is to preserve existing behavior where invalid or unusable local config is ignored and the repository policy defaults are used instead of aborting automation.

### Description
- Update `hooks/opencode/policy.sh` to safely extract allowed override keys with `jq -c` and, if parsing yields a usable object, apply it with `--argjson`, otherwise fall back to base policy JSON so malformed or non-object configs are ignored.
- Add regression coverage in `hooks/opencode/test-policy.sh` which creates a temporary repo with `.autoship/config.json` set to malformed JSON and to a non-object JSON value and asserts that `policy.sh json` and `policy.sh value cargoConcurrencyCap` succeed and return the default value.
- The change touches `hooks/opencode/policy.sh` and `hooks/opencode/test-policy.sh` and preserves the previous precedence where explicit per-key config still overrides defaults when valid.

### Testing
- Ran `bash hooks/opencode/check.sh` which reported failure due to pre-existing issues unrelated to this patch (a syntax error in `hooks/opencode/verify-result.sh`, package verification expectations, and an npm registry error), so full verification did not complete in this environment.
- Ran a static syntax pass with `bash -n hooks/opencode/*.sh hooks/*.sh` which succeeded (no syntax errors introduced by this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f22d09ec0883218eaee9154739b558)