### PR TITLE
feat(hermes): post-merge cleanup for worktrees and branches

### DIFF
--- a/hooks/hermes/post-merge-cleanup.sh
+++ b/hooks/hermes/post-merge-cleanup.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Post-merge cleanup: remove worktrees after PR is merged
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ISSUE_NUM="${1:?Issue number required}"
+REPO="${HERMES_TARGET_REPO:-Maleick/TextQuest}"
+
+echo "=== Post-merge cleanup for issue #$ISSUE_NUM ==="
+
+# 1. Remove local worktree
+wt_path="/Users/maleick/Projects/TextQuest.worktrees/issue-${ISSUE_NUM}"
+if [[ -d "$wt_path" ]]; then
+  echo "Removing worktree: $wt_path"
+  cd /Users/maleick/Projects/TextQuest
+  git worktree remove "$wt_path" --force 2>/dev/null || rm -rf "$wt_path" 2>/dev/null || true
+  git worktree prune
+  echo "✅ Worktree removed"
+else
+  echo "No worktree found at $wt_path"
+fi
+
+# 2. Remove AutoShip workspace
+ws_path="/Users/maleick/Projects/AutoShip/.autoship/workspaces/issue-${ISSUE_NUM}"
+if [[ -d "$ws_path" ]]; then
+  echo "Removing workspace: $ws_path"
+  rm -rf "$ws_path"
+  echo "✅ Workspace removed"
+fi
+
+# 3. Clean up branch
+branch="autoship/issue-${ISSUE_NUM}"
+cd /Users/maleick/Projects/TextQuest
+if git branch | grep -q "$branch"; then
+  git branch -D "$branch" 2>/dev/null || true
+  echo "✅ Local branch removed"
+fi
+
+# 4. Update issue labels
+gh issue edit "$ISSUE_NUM" --repo "$REPO" --remove-label atomic:ready --add-label atomic:complete 2>/dev/null || true
+
+echo "=== Cleanup complete ==="


### PR DESCRIPTION
## Problem

After PR merge, worktrees and branches accumulate:
- TextQuest.worktrees/issue-* directories persist
- AutoShip workspaces remain in .autoship/
- Local branches stay in git

## Solution

Add post-merge-cleanup.sh that runs after PR merge:
1. Removes git worktree
2. Removes AutoShip workspace
3. Deletes local branch
4. Updates issue label to atomic:complete

## Integration

Called by:
- Manual: bash hooks/hermes/post-merge-cleanup.sh <issue>
- Cron: Add to burn-down digest to cleanup completed items
- Webhook: GitHub PR merge webhook (future)

## Testing

Test with a completed issue after next burn-down.