### PR TITLE
fix: remove unused install repo root

### DIFF
--- a/autoresearch-results.tsv
+++ b/autoresearch-results.tsv
@@ -1,1 +1,2 @@
 timestamp	iteration	decision	metric_value	verify_status	guard_status	hypothesis	change_summary	labels	note
+2026-05-06T13:24:50.994Z	1	keep	61	pass	pass		Remove unused REPO_ROOT assignment from hooks/opencode/install.sh to resolve its sole SC2034 ShellCheck issue		

--- a/hooks/opencode/install.sh
+++ b/hooks/opencode/install.sh
@@ -2,7 +2,6 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 for dep in jq gh; do
   if ! command -v "$dep" >/dev/null 2>&1; then
     echo "Error: $dep is required" >&2

--- a/scripts/autoresearch-verify.sh
+++ b/scripts/autoresearch-verify.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# AutoResearch verifier: count shell scripts with zero ShellCheck issues.
+# Scope intentionally includes hooks/, scripts/, and bin/ when present.
+if ! command -v shellcheck >/dev/null 2>&1; then
+  echo "ERROR: shellcheck is required" >&2
+  exit 1
+fi
+
+clean=0
+total=0
+while IFS= read -r -d '' file; do
+  total=$((total + 1))
+  if shellcheck "$file" >/dev/null 2>&1; then
+    clean=$((clean + 1))
+  fi
+done < <(find hooks scripts bin -type f -name "*.sh" -print0 2>/dev/null | sort -z)
+
+printf 'clean_hooks_count=%s\n' "$clean"
+printf 'total_shell_scripts=%s\n' "$total" >&2


### PR DESCRIPTION
## Summary
- Remove unused `REPO_ROOT` assignment from `hooks/opencode/install.sh`.
- Add AutoResearch verifier script and result record for the ShellCheck cleanup.

## Verification
- `bash -n hooks/opencode/install.sh scripts/autoresearch-verify.sh`
- `shellcheck hooks/opencode/install.sh scripts/autoresearch-verify.sh`