### PR TITLE
fix(hermes): write no-agent cronjob scripts to disk instead of inline

### DIFF
--- a/hooks/hermes/cronjob-script-helper.sh
+++ b/hooks/hermes/cronjob-script-helper.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# AutoShip cronjob script helper — write no-agent scripts to disk and return relative path
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+AUTOSHIP_SCRIPTS_DIR="${AUTOSHIP_SCRIPTS_DIR:-$HOME/.hermes/scripts/autoship}"
+AUTOSHIP_TEMPLATE_DIR="${AUTOSHIP_TEMPLATE_DIR:-$REPO_ROOT/scripts/hermes/autoship}"
+
+usage() {
+    echo "Usage: $0 <name> <script_content_file>"
+    echo "  name: base name for the script (e.g. 'continuous-runner')"
+    echo "  script_content_file: path to file containing the bash script content"
+    echo ""
+    echo "Writes script to ~/.hermes/scripts/autoship/<name>.sh, chmod +x, returns relative path."
+    exit 1
+}
+
+if [[ $# -lt 2 ]]; then
+    usage
+fi
+
+name="$1"
+content_file="$2"
+
+if [[ ! -f "$content_file" ]]; then
+    echo "Error: content file not found: $content_file" >&2
+    exit 1
+fi
+
+# Ensure scripts directory exists
+mkdir -p "$AUTOSHIP_SCRIPTS_DIR"
+
+script_path="$AUTOSHIP_SCRIPTS_DIR/${name}.sh"
+
+# If a template exists in the repo, use it as base; otherwise use provided content
+if [[ -f "$AUTOSHIP_TEMPLATE_DIR/${name}.sh" ]]; then
+    cat "$AUTOSHIP_TEMPLATE_DIR/${name}.sh" | sed 's/\r$//' > "$script_path"
+else
+    cat "$content_file" | sed 's/\r$//' > "$script_path"
+fi
+chmod +x "$script_path"
+
+# Verify syntax
+if ! bash -n "$script_path" 2>/dev/null; then
+    echo "Error: script has syntax errors: $script_path" >&2
+    rm -f "$script_path"
+    exit 1
+fi
+
+# Return relative path from ~/.hermes/scripts/
+# The cron scheduler resolves relative to ~/.hermes/scripts/
+rel_path="autoship/${name}.sh"
+echo "$rel_path"

--- a/scripts/hermes/autoship/auto-update.sh
+++ b/scripts/hermes/autoship/auto-update.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# AutoShip auto-update
+set -euo pipefail
+cd /home/kara/projects/AutoShip || exit 1
+git fetch origin
+AHEAD=$(git rev-list HEAD..origin/main --count)
+if [ "$AHEAD" -gt 0 ]; then
+  git pull origin main
+  echo "AutoShip updated: $AHEAD new commits"
+else
+  echo "AutoShip: already up to date"
+fi

--- a/scripts/hermes/autoship/autoresearch-decompose.sh
+++ b/scripts/hermes/autoship/autoresearch-decompose.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# AutoResearch decomposer
+set -euo pipefail
+cd /home/kara/projects/AutoResearch || exit 1
+npm run decompose -- --input /home/kara/projects/AutoShip/.autoship/hermes-plan.json --output /home/kara/projects/AutoShip/.autoship/autoresearch-decomposition.json 2>&1 || echo "AutoResearch decompose not available"

--- a/scripts/hermes/autoship/autoresearch-update.sh
+++ b/scripts/hermes/autoship/autoresearch-update.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# AutoResearch auto-update
+set -euo pipefail
+cd /home/kara/projects/AutoResearch || exit 1
+git fetch origin
+AHEAD=$(git rev-list HEAD..origin/main --count)
+if [ "$AHEAD" -gt 0 ]; then
+  git pull origin main
+  echo "AutoResearch updated: $AHEAD new commits"
+else
+  echo "AutoResearch: already up to date"
+fi

--- a/scripts/hermes/autoship/burn-down-30min.sh
+++ b/scripts/hermes/autoship/burn-down-30min.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# AutoShip burn-down dispatcher — 3 issues at a time, every 30 minutes
+set -euo pipefail
+
+AUTOSHIP_DIR="/home/kara/projects/AutoShip/.autoship"
+WORKSPACES_DIR="$AUTOSHIP_DIR/workspaces"
+REPO_ROOT="/home/kara/projects/AutoShip"
+
+# Get list of issues that have HERMES_PROMPT.md but no status file (not yet started)
+queued=()
+for ws in $(ls -1 "$WORKSPACES_DIR" | grep '^issue-' | sort); do
+    if [[ -f "$WORKSPACES_DIR/$ws/HERMES_PROMPT.md" ]]; then
+        # Check if already has a running/completed status
+        status_file="$WORKSPACES_DIR/$ws/status.json"
+        if [[ ! -f "$status_file" ]]; then
+            issue_num=$(echo "$ws" | sed 's/issue-//')
+            queued+=("$issue_num")
+        fi
+    fi
+done
+
+# Also check event-queue.json for stuck issues
+if [[ -f "$AUTOSHIP_DIR/event-queue.json" ]]; then
+    stuck=$(python3 -c "
+import json
+with open('$AUTOSHIP_DIR/event-queue.json') as f:
+    q = json.load(f)
+for item in q:
+    if item.get('status') == 'STUCK' or item.get('type') == 'stuck':
+        issue = item['issue'].replace('issue-', '')
+        print(issue)
+" 2>/dev/null || true)
+    for issue in $stuck; do
+        if [[ ! " ${queued[@]} " =~ " ${issue} " ]]; then
+            queued+=("$issue")
+        fi
+    done
+fi
+
+# Limit to 3 at a time
+count=0
+for issue in "${queued[@]}"; do
+    if [[ $count -ge 3 ]]; then
+        break
+    fi
+    
+    # Check if already dispatched via cronjob
+    existing=$(hermes cronjob list 2>/dev/null | grep "autoship-issue-$issue" || true)
+    if [[ -n "$existing" ]]; then
+        echo "Issue #$issue already has cronjob, skipping"
+        continue
+    fi
+    
+    echo "Dispatching issue #$issue..."
+    cd "$REPO_ROOT"
+    bash hooks/hermes/dispatch.sh "$issue" 2>&1 || true
+    
+    # Create cronjob for the worker
+    ws_dir="$WORKSPACES_DIR/issue-$issue"
+    if [[ -f "$ws_dir/HERMES_PROMPT.md" ]]; then
+        prompt_file="$ws_dir/HERMES_PROMPT.md"
+        worktree_path=$(cat "$ws_dir/worktree-path.txt" 2>/dev/null || echo "$ws_dir")
+        
+        # Check if cronjob already exists
+        job_list=$(hermes cronjob list 2>/dev/null || echo "")
+        if echo "$job_list" | grep -q "autoship-issue-$issue"; then
+            echo "Cronjob for issue-$issue already exists"
+        else
+            echo "Creating cronjob for issue-$issue..."
+            # Create via hermes cronjob create command
+            hermes cron create \
+                --name "autoship-issue-$issue" \
+                --schedule "every 10m" \
+                --workdir "$worktree_path" \
+                --prompt-file "$prompt_file" \
+                --no-agent 2>/dev/null || \
+            echo "Note: hermes cron create not available, skipping cronjob creation"
+        fi
+    fi
+    
+    count=$((count + 1))
+done
+
+if [[ $count -eq 0 ]]; then
+    echo "No new issues to dispatch. All caught up or max concurrency reached."
+else
+    echo "Dispatched $count issue(s)."
+fi

--- a/scripts/hermes/autoship/cleanup-stuck.sh
+++ b/scripts/hermes/autoship/cleanup-stuck.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# AutoShip stuck worker cleanup
+set -euo pipefail
+cd /home/kara/projects/AutoShip || exit 1
+bash hooks/hermes/cleanup-worktrees.sh 2>&1 || true

--- a/scripts/hermes/autoship/code-archaeology-update.sh
+++ b/scripts/hermes/autoship/code-archaeology-update.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Code-Archaeology auto-update
+set -euo pipefail
+cd /home/kara/projects/Code-Archaeology || exit 1
+git fetch origin
+AHEAD=$(git rev-list HEAD..origin/main --count)
+if [ "$AHEAD" -gt 0 ]; then
+  git pull origin main
+  echo "Code-Archaeology updated: $AHEAD new commits"
+else
+  echo "Code-Archaeology: already up to date"
+fi

--- a/scripts/hermes/autoship/continuous-runner.sh
+++ b/scripts/hermes/autoship/continuous-runner.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# AutoShip continuous runner — keep the pipeline flowing every 15 minutes
+set -euo pipefail
+
+AUTOSHIP_DIR="/home/kara/projects/AutoShip/.autoship"
+REPO_ROOT="/home/kara/projects/AutoShip"
+
+# Step 1: Run the Hermes runner to dispatch any queued workers
+cd "$REPO_ROOT"
+bash hooks/hermes/runner.sh 2>&1 || true
+
+# Step 2: Check for stuck workers and retry them
+cd "$REPO_ROOT"
+bash hooks/hermes/reconcile-state.sh 2>&1 || true
+
+# Step 3: Run stuck worker cleanup if needed
+if [[ -f "$AUTOSHIP_DIR/event-queue.json" ]]; then
+    stuck_count=$(python3 -c "
+import json
+with open('$AUTOSHIP_DIR/event-queue.json') as f:
+    q = json.load(f)
+print(len([x for x in q if x.get('type') == 'stuck']))
+" 2>/dev/null || echo "0")
+    if [[ "$stuck_count" -gt 0 ]]; then
+        echo "$stuck_count stuck issues found, running cleanup..."
+        cd "$REPO_ROOT"
+        bash hooks/hermes/cleanup-worktrees.sh 2>&1 || true
+    fi
+fi
+
+# Step 4: Check if we need to dispatch more issues
+running=$(cd "$REPO_ROOT" && bash hooks/hermes/runner.sh 2>&1 | grep -oP '\d+ running' | grep -oP '\d+' || echo "0")
+max=5
+available=$((max - running))
+
+if [[ "$available" -gt 0 ]]; then
+    echo "$available slot(s) available, checking for queued issues..."
+    cd "$REPO_ROOT"
+    bash hooks/hermes/dispatch.sh 2>&1 || true
+fi
+
+echo "AutoShip continuous runner completed"

--- a/scripts/hermes/autoship/windows-opencode-update.sh
+++ b/scripts/hermes/autoship/windows-opencode-update.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Windows OpenCode auto-update
+set -euo pipefail
+cd /home/kara/.hermes/scripts || exit 1
+python3 windows_bridge.py update-opencode 2>&1
+echo "---"
+python3 windows_bridge.py update-plugins 2>&1


### PR DESCRIPTION
## Problem

The Hermes cron scheduler expects the `script` field to contain a relative file path under `~/.hermes/scripts/`, not inline bash content. When scripts were stored inline, the scheduler tried to execute the first line (e.g. `#!/bin/bash`) as a filename, causing 'Script not found' errors.

This broke 8 no-agent cronjobs including autoship-continuous-runner.

## Fix

- New hook: hooks/hermes/cronjob-script-helper.sh -- writes scripts to disk, strips CRLF, verifies syntax, returns relative path
- Templates: scripts/hermes/autoship/ contains all 8 existing cronjob scripts as version-controlled templates

## Verification

All 9 shell files pass bash -n syntax check. Local dry-run of continuous-runner.sh completed successfully.