### PR TITLE
fix: recover stuck workspace retries

### DIFF
--- a/hooks/opencode/reconcile-state.sh
+++ b/hooks/opencode/reconcile-state.sh
@@ -96,7 +96,7 @@ for dir in "$WORKSPACES_DIR"/*/; do
 
   current_state=$(jq -r --arg key "$key" '.issues[$key].state // empty' "$tmp" 2>/dev/null || true)
   increment_stats=true
-  if [[ "$current_state" != "$new_state" && -x "$REPO_ROOT/hooks/update-state.sh" && -d "$REPO_ROOT/.git" ]]; then
+  if [[ "$current_state" != "$new_state" && -d "$REPO_ROOT/.git" ]]; then
     if (cd "$REPO_ROOT" && autoship_state_set "$action" "$key") >/dev/null 2>&1; then
       cp "$STATE_FILE" "$tmp"
       increment_stats=false

--- a/hooks/opencode/runner.sh
+++ b/hooks/opencode/runner.sh
@@ -170,6 +170,17 @@ is_billing_or_quota_failure() {
   grep -Eiq 'insufficient balance|billing|quota|rate limit|credit' "$log_file"
 }
 
+write_failure_reason() {
+  local category="$1"
+  local log_file="${2:-AUTOSHIP_RUNNER.log}"
+  local summary
+  summary=$(tail -8 "$log_file" 2>/dev/null || echo "worker run failed")
+  {
+    printf 'category=%s\n' "$category"
+    printf 'summary<<EOF\n%s\nEOF\n' "$summary"
+  } >BLOCKED_REASON.txt
+}
+
 annotate_session_failure() {
   local log_file="${1:-AUTOSHIP_RUNNER.log}"
   [[ -f "$log_file" ]] || return 1
@@ -353,6 +364,7 @@ mark_stuck_unless_terminal() {
     COMPLETE | BLOCKED | STUCK) ;;
     *)
       error_msg=$(tail -5 AUTOSHIP_RUNNER.log 2>/dev/null || echo "worker exited without terminal status")
+      write_failure_reason stuck AUTOSHIP_RUNNER.log
       autoship_capture_failure stuck "$wid" "error_summary=$error_msg"
       echo "STUCK" >status
       ;;
@@ -450,6 +462,7 @@ for dir in "$WORKSPACES_DIR"/*/; do
               else
                 echo "STUCK" >status
                 error_msg=$(tail -5 AUTOSHIP_RUNNER.log 2>/dev/null || echo "fallback worker run failed")
+                write_failure_reason model_failure AUTOSHIP_RUNNER.log
                 autoship_capture_failure model_failure "$issue_id" "error_summary=$error_msg"
                 bash "$SCRIPT_DIR/metrics-collector.sh" record-failure "$issue_id" "$fallback_model" >/dev/null 2>&1 || true
                 bash "$SCRIPT_DIR/circuit-breaker.sh" record-failure "$fallback_model" >/dev/null 2>&1 || true
@@ -457,6 +470,7 @@ for dir in "$WORKSPACES_DIR"/*/; do
             else
               echo "STUCK" >status
               error_msg=$(tail -5 AUTOSHIP_RUNNER.log 2>/dev/null || echo "worker run failed")
+              write_failure_reason model_failure AUTOSHIP_RUNNER.log
               autoship_capture_failure model_failure "$issue_id" "error_summary=$error_msg"
               bash "$SCRIPT_DIR/circuit-breaker.sh" record-failure "$model" >/dev/null 2>&1 || true
             fi
@@ -464,6 +478,7 @@ for dir in "$WORKSPACES_DIR"/*/; do
             annotate_session_failure AUTOSHIP_RUNNER.log || true
             echo "STUCK" >status
             error_msg=$(tail -5 AUTOSHIP_RUNNER.log 2>/dev/null || echo "worker run failed")
+            write_failure_reason model_failure AUTOSHIP_RUNNER.log
             autoship_capture_failure model_failure "$issue_id" "error_summary=$error_msg"
             bash "$SCRIPT_DIR/metrics-collector.sh" record-failure "$issue_id" "$model" >/dev/null 2>&1 || true
             bash "$SCRIPT_DIR/circuit-breaker.sh" record-failure "$model" >/dev/null 2>&1 || true
@@ -472,6 +487,7 @@ for dir in "$WORKSPACES_DIR"/*/; do
       else
         echo "opencode CLI not found" >AUTOSHIP_RUNNER.log
         echo "STUCK" >status
+        write_failure_reason missing_opencode AUTOSHIP_RUNNER.log
         autoship_capture_failure model_failure "$issue_id" "error_summary=opencode CLI not found"
         bash "$SCRIPT_DIR/metrics-collector.sh" record-failure "$issue_id" "$model" >/dev/null 2>&1 || true
         bash "$SCRIPT_DIR/circuit-breaker.sh" record-failure "$model" >/dev/null 2>&1 || true

--- a/hooks/opencode/test-policy.sh
+++ b/hooks/opencode/test-policy.sh
@@ -626,7 +626,7 @@ chmod +x "$TESTS_ONLY_REPO/bin/opencode"
   PATH="$TESTS_ONLY_REPO/bin:$PATH" bash hooks/opencode/runner.sh >/dev/null
 )
 for _ in 1 2 3 4 5; do
-  [[ "$(tr -d '[:space:]' <"$TESTS_ONLY_REPO/.autoship/workspaces/issue-254/status")" != "RUNNING" ]] && break
+  [[ "$(tr -d '[:space:]' <"$TESTS_ONLY_REPO/.autoship/workspaces/issue-254/status")" == "STUCK" ]] && break
   sleep 1
 done
 assert_eq "STUCK" "$(tr -d '[:space:]' <"$TESTS_ONLY_REPO/.autoship/workspaces/issue-254/status")" "runner rejects tests-only complete results"

--- a/hooks/opencode/test-policy.sh
+++ b/hooks/opencode/test-policy.sh
@@ -474,7 +474,8 @@ chmod +x "$AUTOCOMMIT_REPO/bin/opencode"
   PATH="$AUTOCOMMIT_REPO/bin:$PATH" bash hooks/opencode/runner.sh >/dev/null
 )
 for _ in 1 2 3 4 5; do
-  [[ "$(tr -d '[:space:]' <"$AUTOCOMMIT_REPO/.autoship/workspaces/issue-253/status")" != "RUNNING" ]] && break
+  [[ "$(tr -d '[:space:]' <"$AUTOCOMMIT_REPO/.autoship/workspaces/issue-253/status")" == "COMPLETE" ]] && \
+    [[ "$(git -C "$AUTOCOMMIT_REPO/.autoship/workspaces/issue-253" rev-list --count HEAD)" == "2" ]] && break
   sleep 1
 done
 assert_eq "COMPLETE" "$(tr -d '[:space:]' <"$AUTOCOMMIT_REPO/.autoship/workspaces/issue-253/status")" "runner keeps complete status after auto-committing production changes"

--- a/hooks/update-state.sh
+++ b/hooks/update-state.sh
@@ -362,8 +362,8 @@ case "$ACTION" in
   set-queued)
     NEW_STATE="queued"
     STAT_KEY=""
-    ADD_LABEL=""
-    REMOVE_LABELS=()
+    ADD_LABEL="agent:ready"
+    REMOVE_LABELS=("autoship:in-progress" "autoship:blocked" "autoship:paused" "autoship:done")
     ;;
   set-running)
     NEW_STATE="running"


### PR DESCRIPTION
## Summary
- Let reconciliation use the installed AutoShip state updater instead of requiring repo-local hooks.
- Write BLOCKED_REASON.txt for stuck worker/model failures so operators can triage retries.
- Restore agent:ready and clear stale AutoShip labels when issues are requeued.

## Verification
- bash -n hooks/opencode/reconcile-state.sh
- bash -n hooks/opencode/runner.sh
- bash -n hooks/update-state.sh

Context: fixes stuck workspace recovery for OpenCode AutoShip agents.