### PR TITLE
fix(retry): normalize and clamp retry attempt

### DIFF
--- a/hooks/opencode/retry.sh
+++ b/hooks/opencode/retry.sh
@@ -9,13 +9,17 @@ WORKSPACE_DIR="$REPO_ROOT/.autoship/workspaces/$ISSUE_KEY"
 
 mkdir -p "$WORKSPACE_DIR"
 
-# Validate attempt is numeric
+# Validate and normalize attempt to base-10 integer
 if [[ ! "$ATTEMPT" =~ ^[0-9]+$ ]]; then
   ATTEMPT=1
+else
+  ATTEMPT=$((10#$ATTEMPT))
 fi
 
-# Cap at 5 retries (16 min delay)
-if [[ "$ATTEMPT" -gt 5 ]]; then
+# Clamp to supported retry range: 1..5
+if [[ "$ATTEMPT" -lt 1 ]]; then
+  ATTEMPT=1
+elif [[ "$ATTEMPT" -gt 5 ]]; then
   ATTEMPT=5
 fi
 


### PR DESCRIPTION
### Motivation
- Prevent the retry script from aborting when `ATTEMPT` is malformed (for example `0`, `000`, or leading-zero inputs like `08`) which caused Bash arithmetic errors and left workspaces without `status`/`retry_after` metadata.
- Apply a minimal, robust fix that preserves the intended exponential backoff/jitter behavior while avoiding crash paths under `set -euo pipefail`.

### Description
- Normalize numeric input to a base-10 integer using `ATTEMPT=$((10#$ATTEMPT))` after validating the string is digits-only.
- Clamp `ATTEMPT` to the supported range `1..5` to prevent negative exponents or excessive delays before arithmetic is performed.
- Preserve the existing exponential backoff, jitter calculation, and output of `status` and `retry_after` files.

### Testing
- Ran `bash hooks/opencode/check.sh`, which failed due to pre-existing unrelated issues (syntax errors in other scripts, a failing policy test, and an npm registry 403 during smoke tests), so the failure is not caused by this change.
- Ran `bash -n hooks/opencode/*.sh hooks/*.sh`, which completed successfully and verified shell syntax for the modified scripts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4f406cbec8321a46db05f8ff5fe7b)