### PR TITLE
feat(autoship): add supervisor loop

### DIFF
--- a/docs/superpowers/plans/2026-05-07-supervisor-loop.md
+++ b/docs/superpowers/plans/2026-05-07-supervisor-loop.md
@@ -1,0 +1,76 @@
+# AutoShip Supervisor Loop Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a persistent OpenCode supervisor loop that keeps AutoShip moving from worker status updates to verification, PR creation, and capacity refill.
+
+**Architecture:** Create one focused hook, `hooks/opencode/supervisor-loop.sh`, that serializes itself with a repo-local lock and runs the existing hooks in order: monitor agents, process the event queue, reconcile state, and run the worker scheduler. The supervisor also clears stale `RUNNING` workspaces that have no live worker PID before asking `runner.sh` to refill capacity.
+
+**Tech Stack:** Bash, jq, GitHub CLI hooks, existing AutoShip OpenCode hook conventions.
+
+---
+
+### Task 1: Add Supervisor Policy Coverage
+
+**Files:**
+- Modify: `hooks/opencode/test-policy.sh`
+
+- [ ] **Step 1: Add a failing stale-worker test**
+
+Append a fixture that creates `.autoship/workspaces/issue-101/status` with `RUNNING` but no `worker.pid`, runs `hooks/opencode/supervisor-loop.sh --once`, and asserts the status becomes `STUCK`.
+
+- [ ] **Step 2: Add a failing refill test**
+
+In the same fixture, create a queued workspace and assert `runner.sh` is invoked by writing a small stub runner that records `runner-called`.
+
+- [ ] **Step 3: Run the focused test**
+
+Run: `bash hooks/opencode/test-policy.sh`
+
+Expected before implementation: failure because `hooks/opencode/supervisor-loop.sh` does not exist.
+
+### Task 2: Implement Supervisor Loop
+
+**Files:**
+- Create: `hooks/opencode/supervisor-loop.sh`
+
+- [ ] **Step 1: Add CLI flags and defaults**
+
+Support `--once`, `--daemon`, and `--interval SECONDS`. Default interval is `AUTOSHIP_SUPERVISOR_INTERVAL_SECONDS` or `30`.
+
+- [ ] **Step 2: Add a lock guard**
+
+Use `.autoship/supervisor-loop.lock` with `lockf` on Darwin, `flock` where available, and a best-effort fallback. Only one loop may run per repo.
+
+- [ ] **Step 3: Add stale worker cleanup**
+
+For each workspace with `status=RUNNING`, mark it `STUCK` when `worker.pid` is absent, non-numeric, or not live. If `worker.command` exists, require the live PID command to match.
+
+- [ ] **Step 4: Run existing hooks in order**
+
+Each pass runs: `monitor-agents.sh`, `process-event-queue.sh`, `reconcile-state.sh`, `runner.sh`.
+
+- [ ] **Step 5: Add logging**
+
+Write pass start/end and stale cleanup messages to `.autoship/logs/supervisor-loop.log`.
+
+### Task 3: Verify and Publish
+
+**Files:**
+- Modify: `hooks/opencode/check.sh` if syntax discovery misses the new hook.
+
+- [ ] **Step 1: Run syntax checks**
+
+Run: `bash -n hooks/opencode/supervisor-loop.sh hooks/opencode/test-policy.sh`
+
+Expected: no output, exit 0.
+
+- [ ] **Step 2: Run focused policy test**
+
+Run: `bash hooks/opencode/test-policy.sh`
+
+Expected: pass.
+
+- [ ] **Step 3: Commit and PR**
+
+Commit on `fix/supervisor-loop`, push to `origin`, and open a PR against `main` in `Maleick/AutoShip`.

--- a/hooks/opencode/create-pr.sh
+++ b/hooks/opencode/create-pr.sh
@@ -41,7 +41,7 @@ canonical_file() {
 
 is_runtime_artifact() {
   case "$1" in
-    .autoship | .autoship/* | AUTOSHIP_PROMPT.md | AUTOSHIP_RESULT.md | AUTOSHIP_RUNNER.log | HERMES_PROMPT.md | HERMES_RESULT.md | BLOCKED_REASON.txt | model | role | routing-log.txt | runner.log | started_at | status | worker.pid | target-isolated | target-isolated/*)
+    .autoship | .autoship/* | AUTOSHIP_PROMPT.md | AUTOSHIP_RESULT.md | AUTOSHIP_RUNNER.log | HERMES_PROMPT.md | HERMES_RESULT.md | BLOCKED_REASON.txt | model | role | routing-log.txt | runner.log | started_at | status | worker.command | worker.pid | target-isolated | target-isolated/*)
       return 0
       ;;
   esac

--- a/hooks/opencode/monitor-agents.sh
+++ b/hooks/opencode/monitor-agents.sh
@@ -78,7 +78,7 @@ emit_event() {
 
 is_runtime_artifact() {
   case "$1" in
-    .autoship | .autoship/* | AUTOSHIP_PROMPT.md | AUTOSHIP_RESULT.md | AUTOSHIP_RUNNER.log | HERMES_PROMPT.md | HERMES_RESULT.md | BLOCKED_REASON.txt | model | role | routing-log.txt | runner.log | started_at | status | worker.pid | target-isolated | target-isolated/*)
+    .autoship | .autoship/* | AUTOSHIP_PROMPT.md | AUTOSHIP_RESULT.md | AUTOSHIP_RUNNER.log | HERMES_PROMPT.md | HERMES_RESULT.md | BLOCKED_REASON.txt | model | role | routing-log.txt | runner.log | started_at | status | worker.command | worker.pid | target-isolated | target-isolated/*)
       return 0
       ;;
   esac

--- a/hooks/opencode/runner.sh
+++ b/hooks/opencode/runner.sh
@@ -226,7 +226,7 @@ is_test_path() {
 
 is_runtime_path() {
   case "$1" in
-    .autoship-event-*.sent | AUTOSHIP_PROMPT.md | AUTOSHIP_RESULT.md | AUTOSHIP_RUNNER.log | AUTOSHIP_VERIFICATION.log | BLOCKED_REASON.txt | PAUSED_REASON.txt | RETRY_CONTEXT.md | model | role | routing-log.txt | started_at | status | worker.pid | target-isolated | target-isolated/*) return 0 ;;
+    .autoship-event-*.sent | AUTOSHIP_PROMPT.md | AUTOSHIP_RESULT.md | AUTOSHIP_RUNNER.log | AUTOSHIP_VERIFICATION.log | BLOCKED_REASON.txt | PAUSED_REASON.txt | RETRY_CONTEXT.md | model | role | routing-log.txt | started_at | status | worker.command | worker.pid | target-isolated | target-isolated/*) return 0 ;;
     *) return 1 ;;
   esac
 }
@@ -478,6 +478,7 @@ for dir in "$WORKSPACES_DIR"/*/; do
       fi
     ) &
     printf '%s\n' "$!" >"$dir/worker.pid"
+    ps -p "$!" -o command= >"$dir/worker.command" 2>/dev/null || true
     echo "Started $(basename "$dir") with $model"
   fi
   started=$((started + 1))

--- a/hooks/opencode/supervisor-loop.sh
+++ b/hooks/opencode/supervisor-loop.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# supervisor-loop.sh — keep AutoShip moving from status changes to capacity refill.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+if [[ -f "$SCRIPT_DIR/lib/common.sh" ]]; then
+  source "$SCRIPT_DIR/lib/common.sh"
+else
+  autoship_repo_root() {
+    git rev-parse --show-toplevel 2>/dev/null || pwd
+  }
+fi
+
+REPO_ROOT="$(autoship_repo_root)"
+cd "$REPO_ROOT"
+
+AUTOSHIP_DIR=".autoship"
+WORKSPACES_DIR="$AUTOSHIP_DIR/workspaces"
+LOCK_FILE="$AUTOSHIP_DIR/supervisor-loop.lock"
+LOG_FILE="$AUTOSHIP_DIR/logs/supervisor-loop.log"
+INTERVAL_SECONDS="${AUTOSHIP_SUPERVISOR_INTERVAL_SECONDS:-30}"
+ONCE=false
+DAEMON=false
+ORIGINAL_ARGS=("$@")
+
+usage() {
+  cat <<'EOF'
+Usage: supervisor-loop.sh [--once] [--daemon] [--interval SECONDS]
+
+Runs AutoShip supervision passes:
+  monitor agents -> process event queue -> reconcile state -> runner refill
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --once)
+      ONCE=true
+      shift
+      ;;
+    --daemon)
+      DAEMON=true
+      shift
+      ;;
+    --interval)
+      INTERVAL_SECONDS="${2:?--interval requires seconds}"
+      shift 2
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ ! "$INTERVAL_SECONDS" =~ ^[0-9]+$ ]] || ((INTERVAL_SECONDS < 1)); then
+  INTERVAL_SECONDS=30
+fi
+
+mkdir -p "$AUTOSHIP_DIR/logs"
+
+log_supervisor() {
+  printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" >>"$LOG_FILE"
+}
+
+status_of() {
+  local status_file="$1/status"
+  [[ -f "$status_file" ]] || return 1
+  tr -d '[:space:]' <"$status_file" 2>/dev/null || true
+}
+
+pid_matches_command() {
+  local pid="$1" expected_file="$2"
+  [[ -s "$expected_file" ]] || return 1
+  local expected current
+  expected=$(cat "$expected_file" 2>/dev/null || true)
+  current=$(ps -p "$pid" -o command= 2>/dev/null || true)
+  [[ -n "$current" && "$current" == "$expected" ]]
+}
+
+worker_is_live() {
+  local dir="$1" pid_file="$1/worker.pid" pid
+  [[ -s "$pid_file" ]] || return 1
+  pid=$(tr -d '[:space:]' <"$pid_file")
+  [[ "$pid" =~ ^[0-9]+$ ]] || return 1
+  kill -0 "$pid" 2>/dev/null || return 1
+  pid_matches_command "$pid" "$dir/worker.command"
+}
+
+has_fresh_result() {
+  local dir="$1" result_file started_file="$1/started_at"
+  for result_file in "$dir/AUTOSHIP_RESULT.md" "$dir/HERMES_RESULT.md"; do
+    [[ -s "$result_file" ]] || continue
+    [[ ! -f "$started_file" || "$result_file" -nt "$started_file" ]] && return 0
+  done
+  return 1
+}
+
+clear_stale_running_workspaces() {
+  [[ -d "$WORKSPACES_DIR" ]] || return 0
+  local dir issue status
+  for dir in "$WORKSPACES_DIR"/*/; do
+    [[ -d "$dir" ]] || continue
+    issue=$(basename "$dir")
+    [[ "$issue" =~ ^issue-[0-9]+$ ]] || continue
+    status=$(status_of "$dir")
+    [[ "$status" == "RUNNING" ]] || continue
+    if ! worker_is_live "$dir"; then
+      if has_fresh_result "$dir"; then
+        printf 'COMPLETE\n' >"$dir/status"
+        log_supervisor "marked stale running workspace complete issue=$issue"
+      else
+        printf 'STUCK\n' >"$dir/status"
+        log_supervisor "marked stale running workspace stuck issue=$issue"
+      fi
+    fi
+  done
+}
+
+run_hook_if_present() {
+  local hook="$1"
+  if [[ -x "$SCRIPT_DIR/$hook" ]]; then
+    bash "$SCRIPT_DIR/$hook"
+  elif [[ -f "$SCRIPT_DIR/$hook" ]]; then
+    bash "$SCRIPT_DIR/$hook"
+  fi
+}
+
+supervisor_pass() {
+  log_supervisor "pass started"
+  run_hook_if_present monitor-agents.sh
+  clear_stale_running_workspaces
+  run_hook_if_present process-event-queue.sh
+  run_hook_if_present reconcile-state.sh
+  run_hook_if_present runner.sh
+  log_supervisor "pass finished"
+}
+
+run_loop() {
+  while true; do
+    supervisor_pass
+    [[ "$ONCE" == "true" ]] && break
+    sleep "$INTERVAL_SECONDS"
+  done
+}
+
+with_lock() {
+  mkdir -p "$AUTOSHIP_DIR"
+  if [[ -L "$LOCK_FILE" ]]; then
+    echo "Error: refusing symlink supervisor lock: $LOCK_FILE" >&2
+    exit 1
+  fi
+  touch "$LOCK_FILE"
+  if [[ "$(uname -s 2>/dev/null || true)" == "Darwin" ]] && command -v lockf >/dev/null 2>&1; then
+    if [[ -z "${AUTOSHIP_SUPERVISOR_LOCKED:-}" ]]; then
+      export AUTOSHIP_SUPERVISOR_LOCKED=1
+      exec lockf -k "$LOCK_FILE" "$0" "${ORIGINAL_ARGS[@]}"
+    fi
+  elif command -v flock >/dev/null 2>&1; then
+    exec 9>"$LOCK_FILE"
+    flock -x 9
+  elif command -v lockf >/dev/null 2>&1; then
+    if [[ -z "${AUTOSHIP_SUPERVISOR_LOCKED:-}" ]]; then
+      export AUTOSHIP_SUPERVISOR_LOCKED=1
+      exec lockf -k "$LOCK_FILE" "$0" "${ORIGINAL_ARGS[@]}"
+    fi
+  else
+    local lock_dir="$LOCK_FILE.d"
+    if ! mkdir "$lock_dir" 2>/dev/null; then
+      log_supervisor "supervisor already running lock=$lock_dir"
+      exit 0
+    fi
+    trap 'rmdir "$lock_dir" 2>/dev/null || true' EXIT INT TERM
+  fi
+  run_loop
+}
+
+if [[ "$DAEMON" == "true" && "$ONCE" != "true" ]]; then
+  log_supervisor "daemon started interval=${INTERVAL_SECONDS}s"
+fi
+
+with_lock "$@"

--- a/hooks/opencode/test-policy.sh
+++ b/hooks/opencode/test-policy.sh
@@ -350,6 +350,7 @@ assert_eq "1" "$artifact_count" "runner captures a salvaged truncation failure a
 artifact_file=$(find "$RUNNER_REPO/.autoship/failures" -name '*-issue-996.json' | head -1)
 jq -e '.issue == "issue-996" and .model == "opencode/test-free" and .role == "implementer" and .workspace != "" and .hook == "hooks/opencode/runner.sh" and .failure_category == "salvaged_truncation" and (.logs | contains("ok")) and .attempt == 2' "$artifact_file" >/dev/null || fail "failure artifact includes issue, model, workspace, hook, logs, category, role, and attempt"
 test -s "$RUNNER_REPO/.autoship/workspaces/issue-996/worker.pid" || fail "runner records worker pid for lifecycle monitoring"
+test -s "$RUNNER_REPO/.autoship/workspaces/issue-996/worker.command" || fail "runner records worker command for lifecycle monitoring"
 
 RETRY_REPO="$TMP_DIR/retry-limit-repo"
 mkdir -p "$RETRY_REPO/.autoship/workspaces/issue-181" "$RETRY_REPO/.autoship/failures" "$RETRY_REPO/hooks/opencode" "$RETRY_REPO/hooks"
@@ -804,6 +805,46 @@ touch -t 202604240000 "$MONITOR_COMPLETE_REPO/.autoship/workspaces/issue-998/sta
   bash hooks/opencode/monitor-agents.sh >/dev/null
 )
 assert_eq "COMPLETE" "$(tr -d '[:space:]' <"$MONITOR_COMPLETE_REPO/.autoship/workspaces/issue-998/status")" "monitor marks dead worker complete when fresh result artifact exists"
+
+SUPERVISOR_REPO="$TMP_DIR/supervisor-repo"
+mkdir -p "$SUPERVISOR_REPO/.autoship/workspaces/issue-1101" "$SUPERVISOR_REPO/.autoship/workspaces/issue-1102" "$SUPERVISOR_REPO/.autoship/workspaces/issue-1103" "$SUPERVISOR_REPO/hooks/opencode" "$SUPERVISOR_REPO/hooks"
+git init -q "$SUPERVISOR_REPO"
+cp "$SCRIPT_DIR/supervisor-loop.sh" "$SUPERVISOR_REPO/hooks/opencode/supervisor-loop.sh"
+cat >"$SUPERVISOR_REPO/hooks/opencode/monitor-agents.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'monitor\n' >>.autoship/order.log
+SH
+cat >"$SUPERVISOR_REPO/hooks/opencode/process-event-queue.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'events\n' >>.autoship/order.log
+SH
+cat >"$SUPERVISOR_REPO/hooks/opencode/reconcile-state.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'reconcile\n' >>.autoship/order.log
+SH
+cat >"$SUPERVISOR_REPO/hooks/opencode/runner.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'runner\n' >>.autoship/order.log
+SH
+chmod +x "$SUPERVISOR_REPO/hooks/opencode/"*.sh
+cat >"$SUPERVISOR_REPO/.autoship/state.json" <<'JSON'
+{"repo":"owner/repo","issues":{"issue-1101":{"state":"running"},"issue-1102":{"state":"queued"},"issue-1103":{"state":"running"}},"stats":{},"config":{"maxConcurrentAgents":2}}
+JSON
+printf 'RUNNING\n' >"$SUPERVISOR_REPO/.autoship/workspaces/issue-1101/status"
+printf 'QUEUED\n' >"$SUPERVISOR_REPO/.autoship/workspaces/issue-1102/status"
+printf 'RUNNING\n' >"$SUPERVISOR_REPO/.autoship/workspaces/issue-1103/status"
+printf '2026-05-07T00:00:00Z\n' >"$SUPERVISOR_REPO/.autoship/workspaces/issue-1103/started_at"
+printf 'result\n' >"$SUPERVISOR_REPO/.autoship/workspaces/issue-1103/AUTOSHIP_RESULT.md"
+touch -t 202605070000 "$SUPERVISOR_REPO/.autoship/workspaces/issue-1103/started_at"
+touch -t 202605070001 "$SUPERVISOR_REPO/.autoship/workspaces/issue-1103/AUTOSHIP_RESULT.md"
+(
+  cd "$SUPERVISOR_REPO"
+  bash hooks/opencode/supervisor-loop.sh --once >/dev/null
+)
+assert_eq "STUCK" "$(tr -d '[:space:]' <"$SUPERVISOR_REPO/.autoship/workspaces/issue-1101/status")" "supervisor marks RUNNING workspace without worker pid stuck"
+assert_eq "COMPLETE" "$(tr -d '[:space:]' <"$SUPERVISOR_REPO/.autoship/workspaces/issue-1103/status")" "supervisor preserves fresh results from stale RUNNING workspace"
+assert_eq $'monitor\nevents\nreconcile\nrunner' "$(cat "$SUPERVISOR_REPO/.autoship/order.log")" "supervisor runs monitor, event processing, reconcile, and runner in order"
+test -s "$SUPERVISOR_REPO/.autoship/logs/supervisor-loop.log" || fail "supervisor writes a lifecycle log"
 
 QUEUE_REPO="$TMP_DIR/queue-repo"
 mkdir -p "$QUEUE_REPO/.autoship" "$QUEUE_REPO/hooks/opencode" "$QUEUE_REPO/hooks"


### PR DESCRIPTION
## Summary
- Add an OpenCode supervisor loop that runs monitor, event processing, state reconciliation, and runner refill in order.
- Mark stale RUNNING workspaces with missing/dead worker identity as STUCK, while preserving fresh result artifacts as COMPLETE.
- Record worker command metadata and treat it as runtime-only so worker liveness checks are resilient to PID reuse.

## Verification
- bash -n hooks/opencode/supervisor-loop.sh hooks/opencode/runner.sh hooks/opencode/monitor-agents.sh hooks/opencode/create-pr.sh hooks/opencode/test-policy.sh
- bash hooks/opencode/test-policy.sh
- npm run typecheck
- bash hooks/opencode/verify-package.sh