### PR TITLE
ci(release): use npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,5 +36,4 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
## Summary
- Remove the stale `NPM_TOKEN` release env so semantic-release uses npm Trusted Publisher/OIDC.
- Keep `id-token: write` and the existing semantic-release flow intact.

## Verification
- `bash hooks/opencode/check.sh`
- `bash -n hooks/opencode/*.sh hooks/hermes/*.sh hooks/*.sh`

## Test Plan
- Merge this PR to `main`.
- Confirm the Release workflow publishes through npm Trusted Publisher.
- Close issue #349 after the release passes.