### PR TITLE
AutoShip: [FEATURE] Set up GhidraMCP on Frostreaver for autonomous EQ binary research (#343)

### DIFF
--- a/docs/GHIDRA_MCP_SETUP.md
+++ b/docs/GHIDRA_MCP_SETUP.md
@@ -1,0 +1,101 @@
+# GhidraMCP Setup Guide for Frostreaver
+
+## Prerequisites
+- Windows 10/11 on Frostreaver
+- Java JDK 17+ (download from https://adoptium.net/ if missing)
+- eqgame.exe binary available
+
+## Step 1: Install Ghidra
+
+Download and extract:
+```powershell
+# Run in PowerShell as xmale
+$GhidraVersion = "11.3.2"
+$Url = "https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_${GhidraVersion}_build/ghidra_${GhidraVersion}_PUBLIC_20250415.zip"
+Invoke-WebRequest -Uri $Url -OutFile "$env:USERPROFILE\Downloads\ghidra.zip" -UseBasicParsing
+Expand-Archive -Path "$env:USERPROFILE\Downloads\ghidra.zip" -DestinationPath "C:\ghidra" -Force
+```
+
+## Step 2: Install GhidraMCP Plugin
+
+```powershell
+# Download GhidraMCP 1.4
+$McpUrl = "https://github.com/LaurieWired/GhidraMCP/releases/download/GhidraMCP-1.4/GhidraMCP-1-4.zip"
+Invoke-WebRequest -Uri $McpUrl -OutFile "$env:USERPROFILE\Downloads\ghidramcp.zip" -UseBasicParsing
+Expand-Archive -Path "$env:USERPROFILE\Downloads\ghidramcp.zip" -DestinationPath "C:\ghidra\GhidraMCP" -Force
+```
+
+In Ghidra GUI:
+1. File → Install Extensions
+2. Click `+` button
+3. Select `C:\ghidra\GhidraMCP\GhidraMCP-1-4.zip`
+4. Restart Ghidra
+5. File → Configure → Developer → Enable **GhidraMCPPlugin**
+
+## Step 3: Load eqgame.exe
+
+1. Create new project: File → New Project → Non-Shared
+2. File → Import File → select `eqgame.exe`
+3. Select "x86:LE:64:default" as language
+4. Run auto-analysis (Analysis → Auto Analyze)
+
+## Step 4: Enable GhidraMCP HTTP Server
+
+1. Edit → Tool Options → GhidraMCP HTTP Server
+2. Set port to **8080**
+3. Enable the server
+4. Verify: `curl http://localhost:8080/` should return JSON status
+
+## Step 5: Network Access from Mac
+
+Option A — Tailscale (recommended):
+- Frostreaver already has Tailscale
+- Ensure Tailscale is running on both Mac and Frostreaver
+- Access via `http://100.90.7.126:8080/`
+
+Option B — SSH tunnel:
+```bash
+# From Mac terminal
+ssh -L 8080:localhost:8080 xmale@192.168.1.207
+```
+
+## Step 6: Claude Code MCP Configuration
+
+Add to `.claude/settings.json` on your Mac:
+
+```json
+{
+  "mcpServers": {
+    "ghidra": {
+      "command": "python",
+      "args": [
+        "/ABSOLUTE_PATH_TO/bridge_mcp_ghidra.py",
+        "--ghidra-server",
+        "http://100.90.7.126:8080/"
+      ]
+    }
+  }
+}
+```
+
+Or for SSE transport (Cline/VSC):
+```bash
+python bridge_mcp_ghidra.py --transport sse --mcp-host 127.0.0.1 --mcp-port 8081 --ghidra-server http://100.90.7.126:8080/
+```
+
+## Research Targets Checklist
+
+- [ ] Movement agreement packet opcode and field layout
+- [ ] Memshift detection opcodes (6 main loop opcodes every 3 min)
+- [ ] A/B packet counter function location
+- [ ] TLP anti-cheat system entry points
+- [ ] CEverQuest::StartCasting validation (offset 0x14029D5A0)
+
+## Troubleshooting
+
+| Issue | Fix |
+|-------|-----|
+| Java not found | Install Eclipse Temurin JDK 17 from adoptium.net |
+| Plugin won't load | Ensure GhidraMCP version matches Ghidra version |
+| HTTP server not responding | Check Windows Firewall, allow port 8080 |
+| Can't reach from Mac | Verify Tailscale connected on both machines |

--- a/scripts/install_ghidra_frostreaver.ps1
+++ b/scripts/install_ghidra_frostreaver.ps1
@@ -1,0 +1,74 @@
+# Ghidra + GhidraMCP Installation Script for Frostreaver
+# Run as xmale in PowerShell (Admin not required)
+
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "Continue"
+
+# Config
+$GhidraVersion = "11.3.2"
+$GhidraUrl = "https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_${GhidraVersion}_build/ghidra_${GhidraVersion}_PUBLIC_20250415.zip"
+$GhidraMcpUrl = "https://github.com/LaurieWired/GhidraMCP/releases/download/GhidraMCP-1.4/GhidraMCP-1-4.zip"
+$InstallDir = "C:\ghidra"
+$DownloadsDir = "$env:USERPROFILE\Downloads"
+
+# Ensure install dir
+if (!(Test-Path $InstallDir)) {
+    New-Item -ItemType Directory -Path $InstallDir | Out-Null
+}
+
+# Download Ghidra
+$GhidraZip = "$DownloadsDir\ghidra_${GhidraVersion}_PUBLIC.zip"
+if (!(Test-Path $GhidraZip)) {
+    Write-Host "Downloading Ghidra ${GhidraVersion}..."
+    Invoke-WebRequest -Uri $GhidraUrl -OutFile $GhidraZip -UseBasicParsing
+} else {
+    Write-Host "Ghidra zip already downloaded."
+}
+
+# Extract Ghidra
+Write-Host "Extracting Ghidra to ${InstallDir}..."
+Expand-Archive -Path $GhidraZip -DestinationPath $InstallDir -Force
+
+# Find extracted folder (usually ghidra_${GhidraVersion}_PUBLIC)
+$GhidraHome = (Get-ChildItem -Path $InstallDir -Directory | Select-Object -First 1).FullName
+Write-Host "Ghidra home: $GhidraHome"
+
+# Download GhidraMCP
+$McpZip = "$DownloadsDir\GhidraMCP-1-4.zip"
+if (!(Test-Path $McpZip)) {
+    Write-Host "Downloading GhidraMCP 1.4..."
+    Invoke-WebRequest -Uri $GhidraMcpUrl -OutFile $McpZip -UseBasicParsing
+} else {
+    Write-Host "GhidraMCP zip already downloaded."
+}
+
+# Extract GhidraMCP
+$McpDir = "$InstallDir\GhidraMCP"
+if (!(Test-Path $McpDir)) {
+    New-Item -ItemType Directory -Path $McpDir | Out-Null
+}
+Expand-Archive -Path $McpZip -DestinationPath $McpDir -Force
+
+# Verify Java
+$java = Get-Command java -ErrorAction SilentlyContinue
+if (!$java) {
+    Write-Warning "Java not found in PATH. Ghidra requires JDK 17+. Please install from https://adoptium.net/"
+} else {
+    Write-Host "Java found: $($java.Source)"
+}
+
+Write-Host ""
+Write-Host "=== INSTALLATION COMPLETE ==="
+Write-Host "Ghidra home: $GhidraHome"
+Write-Host "GhidraMCP plugin: $McpDir"
+Write-Host ""
+Write-Host "Next steps (manual):"
+Write-Host "1. Launch Ghidra:  ${GhidraHome}\ghidraRun.bat"
+Write-Host "2. File -> Install Extensions -> + -> Select ${McpDir}\GhidraMCP-1-4.zip"
+Write-Host "3. Restart Ghidra"
+Write-Host "4. File -> Configure -> Developer -> Enable GhidraMCPPlugin"
+Write-Host "5. Load eqgame.exe, run auto-analysis"
+Write-Host "6. Enable HTTP server: Edit -> Tool Options -> GhidraMCP HTTP Server"
+Write-Host ""
+Write-Host "MCP bridge config for Claude Code:"
+Write-Host "  python $McpDir\bridge_mcp_ghidra.py --ghidra-server http://127.0.0.1:8080/"


### PR DESCRIPTION
## Summary

Adds documentation and installation scripts to set up GhidraMCP (LaurieWired/GhidraMCP) on the Frostreaver Windows machine for autonomous reverse engineering of eqgame.exe.

## Changes

-  — Complete setup guide covering:
  - Ghidra 11.3.2 installation via PowerShell
  - GhidraMCP 1.4 plugin installation and configuration
  - eqgame.exe loading and auto-analysis steps
  - Network access configuration (Tailscale + SSH tunnel options)
  - Claude Code MCP server configuration ()
  - Research targets checklist (movement packets, memshift, anti-cheat)
  - Troubleshooting table

-  — Automated PowerShell script that:
  - Downloads Ghidra and GhidraMCP to 
  - Verifies Java installation
  - Prints next-step instructions for GUI configuration

## Verification

- [x] Documentation reviewed for accuracy against GhidraMCP 1.4 release
- [x] PowerShell script syntax validated
- [x] URLs verified (Ghidra 11.3.2, GhidraMCP 1.4)

## Next Steps (Manual)

1. Run  on Frostreaver as xmale
2. Complete GUI steps in Ghidra (extensions, plugin enable, HTTP server)
3. Load eqgame.exe and run auto-analysis
4. Configure Tailscale/Claude Code MCP endpoint

## Issue

Closes #343