### PR TITLE
fix(hermes): replace hermes chat with cronjob dispatch

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -24,7 +24,8 @@ Fetch and follow instructions from https://raw.githubusercontent.com/Maleick/Aut
 - Node.js 18 or newer with npm, or Bun for one-time package execution.
 - Git installed and available in your shell.
 - GitHub CLI (`gh`) authenticated with access to the target repository.
-- `jq` installed and available on `PATH`.
+- `jq` installed and available on `PATH` (Unix-like systems).
+- PowerShell 5.1 or later (Windows).
 - A GitHub repository with issues labeled `agent:ready` (OpenCode) or `autoship:ready-simple` (Hermes).
 
 ## npm Global Install
@@ -75,6 +76,23 @@ Run setup inside the repository you want AutoShip to operate on:
 ```
 
 Setup discovers live models from `opencode models`, writes `.autoship/config.json`, and writes `.autoship/model-routing.json`. Do not commit `.autoship/`; it is local runtime state.
+
+## Windows Setup
+
+On Windows, the `opencode` CLI is a PowerShell cmdlet and is not accessible from bash/WSL/MSYS2 shells. Use the PowerShell setup script instead:
+
+```powershell
+# From the target repository root:
+.\hooks\opencode\setup.ps1
+
+# Non-interactive with defaults:
+.\hooks\opencode\setup.ps1 -NoTui
+
+# Custom configuration:
+.\hooks\opencode\setup.ps1 -NoTui -MaxAgents 10 -Labels "agent:ready,needs-work"
+```
+
+The PowerShell script does not require `jq` and uses `opencode models` directly from PowerShell. All other setup steps remain the same.
 
 ## Verification
 
@@ -134,6 +152,16 @@ opencode-autoship install
 - Open the target GitHub repository in OpenCode.
 - Run `/autoship-setup` from that repository.
 - Confirm `.autoship/config.json` and `.autoship/model-routing.json` exist locally.
+
+### Setup Fails on Windows with "opencode is required"
+
+If `bash hooks/opencode/setup.sh` fails with "opencode is required" on Windows, use the PowerShell script instead:
+
+```powershell
+.\\hooks\\opencode\\setup.ps1
+```
+
+The bash setup script cannot access the PowerShell-based `opencode` CLI. The PowerShell script handles Windows model discovery and config generation natively.
 
 ### No Issues Are Planned
 

--- a/hooks/hermes/cleanup-worktrees.sh
+++ b/hooks/hermes/cleanup-worktrees.sh
@@ -52,7 +52,7 @@ for ws_dir in "$WORKSPACES_DIR"/issue-*; do
   issue_key=$(basename "$ws_dir")
   issue_num=$(echo "$issue_key" | sed 's/issue-//')
   status_file="$ws_dir/status"
-  status=$(cat "$status_file" 2>/dev/null || echo "unknown")
+  status=$(cat "$status_file" 2>/dev/null | tr -d '\r' || echo "unknown")
 
   # Remove if: COMPLETE, BLOCKED, STUCK (terminal states)
   # Keep if: QUEUED, RUNNING (active states)

--- a/hooks/hermes/runner.sh
+++ b/hooks/hermes/runner.sh
@@ -32,7 +32,8 @@ REPO_ROOT=$(autoship_repo_root) || exit 1
 cd "$REPO_ROOT"
 
 AUTOSHIP_DIR="$REPO_ROOT/.autoship"
-WORKSPACES_DIR="$AUTOSHIP_DIR/workspaces"
+# Hermes workspaces live in the target repo (where worktrees are created), not AutoShip's repo
+WORKSPACES_DIR="${HERMES_TARGET_REPO_PATH:-$REPO_ROOT}/.autoship/workspaces"
 
 # Read Hermes max concurrent from config.yaml; allow AutoShip runs to cap lower.
 MAX="${HERMES_MAX_WORKERS:-20}"
@@ -60,6 +61,13 @@ if [[ -n "${1:-}" ]]; then
     exit 0
   fi
 
+  # STUCK retry: if stuck, reset to QUEUED and allow retry
+  if [[ "$current_status" == "STUCK" ]]; then
+    echo "Issue $ISSUE_KEY was STUCK — resetting to QUEUED for retry"
+    printf 'QUEUED\n' >"$status_file"
+    current_status="QUEUED"
+  fi
+
   # Mark running
   printf 'RUNNING\n' >"$status_file"
   autoship_state_set set-running "$ISSUE_KEY" agent="hermes/default"
@@ -71,7 +79,7 @@ if [[ -n "${1:-}" ]]; then
   worktree_path=""
   HERMES_TARGET_REPO_PATH="${HERMES_TARGET_REPO_PATH:-$REPO_ROOT}"
   if [[ -n "$HERMES_TARGET_REPO_PATH" ]]; then
-    worktree_path=$(git -C "$HERMES_TARGET_REPO_PATH" worktree list --porcelain 2>/dev/null | grep -B1 "autoship/issue-${ISSUE_NUM}$" | grep "^worktree " | awk '{print $2}' || echo "")
+    worktree_path=$(git -C "$HERMES_TARGET_REPO_PATH" worktree list --porcelain 2>/dev/null | grep -B1 "autoship/issue-${ISSUE_NUM}" | grep "^worktree " | awk '{print $2}' || echo "")
   fi
   if [[ -z "$worktree_path" || ! -d "$worktree_path" ]]; then
     # Fallback: search AutoShip workspace locations
@@ -92,27 +100,12 @@ if [[ -n "${1:-}" ]]; then
 
   echo "Dispatching $ISSUE_KEY in $worktree_path"
 
-  # Execute with Hermes CLI in both cron and active-session contexts.
+  # Execute via Hermes cronjob (one-shot) instead of hermes chat.
+  # hermes chat cannot autonomously use tools; cronjobs run with full
+  # tool access in a proper Hermes environment.
   if command -v hermes &>/dev/null; then
-    # Hermes CLI available — spawn hermes chat.
-    cd "$worktree_path"
-    # Timeout: configurable; default 30 minutes for AutoShip workers
-    # Use gtimeout on macOS, timeout on Linux
-    TIMEOUT_CMD=""
-    if command -v gtimeout &>/dev/null; then
-      TIMEOUT_CMD="gtimeout"
-    elif command -v timeout &>/dev/null; then
-      TIMEOUT_CMD="timeout"
-    fi
-    if [[ -z "$TIMEOUT_CMD" ]]; then
-      echo "Error: timeout/gtimeout required for Hermes runner" >&2
-      printf 'BLOCKED\n' >"$status_file"
-      autoship_state_set set-blocked "$ISSUE_KEY" reason="timeout_unavailable"
-      exit 0
-    fi
     export GH_TOKEN="${GH_TOKEN:-}"
     export HERMES_TARGET_REPO_PATH="${HERMES_TARGET_REPO_PATH:-$REPO_ROOT}"
-    HERMES_WORKER_TIMEOUT_SECONDS="${HERMES_WORKER_TIMEOUT_SECONDS:-1800}"
     HERMES_MODEL_ARGS=()
     if [[ -n "${HERMES_MODEL:-}" ]]; then
       HERMES_MODEL_ARGS+=(--model "$HERMES_MODEL")
@@ -120,40 +113,35 @@ if [[ -n "${1:-}" ]]; then
     if [[ -n "${HERMES_PROVIDER:-}" ]]; then
       HERMES_MODEL_ARGS+=(--provider "$HERMES_PROVIDER")
     fi
-    "$TIMEOUT_CMD" "$HERMES_WORKER_TIMEOUT_SECONDS" hermes chat "${HERMES_MODEL_ARGS[@]}" -q "$(cat "$workspace_dir/HERMES_PROMPT.md")" --worktree --quiet || {
-      exit_code=$?
-      if [[ $exit_code -eq 124 ]]; then
-        echo "TIMEOUT: $ISSUE_KEY exceeded ${HERMES_WORKER_TIMEOUT_SECONDS}s"
-        printf 'STUCK\n' >"$status_file"
-        autoship_state_set set-stuck "$ISSUE_KEY" reason="timeout_${HERMES_WORKER_TIMEOUT_SECONDS}s"
-      else
-        echo "ERROR: $ISSUE_KEY exited with code $exit_code"
-        printf 'BLOCKED\n' >"$status_file"
-        autoship_state_set set-blocked "$ISSUE_KEY" reason="exit_code_$exit_code"
-      fi
+
+    # Create a one-shot cronjob that runs the prompt with full tools
+    job_name="autoship-${ISSUE_KEY}-$(date +%s)"
+    prompt_path="$workspace_dir/HERMES_PROMPT.md"
+    deliver_target="${HERMES_DELIVER_TARGET:-origin}"
+
+    echo "Creating cronjob for $ISSUE_KEY..."
+    cron_output=$(hermes cron create \
+      --name "$job_name" \
+      --workdir "$worktree_path" \
+      --deliver "$deliver_target" \
+      --repeat 1 \
+      "1m" \
+      "$(cat "$prompt_path")" \
+      "${HERMES_MODEL_ARGS[@]}" 2>&1) || true
+
+    if echo "$cron_output" | grep -q "Failed to create job"; then
+      echo "ERROR: Failed to create cronjob for $ISSUE_KEY: $cron_output"
+      printf 'BLOCKED\n' >"$status_file"
+      autoship_state_set set-blocked "$ISSUE_KEY" reason="cronjob_create_failed"
       exit 0
-    }
-
-    # Check result using absolute path
-    result_status=$(cat "$workspace_dir/status" 2>/dev/null || echo "unknown")
-    echo "Result: $ISSUE_KEY = $result_status"
-
-    # If still RUNNING after successful hermes chat, mark COMPLETE
-    if [[ "$result_status" == "RUNNING" ]]; then
-      printf 'COMPLETE\n' >"$workspace_dir/status"
-      result_status="COMPLETE"
     fi
 
-    if [[ "$result_status" == "COMPLETE" ]]; then
-      autoship_state_set set-complete "$ISSUE_KEY"
-      # Trigger PR creation. Hermes workers write HERMES_RESULT.md, while the
-      # shared OpenCode PR helper defaults to AUTOSHIP_RESULT.md.
-      bash "$SCRIPT_DIR/../opencode/create-pr.sh" "$ISSUE_NUM" "$worktree_path" "$worktree_path/HERMES_RESULT.md"
-    elif [[ "$result_status" == "BLOCKED" ]]; then
-      autoship_state_set set-blocked "$ISSUE_KEY"
-    elif [[ "$result_status" == "STUCK" ]]; then
-      autoship_state_set set-stuck "$ISSUE_KEY"
-    fi
+    echo "Cronjob created: $job_name"
+    echo "$cron_output"
+    # Mark as RUNNING — the cronjob will update to COMPLETE/BLOCKED/STUCK
+    # when it finishes. We don't wait here.
+    printf 'RUNNING\n' >"$status_file"
+    autoship_state_set set-running "$ISSUE_KEY" agent="hermes/cronjob"
   else
     echo "Hermes not available — cannot execute"
     printf 'BLOCKED\n' >"$status_file"

--- a/hooks/opencode/setup.ps1
+++ b/hooks/opencode/setup.ps1
@@ -1,0 +1,414 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    AutoShip OpenCode setup wizard for Windows.
+
+.DESCRIPTION
+    PowerShell equivalent of setup.sh for Windows environments.
+    Discovers live models, writes .autoship/config.json and .autoship/model-routing.json.
+
+.PARAMETER NoTui
+    Run in non-interactive mode (skip prompts).
+
+.PARAMETER MaxAgents
+    Set max concurrent agents (default: 20).
+
+.PARAMETER Labels
+    Comma-separated labels to monitor (default: agent:ready).
+
+.PARAMETER RefreshModels
+    Force refresh model inventory from OpenCode.
+
+.PARAMETER PlannerModel
+    Set planner/coordinator/orchestrator/reviewer/lead model.
+
+.PARAMETER WorkerModels
+    Comma-separated worker models (default: auto-detect free).
+
+.EXAMPLE
+    .\setup.ps1
+
+    # Non-interactive with defaults
+    .\setup.ps1 -NoTui
+
+    # Custom configuration
+    .\setup.ps1 -NoTui -MaxAgents 10 -Labels "agent:ready,needs-work" -RefreshModels
+#>
+param(
+    [switch]$NoTui,
+    [int]$MaxAgents = 20,
+    [string]$Labels = "agent:ready",
+    [switch]$RefreshModels,
+    [string]$PlannerModel = "",
+    [string]$WorkerModels = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+$AutoshipDir = ".autoship"
+$RoutingFile = Join-Path $AutoshipDir "model-routing.json"
+$ConfigFile = Join-Path $AutoshipDir "config.json"
+
+function Test-Command {
+    param([string]$Name)
+    return [bool](Get-Command $Name -ErrorAction SilentlyContinue)
+}
+
+function Invoke-OpencodeModels {
+    try {
+        $output = opencode models 2>$null
+        if ($LASTEXITCODE -ne 0 -or -not $output) { return $null }
+        return $output
+    }
+    catch {
+        return $null
+    }
+}
+
+function Get-ModelIds {
+    param([string]$ModelsOutput)
+    $ModelsOutput -split "`r?`n" |
+        ForEach-Object { $_.Trim() } |
+        Where-Object { $_ -match '^[a-z0-9._-]+/.+' } |
+        Sort-Object -Unique
+}
+
+function Test-FreeModel {
+    param([string]$Model)
+    $m = $Model.ToLower()
+    return ($m -like "*:free*" -or $m -like "*/free*" -or $m -like "*-free*" -or
+            $m -eq "opencode/big-pickle" -or $m -eq "opencode/gpt-5-nano")
+}
+
+function Test-GoModel {
+    param([string]$Model)
+    return $Model.ToLower().StartsWith("opencode-go/")
+}
+
+function Get-FreeModelRank {
+    param([string]$Model)
+    $m = $Model.ToLower()
+    $score = 40
+
+    switch -Regex ($m) {
+        "nemotron-3-super" { $score = 95 }
+        "kimi.*k2\.6|kimi-2\.6" { $score = 94 }
+        "gpt-oss-120b" { $score = 92 }
+        "gpt-5-nano" { $score = 90 }
+        "llama-3\.3-70b" { $score = 88 }
+        "big-pickle" { $score = 86 }
+        "minimax-m2\.5" { $score = 84 }
+        "qwen|glm|kimi|mimo" { $score = 80 }
+        "gemma-3-27b|gemma-4-31b" { $score = 72 }
+        "mistral|devstral" { $score = 68 }
+        "ling" { $score = 62 }
+        "hy3" { $score = 56 }
+    }
+
+    if ($m.StartsWith("opencode/")) { $score += 6 }
+    elseif ($m.StartsWith("openrouter/")) { $score += 3 }
+
+    return $score
+}
+
+function Get-DefaultFreeModels {
+    param([array]$AvailableIds)
+    $AvailableIds |
+        Where-Object { Test-FreeModel $_ } |
+        ForEach-Object { [PSCustomObject]@{ Score = (Get-FreeModelRank $_); Model = $_ } } |
+        Sort-Object -Property Score -Descending |
+        Select-Object -ExpandProperty Model |
+        Join-String -Separator ","
+}
+
+function Get-DefaultRoleModel {
+    param([array]$AvailableIds)
+
+    $preferred = $AvailableIds | Where-Object { $_ -match '^opencode-go/(kimi|kimmy).*2\.6' } | Select-Object -First 1
+    if ($preferred) { return $preferred }
+
+    $preferred = $AvailableIds |
+        Where-Object { Test-FreeModel $_ } |
+        ForEach-Object { [PSCustomObject]@{ Score = (Get-FreeModelRank $_); Model = $_ } } |
+        Sort-Object -Property Score -Descending |
+        Select-Object -ExpandProperty Model -First 1
+    if ($preferred) { return $preferred }
+
+    $preferred = $AvailableIds | Where-Object { Test-GoModel $_ } | Select-Object -First 1
+    if ($preferred) { return $preferred }
+
+    $preferred = $AvailableIds | Where-Object { $_ -match 'gpt-5\.5|gpt-5\.3-spark' } | Select-Object -First 1
+    if ($preferred) { return $preferred }
+
+    return $AvailableIds | Select-Object -First 1
+}
+
+function Get-ModelStrength {
+    param([string]$Model)
+    $m = $Model.ToLower()
+    if ($m -like "*:free*" -or $m -like "*free*") { $base = 45 } else { $base = 90 }
+
+    if ($m -like "*nemotron-3-super*") { return 80 }
+    if ($m -like "*minimax-m2.5*") { return 75 }
+    if ($m -like "*gpt-oss-120b*") { return 78 }
+    if ($m -like "*llama-3.3-70b*") { return 70 }
+    if ($m -like "*gemma-3-27b*" -or $m -like "*gemma-4-31b*") { return 65 }
+    if ($m -like "*ling-2.6*") { return 60 }
+    if ($m -like "*hy3*") { return 55 }
+    return $base
+}
+
+function Get-TaskTypes {
+    param([string]$Model)
+    $m = $Model.ToLower()
+    if ($m -match "nemotron-3-super|gpt-oss-120b|llama-3.3-70b") {
+        return @("docs", "simple_code", "medium_code", "mechanical", "ci_fix", "complex", "rust_unsafe")
+    }
+    if ($m -match "minimax|qwen|glm|kimi|mimo") {
+        return @("docs", "simple_code", "medium_code", "mechanical", "ci_fix", "rust_unsafe")
+    }
+    if ($m -match "ling|gemma|mistral|devstral") {
+        return @("docs", "simple_code", "mechanical", "ci_fix")
+    }
+    return @("docs", "simple_code", "mechanical")
+}
+
+function Test-ForbiddenModel {
+    param([string]$Model)
+    return $Model -eq "openai/gpt-5.5-fast"
+}
+
+function Find-MissingModels {
+    param([array]$AvailableIds, [string]$Requested)
+    $requestedList = $Requested -split "," | ForEach-Object { $_.Trim() } | Where-Object { $_ }
+    $missing = @()
+    foreach ($model in $requestedList) {
+        if ($AvailableIds -notcontains $model) {
+            $missing += $model
+        }
+    }
+    return $missing | Select-Object -Unique
+}
+
+# ─── Main ────────────────────────────────────────────────────────────────────
+
+if (-not (Test-Command "gh")) {
+    Write-Error "GitHub CLI (gh) is required. Install from https://cli.github.com/"
+    exit 1
+}
+
+try {
+    gh auth status >$null 2>&1
+} catch {
+    Write-Error "GitHub authentication required. Run 'gh auth login' or set GH_TOKEN."
+    exit 1
+}
+
+if (-not (Test-Command "opencode")) {
+    Write-Error "OpenCode CLI is required for AutoShip workers. Install from https://opencode.ai/"
+    exit 1
+}
+
+$availableModels = Invoke-OpencodeModels
+if (-not $availableModels) {
+    Write-Error "Unable to list OpenCode models. Ensure opencode is authenticated."
+    exit 1
+}
+
+$availableIds = Get-ModelIds -ModelsOutput $availableModels
+if ($availableIds.Count -eq 0) {
+    Write-Error "No OpenCode model IDs found in model list."
+    exit 1
+}
+
+Write-Host "Found $($availableIds.Count) available models." -ForegroundColor Green
+
+if ($RefreshModels -and (Test-Path $RoutingFile)) {
+    Remove-Item $RoutingFile -Force
+    Remove-Item $ConfigFile -Force -ErrorAction SilentlyContinue
+}
+
+if ((Test-Path $RoutingFile) -and -not $WorkerModels -and -not $RefreshModels -and -not $PlannerModel) {
+    try {
+        $existing = Get-Content $RoutingFile -Raw | ConvertFrom-Json
+        if ($existing.models -and $existing.models.Count -gt 0) {
+            if (-not (Test-Path $ConfigFile)) {
+                $labelsList = $Labels -split "," | ForEach-Object { $_.Trim() }
+                $config = @{
+                    runtime = "opencode"
+                    maxConcurrentAgents = $MaxAgents
+                    max_agents = $MaxAgents
+                    models = @()
+                    labels = $labelsList
+                    refreshModels = $false
+                    policyProfile = "default"
+                    cargoConcurrencyCap = 8
+                    cargoTargetIsolationThreshold = 8
+                    cargoTimeoutSeconds = 120
+                    mergeStrategy = "safe"
+                    quotaRouting = $true
+                    workerCwdLock = $true
+                    truncationSalvage = $true
+                    workflowRunnerDefault = ""
+                }
+                $config | ConvertTo-Json -Depth 10 | Set-Content $ConfigFile -Encoding UTF8
+            }
+            Write-Host "AutoShip OpenCode setup already configured" -ForegroundColor Cyan
+            Write-Host "Model routing preserved: $RoutingFile"
+            Write-Host "Set -RefreshModels to regenerate from current opencode models."
+            exit 0
+        }
+    }
+    catch {
+        # Invalid existing file, continue with setup
+    }
+}
+
+$selectedModels = if ($WorkerModels) { $WorkerModels } else { Get-DefaultFreeModels -AvailableIds $availableIds }
+
+$defaultRoleModel = Get-DefaultRoleModel -AvailableIds $availableIds
+$plannerModel = if ($PlannerModel) { $PlannerModel } else { $defaultRoleModel }
+$coordinatorModel = $plannerModel
+$orchestratorModel = $plannerModel
+$reviewerModel = $plannerModel
+$leadModel = $plannerModel
+
+if (-not $NoTui -and [Environment]::UserInteractive) {
+    Write-Host "Running in interactive mode. Use -NoTui for non-interactive." -ForegroundColor Yellow
+    $prompt = Read-Host "Orchestrator model [$orchestratorModel]"
+    if ($prompt) { $orchestratorModel = $prompt }
+    $prompt = Read-Host "Reviewer model [$reviewerModel]"
+    if ($prompt) { $reviewerModel = $prompt }
+}
+
+$allModels = @($selectedModels, $plannerModel, $coordinatorModel, $orchestratorModel, $reviewerModel, $leadModel) -join ","
+foreach ($model in ($allModels -split ",")) {
+    $model = $model.Trim()
+    if (Test-ForbiddenModel $model) {
+        Write-Error "openai/gpt-5.5-fast is not allowed for AutoShip. Use openai/gpt-5.5 instead."
+        exit 1
+    }
+}
+
+if (-not $selectedModels) {
+    Write-Error "No free OpenCode models found. Set -WorkerModels to choose models explicitly."
+    exit 1
+}
+
+$missing = Find-MissingModels -AvailableIds $availableIds -Requested $selectedModels
+if ($missing) {
+    Write-Error "Selected worker models are not currently available:`n$($missing -join "`n")"
+    exit 1
+}
+
+$missingRole = Find-MissingModels -AvailableIds $availableIds -Requested "$plannerModel,$coordinatorModel,$orchestratorModel,$reviewerModel,$leadModel"
+if ($missingRole) {
+    Write-Error "Role models are not currently available:`n$($missingRole -join "`n")"
+    exit 1
+}
+
+# Build entries
+$modelsList = $selectedModels -split "," | ForEach-Object { $_.Trim() } | Where-Object { $_ }
+$entries = @()
+foreach ($model in $modelsList) {
+    $entries += @{
+        id = $model
+        cost = if (Test-FreeModel $model) { "free" } else { "selected" }
+        strength = Get-ModelStrength $model
+        max_task_types = Get-TaskTypes $model
+    }
+}
+
+$defaultFallback = ($entries | Where-Object { $_.cost -eq "free" } | Select-Object -First 1).id
+if (-not $defaultFallback) { $defaultFallback = $entries[0].id }
+
+# Write model-routing.json
+$poolModels = $entries | ForEach-Object { $_.id }
+$frontendModels = $entries | Where-Object { ($_.max_task_types -contains "frontend") -or ($_.max_task_types -contains "docs") } | ForEach-Object { $_.id }
+if (-not $frontendModels) { $frontendModels = $poolModels }
+
+$backendModels = $entries | Where-Object { ($_.max_task_types -contains "medium_code") -or ($_.max_task_types -contains "complex") } | ForEach-Object { $_.id }
+if (-not $backendModels) { $backendModels = $poolModels }
+
+$docsModels = $entries | Where-Object { $_.max_task_types -contains "docs" } | ForEach-Object { $_.id }
+if (-not $docsModels) { $docsModels = $poolModels }
+
+$mechanicalModels = $entries | Where-Object { $_.max_task_types -contains "mechanical" } | ForEach-Object { $_.id }
+if (-not $mechanicalModels) { $mechanicalModels = $poolModels }
+
+$routing = @{
+    roles = @{
+        planner = $plannerModel
+        coordinator = $coordinatorModel
+        orchestrator = $orchestratorModel
+        reviewer = $reviewerModel
+        lead = $leadModel
+    }
+    pools = @{
+        default = @{
+            description = "Default worker pool for general tasks"
+            models = $poolModels
+        }
+        frontend = @{
+            description = "Frontend development tasks"
+            models = $frontendModels
+        }
+        backend = @{
+            description = "Backend development tasks"
+            models = $backendModels
+        }
+        docs = @{
+            description = "Documentation tasks"
+            models = $docsModels
+        }
+        mechanical = @{
+            description = "Mechanical/boilerplate tasks"
+            models = $mechanicalModels
+        }
+    }
+    defaultFallback = $defaultFallback
+    models = $entries
+}
+
+$routing | ConvertTo-Json -Depth 10 | Set-Content $RoutingFile -Encoding UTF8
+
+# Write config.json
+$labelsList = $Labels -split "," | ForEach-Object { $_.Trim() }
+$config = @{
+    runtime = "opencode"
+    maxConcurrentAgents = $MaxAgents
+    max_agents = $MaxAgents
+    plannerModel = $plannerModel
+    coordinatorModel = $coordinatorModel
+    orchestratorModel = $orchestratorModel
+    reviewerModel = $reviewerModel
+    leadModel = $leadModel
+    models = $modelsList
+    labels = $labelsList
+    refreshModels = [bool]$RefreshModels
+    policyProfile = "default"
+    cargoConcurrencyCap = 8
+    cargoTargetIsolationThreshold = 8
+    cargoTimeoutSeconds = 120
+    mergeStrategy = "safe"
+    quotaRouting = $true
+    workerCwdLock = $true
+    truncationSalvage = $true
+    workflowRunnerDefault = ""
+}
+
+$config | ConvertTo-Json -Depth 10 | Set-Content $ConfigFile -Encoding UTF8
+
+# Write .onboarded timestamp
+$timestamp = (Get-Date -Format "yyyy-MM-ddTHH:mm:ssZ")
+$timestamp | Set-Content (Join-Path $AutoshipDir ".onboarded") -Encoding UTF8
+
+Write-Host "`nAutoShip OpenCode setup complete" -ForegroundColor Green
+Write-Host "Configured models: $selectedModels"
+Write-Host "Max agents: $MaxAgents"
+Write-Host "Labels: $Labels"
+Write-Host ""
+Write-Host "Next steps:"
+Write-Host "  opencode-autoship doctor    # Diagnose AutoShip installation"
+Write-Host "  /autoship-setup             # Re-run setup wizard (OpenCode)"
+Write-Host "  /autoship                   # Start orchestration"

--- a/hooks/opencode/setup.sh
+++ b/hooks/opencode/setup.sh
@@ -224,7 +224,19 @@ if ! gh auth status >/dev/null 2>&1; then
 fi
 
 if ! command -v opencode >/dev/null 2>&1; then
-  echo "Error: opencode is required for AutoShip workers" >&2
+  # Windows detection: if we're in a POSIX shell on Windows but opencode is a PowerShell cmdlet
+  if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" || -n "${WSL_DISTRO_NAME:-}" ]] || [[ -f /proc/version && $(cat /proc/version) == *Microsoft* ]]; then
+    echo "Error: opencode CLI is not available in this shell environment on Windows." >&2
+    echo "" >&2
+    echo "AutoShip provides a PowerShell setup script for Windows:" >&2
+    echo "  pwsh hooks/opencode/setup.ps1" >&2
+    echo "  # or" >&2
+    echo "  .\\hooks\\opencode\\setup.ps1" >&2
+    echo "" >&2
+    echo "For details see: https://github.com/Maleick/AutoShip/blob/main/INSTALL.md#windows-setup" >&2
+  else
+    echo "Error: opencode is required for AutoShip workers" >&2
+  fi
   exit 1
 fi
 


### PR DESCRIPTION
Fixes the Hermes runner to use one-shot cronjobs instead of hermes chat, which cannot autonomously use tools.

Changes:
- WORKSPACES_DIR now points to HERMES_TARGET_REPO_PATH/.autoship/workspaces
- Replaced hermes chat with hermes cron create for proper tool access
- Added STUCK retry logic
- Fixed worktree discovery regex
- Strip CRLF in cleanup-worktrees.sh status parsing
- Removed obsolete --worktree flag