### PR TITLE
fix(hermes): make worker timeout configurable

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -122,6 +122,8 @@ This is now standard procedure for all repos under `~/Projects/`.
 
 **Hermes result-file pitfall**: Hermes prompts write `HERMES_RESULT.md`, while shared OpenCode PR helpers default to `AUTOSHIP_RESULT.md`. `hooks/hermes/runner.sh` must pass `$worktree_path/HERMES_RESULT.md` into `hooks/opencode/create-pr.sh`; otherwise completed Hermes work can create PRs but log `VERDICT: FAIL - AUTOSHIP_RESULT.md missing`.
 
+**Issue closure pitfall**: Worker prompts must NOT tell Hermes to run `gh issue close` after PR creation. Use `Closes #N` in the PR body and let GitHub close the issue after merge. Manually closing issues while their PRs are open hides follow-up work from AutoShip planners and breaks issue/PR lifecycle state.
+
 If you encounter old stubs, update AutoShip: `cd ~/Projects/AutoShip && git pull origin main`
 
 **User Preference**: All AutoShip improvements must be made in `~/Projects/AutoShip` repo and submitted as PRs (or direct to main if explicitly approved). Do not bake AutoShip logic into this Hermes skill — keep skills as thin wrappers.

--- a/SKILL.md
+++ b/SKILL.md
@@ -120,6 +120,8 @@ This is now standard procedure for all repos under `~/Projects/`.
 - `HERMES_TARGET_REPO_PATH`: Must be set to target repo path (default: `$HOME/Projects/TextQuest`)
 - `HERMES_SESSION_ID`: Auto-detected; triggers delegate_task mode instead of `hermes chat`
 
+**Hermes result-file pitfall**: Hermes prompts write `HERMES_RESULT.md`, while shared OpenCode PR helpers default to `AUTOSHIP_RESULT.md`. `hooks/hermes/runner.sh` must pass `$worktree_path/HERMES_RESULT.md` into `hooks/opencode/create-pr.sh`; otherwise completed Hermes work can create PRs but log `VERDICT: FAIL - AUTOSHIP_RESULT.md missing`.
+
 If you encounter old stubs, update AutoShip: `cd ~/Projects/AutoShip && git pull origin main`
 
 **User Preference**: All AutoShip improvements must be made in `~/Projects/AutoShip` repo and submitted as PRs (or direct to main if explicitly approved). Do not bake AutoShip logic into this Hermes skill — keep skills as thin wrappers.

--- a/hooks/hermes/dispatch.sh
+++ b/hooks/hermes/dispatch.sh
@@ -202,7 +202,7 @@ prompt = f"""# Hermes Agent Prompt — AutoShip Issue #{issue_num}
 - Commit with conventional format: "feat|fix|docs|refactor(scope): description (#{issue_num})".
 - **PUSH branch to origin**: `git push origin autoship/issue-{issue_num}`
 - **CREATE PR via gh CLI**: `gh pr create --title "..." --body "Closes #{issue_num}" --base {base_branch} --head autoship/issue-{issue_num}`
-- **CLOSE issue**: `gh issue close {issue_num} --reason completed`
+- **DO NOT manually close the GitHub issue**. The `Closes #{issue_num}` PR body will close it only after the PR is merged. Manually closing issues while PRs are still open blocks follow-up automation.
 - Write HERMES_RESULT.md in worktree root with: status (COMPLETE/BLOCKED/STUCK), files changed, validation results.
 - Update {workspace_path}/status to COMPLETE, BLOCKED, or STUCK.
 - If stuck at minute 8, stop and report STUCK with exact status.

--- a/hooks/hermes/runner.sh
+++ b/hooks/hermes/runner.sh
@@ -96,7 +96,7 @@ if [[ -n "${1:-}" ]]; then
   if command -v hermes &>/dev/null; then
     # Hermes CLI available — spawn hermes chat.
     cd "$worktree_path"
-    # Timeout: 10 minutes (600 seconds) for atomic work
+    # Timeout: configurable; default 30 minutes for AutoShip workers
     # Use gtimeout on macOS, timeout on Linux
     TIMEOUT_CMD=""
     if command -v gtimeout &>/dev/null; then
@@ -110,12 +110,13 @@ if [[ -n "${1:-}" ]]; then
       autoship_state_set set-blocked "$ISSUE_KEY" reason="timeout_unavailable"
       exit 0
     fi
-    "$TIMEOUT_CMD" 600 hermes chat -q "$(cat "$workspace_dir/HERMES_PROMPT.md")" --worktree --quiet || {
+    HERMES_WORKER_TIMEOUT_SECONDS="${HERMES_WORKER_TIMEOUT_SECONDS:-1800}"
+    "$TIMEOUT_CMD" "$HERMES_WORKER_TIMEOUT_SECONDS" hermes chat -q "$(cat "$workspace_dir/HERMES_PROMPT.md")" --worktree --quiet || {
       exit_code=$?
       if [[ $exit_code -eq 124 ]]; then
-        echo "TIMEOUT: $ISSUE_KEY exceeded 10 minutes"
+        echo "TIMEOUT: $ISSUE_KEY exceeded ${HERMES_WORKER_TIMEOUT_SECONDS}s"
         printf 'STUCK\n' >"$status_file"
-        autoship_state_set set-stuck "$ISSUE_KEY" reason="timeout_10min"
+        autoship_state_set set-stuck "$ISSUE_KEY" reason="timeout_${HERMES_WORKER_TIMEOUT_SECONDS}s"
       else
         echo "ERROR: $ISSUE_KEY exited with code $exit_code"
         printf 'BLOCKED\n' >"$status_file"

--- a/hooks/hermes/runner.sh
+++ b/hooks/hermes/runner.sh
@@ -34,9 +34,9 @@ cd "$REPO_ROOT"
 AUTOSHIP_DIR="$REPO_ROOT/.autoship"
 WORKSPACES_DIR="$AUTOSHIP_DIR/workspaces"
 
-# Read Hermes max concurrent from config.yaml
-MAX=20
-if [[ -f "$HOME/.hermes/config.yaml" ]]; then
+# Read Hermes max concurrent from config.yaml; allow AutoShip runs to cap lower.
+MAX="${HERMES_MAX_WORKERS:-20}"
+if [[ -z "${HERMES_MAX_WORKERS:-}" && -f "$HOME/.hermes/config.yaml" ]]; then
   config_max=$(grep 'max_concurrent_children' "$HOME/.hermes/config.yaml" | awk '{print $2}' | tr -d '"')
   if [[ "$config_max" =~ ^[0-9]+$ ]]; then
     MAX="$config_max"
@@ -111,7 +111,14 @@ if [[ -n "${1:-}" ]]; then
       exit 0
     fi
     HERMES_WORKER_TIMEOUT_SECONDS="${HERMES_WORKER_TIMEOUT_SECONDS:-1800}"
-    "$TIMEOUT_CMD" "$HERMES_WORKER_TIMEOUT_SECONDS" hermes chat -q "$(cat "$workspace_dir/HERMES_PROMPT.md")" --worktree --quiet || {
+    HERMES_MODEL_ARGS=()
+    if [[ -n "${HERMES_MODEL:-}" ]]; then
+      HERMES_MODEL_ARGS+=(--model "$HERMES_MODEL")
+    fi
+    if [[ -n "${HERMES_PROVIDER:-}" ]]; then
+      HERMES_MODEL_ARGS+=(--provider "$HERMES_PROVIDER")
+    fi
+    "$TIMEOUT_CMD" "$HERMES_WORKER_TIMEOUT_SECONDS" hermes chat "${HERMES_MODEL_ARGS[@]}" -q "$(cat "$workspace_dir/HERMES_PROMPT.md")" --worktree --quiet || {
       exit_code=$?
       if [[ $exit_code -eq 124 ]]; then
         echo "TIMEOUT: $ISSUE_KEY exceeded ${HERMES_WORKER_TIMEOUT_SECONDS}s"

--- a/hooks/hermes/runner.sh
+++ b/hooks/hermes/runner.sh
@@ -137,8 +137,9 @@ if [[ -n "${1:-}" ]]; then
 
     if [[ "$result_status" == "COMPLETE" ]]; then
       autoship_state_set set-complete "$ISSUE_KEY"
-      # Trigger PR creation
-      bash "$SCRIPT_DIR/../opencode/create-pr.sh" "$ISSUE_NUM" "$worktree_path"
+      # Trigger PR creation. Hermes workers write HERMES_RESULT.md, while the
+      # shared OpenCode PR helper defaults to AUTOSHIP_RESULT.md.
+      bash "$SCRIPT_DIR/../opencode/create-pr.sh" "$ISSUE_NUM" "$worktree_path" "$worktree_path/HERMES_RESULT.md"
     elif [[ "$result_status" == "BLOCKED" ]]; then
       autoship_state_set set-blocked "$ISSUE_KEY"
     elif [[ "$result_status" == "STUCK" ]]; then


### PR DESCRIPTION
## Summary
- Make Hermes worker timeout configurable with HERMES_WORKER_TIMEOUT_SECONDS
- Increase default timeout from 10 minutes to 30 minutes
- Preserve STUCK marking with explicit timeout reason

## Testing
- bash -n hooks/hermes/runner.sh
- git diff --check