### PR TITLE
fix(resource-monitor): correct vmstat conditional syntax

### DIFF
--- a/hooks/opencode/resource-monitor.sh
+++ b/hooks/opencode/resource-monitor.sh
@@ -23,7 +23,7 @@ get_cpu_pct() {
     cpu_pct=$(awk "BEGIN {printf \"%.0f\", 100 * (1 - ($idle2 - $idle1) / ($total2 - $total1))}")
   fi
   # Fallback: try ps or vmstat
-  if [[ -z "$cpu_pct" && command -v vmstat >/dev/null 2>&1 ]]; then
+  if [[ -z "$cpu_pct" ]] && command -v vmstat >/dev/null 2>&1; then
     cpu_pct=$(vmstat 1 2 2>/dev/null | tail -1 | awk '{print 100 - $15}')
   fi
   printf '%s\n' "${cpu_pct:-0}"


### PR DESCRIPTION
### Motivation
- Fix a Bash conditional parse error in `hooks/opencode/resource-monitor.sh` that caused the script to fail parsing and disabled resource-aware concurrency reduction in `dispatch.sh`.

### Description
- Move the `command -v vmstat >/dev/null 2>&1` test out of the `[[ ... ]]` expression so the `vmstat` fallback path parses and executes correctly (one-line syntax-only change).

### Testing
- `bash -n hooks/opencode/resource-monitor.sh` passed and `bash hooks/opencode/resource-monitor.sh 8` produced valid JSON; `bash -n hooks/opencode/*.sh hooks/*.sh` passed, while `bash hooks/opencode/check.sh` still reports unrelated pre-existing failures in other hooks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4f406f9388321ba140c838d516813)