### PR TITLE
fix(circuit-breaker): selector read disabled models from .models map

### DIFF
--- a/hooks/opencode/select-model.sh
+++ b/hooks/opencode/select-model.sh
@@ -51,8 +51,8 @@ JQ_DEFS='
 def hist($id):
   (($history[0] // {})[$id] // {success: 0, fail: 0});
 def circuit_open($id):
-  if ($circuit[0] // {}) | has($id) then
-    ((($circuit[0] // {})[$id].disabled_until // 0) | tonumber) > ($now | tonumber)
+  if (($circuit[0] // {}).models // {}) | has($id) then
+    ((((($circuit[0] // {}).models // {})[$id].disabled_until) // 0) | tonumber) > ($now | tonumber)
   else
     false
   end;
@@ -107,8 +107,8 @@ jq -r --arg task "$TASK_TYPE" --argjson issue "$ISSUE_NUM" --slurpfile history "
   def hist($id):
     (($history[0] // {})[$id] // {success: 0, fail: 0});
   def circuit_open($id):
-    if ($circuit[0] // {}) | has($id) then
-      ((($circuit[0] // {})[$id].disabled_until // 0) | tonumber) > ($now | tonumber)
+    if (($circuit[0] // {}).models // {}) | has($id) then
+      ((((($circuit[0] // {}).models // {})[$id].disabled_until) // 0) | tonumber) > ($now | tonumber)
     else
       false
     end;


### PR DESCRIPTION
### Motivation
- The model selector checked for tripped models at the root of the circuit-breaker JSON while `circuit-breaker.sh` records per-model state under a `.models` map, so disabled models were not being excluded as intended.

### Description
- Update `circuit_open()` in `hooks/opencode/select-model.sh` (both the `--log` and normal selection paths) to read `($circuit[0].models // {})[$id].disabled_until` and test presence with `($circuit[0].models // {}) | has($id)`, aligning the selector with the recorder schema.

### Testing
- Ran `bash hooks/opencode/check.sh` and `bash -n hooks/opencode/*.sh hooks/*.sh`; overall verification failed due to pre-existing unrelated issues (syntax errors in other scripts and failing policy/smoke checks).
- Verified that the modified `hooks/opencode/select-model.sh` has no shell syntax errors and that the selector now references the nested `.models` map in both code paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4f406afb08321ab695bf8c187c823)