### PR TITLE
fix(opencode): route rust unsafe workers

### DIFF
--- a/hooks/opencode/lib/common.sh
+++ b/hooks/opencode/lib/common.sh
@@ -41,9 +41,9 @@ autoship_state_set() {
   local action="$1"
   local issue_key="$2"
   shift 2
-  local repo_root
-  repo_root="$(autoship_repo_root)"
-  bash "$repo_root/hooks/update-state.sh" "$action" "$issue_key" "$@"
+  local hook_root
+  hook_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+  bash "$hook_root/update-state.sh" "$action" "$issue_key" "$@"
 }
 
 # ── Thin failure capture wrapper ────────────────────────────────
@@ -51,9 +51,9 @@ autoship_capture_failure() {
   local category="$1"
   local issue_id="$2"
   shift 2
-  local repo_root
-  repo_root="$(autoship_repo_root)"
-  bash "$repo_root/hooks/capture-failure.sh" "$category" "$issue_id" "$@" 2>/dev/null || true
+  local hook_root
+  hook_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+  bash "$hook_root/capture-failure.sh" "$category" "$issue_id" "$@" 2>/dev/null || true
 }
 
 # ── Config value reader ─────────────────────────────────────────

--- a/hooks/opencode/setup.sh
+++ b/hooks/opencode/setup.sh
@@ -320,9 +320,9 @@ def strength(model: str) -> int:
 def task_types(model: str) -> list[str]:
     lower = model.lower()
     if any(token in lower for token in ["nemotron-3-super", "gpt-oss-120b", "llama-3.3-70b"]):
-        return ["docs", "simple_code", "medium_code", "mechanical", "ci_fix", "complex"]
+        return ["docs", "simple_code", "medium_code", "mechanical", "ci_fix", "complex", "rust_unsafe"]
     if any(token in lower for token in ["minimax", "qwen", "glm", "kimi", "mimo"]):
-        return ["docs", "simple_code", "medium_code", "mechanical", "ci_fix"]
+        return ["docs", "simple_code", "medium_code", "mechanical", "ci_fix", "rust_unsafe"]
     if any(token in lower for token in ["ling", "gemma", "mistral", "devstral"]):
         return ["docs", "simple_code", "mechanical", "ci_fix"]
     return ["docs", "simple_code", "mechanical"]

--- a/hooks/opencode/test-model-parsing.sh
+++ b/hooks/opencode/test-model-parsing.sh
@@ -183,6 +183,9 @@ install_mock_opencode_models_fixture "$FREE_REPO/bin"
 assert_eq "2" "$(jq '[.models[] | select(.cost == "free")] | length' "$FREE_REPO/autoship/.autoship/model-routing.json")" "setup fixture free defaults include only free workers"
 assert_eq "opencode/nemotron-3-super-free" "$(jq -r '.defaultFallback' "$FREE_REPO/autoship/.autoship/model-routing.json")" "setup chooses strongest ranked free model as default fallback"
 assert_eq "opencode/nemotron-3-super-free" "$(jq -r '.roles.orchestrator' "$FREE_REPO/autoship/.autoship/model-routing.json")" "setup defaults role models from live free inventory"
+if ! jq -e '[.models[] | select((.max_task_types // []) | index("rust_unsafe") != null)] | length > 0' "$FREE_REPO/autoship/.autoship/model-routing.json" >/dev/null; then
+  fail "setup free defaults must include rust_unsafe-capable workers"
+fi
 if jq -e '.pools.default.models[] | select(. == "openai/gpt-5.5" or . == "openai/gpt-5.3-spark")' "$FREE_REPO/autoship/.autoship/model-routing.json" >/dev/null; then
   fail "setup default worker pool must not include paid or role models from fixture"
 fi


### PR DESCRIPTION
## Summary
- Resolve installed AutoShip state/failure hooks relative to the installed hook bundle instead of the target repository.
- Include `rust_unsafe` in generated free-first worker capabilities for capable models.
- Add a model-routing test assertion so free setup keeps `rust_unsafe` dispatchable.

## Verification
- `bash hooks/opencode/test-model-parsing.sh`
- `npm run typecheck`
- `npm run build`

## Notes
- `bash hooks/opencode/test-policy.sh` currently exits 1 in the doctor fixture area without an assertion message; its earlier sections reached existing expected fixture output, but I did not count it as passing.