### PR TITLE
fix: remove OpenRouter from defaults

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ See [AGENT_CATALOG.md](AGENT_CATALOG.md) for the specialized agent roles, inputs
 - **OpenCode** is the primary supported worker runtime.
 - **Hermes** is supported as an alternative runtime via `hooks/hermes/`.
 - Role models are selected from live `opencode models` inventory and `.autoship/model-routing.json`; do not assume `openai/gpt-5.5` is available or preferred.
-- Prefer capable free models first, then OpenCode Go role models when available; use Kimi/Kimmy 2.6 only through `opencode-go/*` unless the operator explicitly selects a paid Zen/OpenRouter model.
+- Prefer capable free models first, then OpenCode Go role models when available; use Kimi/Kimmy 2.6 only through `opencode-go/*` unless the operator explicitly selects another supported provider model.
 - `openai/gpt-5.5-fast` is not allowed.
 - Worker models come from live `opencode models` inventory and are routed free-first with deterministic rotation across compatible workers.
 - Default active worker cap is 20 for both OpenCode and Hermes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -442,7 +442,7 @@
 - OpenCode-only runtime.
 - Live model discovery from `opencode models`.
 - `openai/gpt-5.5` planner/coordinator/orchestrator/reviewer roles.
-- Free worker models by default, with operator-selected Spark, Go-provider, Nvidia, OpenRouter, and other OpenCode models allowed when available.
+- Free worker models by default, with operator-selected Spark, Go-provider, Nvidia, and other supported OpenCode models allowed when available.
 - Learned worker model selection using task fit, configured strength, cost class, and prior success/failure history.
 - Default active worker cap increased to 15.
 - Removed stale runtime, assistant, and pre-rename references from docs and public pages.

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ AutoShip also loads committed policy profiles from `policies/`. Policies enrich 
 - Queue ordering: lowest issue number first
 - Model routing (OpenCode): ranked free OpenCode models first, with deterministic rotation across compatible workers
 - Model routing (Hermes): inherits from `~/.hermes/config.yaml`, no per-issue selection
-- Role selection: best available role model from `opencode models`, preferring free models first, then OpenCode Go models; paid Zen/OpenRouter Kimi models require explicit selection
+- Role selection: best available role model from `opencode models`, preferring free models first, then OpenCode Go models; paid provider models require explicit selection
 - Free detection: `:free`/`-free` IDs and bundled free Zen models such as `opencode/big-pickle` and `opencode/gpt-5-nano`
 - Go routing: `opencode-go/*` models are included as low-cost subscription fallback models, not free models
 - Orchestrator/reviewer: prompted during first-run setup and configurable independently

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -19,7 +19,7 @@ const AUTOSHIP_COMMANDS = {
     "autoship-dashboard": { description: "Show AutoShip dashboard metrics", agent: "build", subtask: false },
     "autoship-retry": { description: "Retry a blocked or stuck AutoShip issue", agent: "build", subtask: false },
 };
-const ENABLED_PROVIDERS = ["kimi-for-coding", "nvidia", "openai", "opencode", "opencode-go", "openrouter"];
+const ENABLED_PROVIDERS = ["kimi-for-coding", "nvidia", "openai", "opencode", "opencode-go"];
 const DISABLED_PROVIDERS = ["github-copilot"];
 const LEGACY_PLUGIN_REGISTRATIONS = new Set([
     "opencode-autoship@latest",

--- a/docs/OPENCODE_INSTALL.md
+++ b/docs/OPENCODE_INSTALL.md
@@ -136,7 +136,7 @@ AUTOSHIP_REFRESH_MODELS=1 bash hooks/opencode/setup.sh
 
 `setup.sh` writes `.autoship/model-routing.json`. This file is intentionally user-editable and is preserved on later setup runs unless `AUTOSHIP_REFRESH_MODELS=1` or `AUTOSHIP_MODELS=...` is provided.
 
-By default, setup chooses the best available role model from `opencode models`, preferring capable free models first and OpenCode Go models second. First-run setup asks which models to use for orchestrator and reviewer; they can be the same model or different models. Worker models are selected per task by the model selector using task compatibility, configured strength, cost class, previous success/failure history, and deterministic issue-number rotation across compatible workers. Free models, OpenCode Go models, and explicitly selected provider models can be configured. Paid Zen/OpenRouter Kimi models require explicit selection. `openai/gpt-5.5-fast` is rejected.
+By default, setup chooses the best available role model from `opencode models`, preferring capable free models first and OpenCode Go models second. First-run setup asks which models to use for orchestrator and reviewer; they can be the same model or different models. Worker models are selected per task by the model selector using task compatibility, configured strength, cost class, previous success/failure history, and deterministic issue-number rotation across compatible workers. Free models, OpenCode Go models, and explicitly selected provider models can be configured. Paid provider models require explicit selection. `openai/gpt-5.5-fast` is rejected.
 
 ## Troubleshooting
 

--- a/docs/OPENCODE_PORT_SPEC.md
+++ b/docs/OPENCODE_PORT_SPEC.md
@@ -10,7 +10,7 @@ AutoShip supports OpenCode as its only worker runtime.
 - Operators may explicitly select model IDs with `AUTOSHIP_MODELS`.
 - Selected models must exist in the current OpenCode model list.
 - Selected routing is saved in `.autoship/model-routing.json`, which is user-editable and preserved by setup unless refresh is requested.
-- Role models are selected from live `opencode models` inventory. Setup prefers capable free models first, then OpenCode Go models, instead of requiring `openai/gpt-5.5`. Paid Zen/OpenRouter Kimi models require explicit selection.
+- Role models are selected from live `opencode models` inventory. Setup prefers capable free models first, then OpenCode Go models, instead of requiring `openai/gpt-5.5`. Paid provider models require explicit selection.
 - First-run setup prompts for orchestrator and reviewer models; they may be the same model or different models.
 - Worker models are selected per task by `select-model.sh`, which scores task compatibility, cost class, configured strength, prior success/failure history, and rotates deterministically by issue number across compatible workers.
 - Complex tasks require a sufficiently strong compatible worker; otherwise `select-model.sh` falls back to the configured orchestrator model as an advisor.

--- a/hooks/hermes/setup.sh
+++ b/hooks/hermes/setup.sh
@@ -38,7 +38,6 @@ ROUTING='{
   ],
   "providers": [
     "nous",
-    "openrouter",
     "openai",
     "kimi-coding",
     "local"

--- a/hooks/opencode/model-parser.sh
+++ b/hooks/opencode/model-parser.sh
@@ -8,6 +8,7 @@ normalize_model_ids() {
 is_free_model() {
   local model
   model=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
+  [[ "$model" == openrouter/* ]] && return 1
   [[ "$model" == *":free" || "$model" == *"/free"* || "$model" == *"-free"* || "$model" == "opencode/big-pickle" || "$model" == "opencode/gpt-5-nano" ]]
 }
 
@@ -104,7 +105,6 @@ free_model_rank() {
 
   case "$model" in
     opencode/*) score=$((score + 6)) ;;
-    openrouter/*) score=$((score + 3)) ;;
   esac
 
   printf '%s\n' "$score"

--- a/hooks/opencode/setup.ps1
+++ b/hooks/opencode/setup.ps1
@@ -98,6 +98,7 @@ function Get-ModelIds {
 function Test-FreeModel {
     param([string]$Model)
     $m = $Model.ToLower()
+    if ($m.StartsWith("openrouter/")) { return $false }
     return ($m -like "*:free*" -or $m -like "*/free*" -or $m -like "*-free*" -or
             $m -eq "opencode/big-pickle" -or $m -eq "opencode/gpt-5-nano")
 }
@@ -128,7 +129,6 @@ function Get-FreeModelRank {
     }
 
     if ($m.StartsWith("opencode/")) { $score += 6 }
-    elseif ($m.StartsWith("openrouter/")) { $score += 3 }
 
     return $score
 }

--- a/hooks/opencode/test-model-parsing.sh
+++ b/hooks/opencode/test-model-parsing.sh
@@ -24,7 +24,7 @@ source "$SCRIPT_DIR/test-fixtures/mock-opencode-models.sh"
 
 AVAILABLE="opencode/nemotron-3-super-free
 opencode/minimax-m2.5-free
-openrouter/google/gemma-3-27b-it:free
+nvidia/google/gemma-3-27b-it
 openai/gpt-5.5
 openai/gpt-5.3-spark"
 AVAILABLE_IDS=$(normalize_model_ids "$AVAILABLE")
@@ -32,8 +32,8 @@ AVAILABLE_IDS=$(normalize_model_ids "$AVAILABLE")
 echo "=== Test: free model IDs ==="
 DEFAULT_FREE=$(default_free_models "$AVAILABLE_IDS")
 DEFAULT_FREE_NL=$(printf '%s\n' "$DEFAULT_FREE" | tr ',' '\n')
-assert_eq "3" "$(classify_models "$DEFAULT_FREE_NL" | grep -c ':free' || true)" "default model pool prefers free models"
-assert_eq "opencode/nemotron-3-super-free,opencode/minimax-m2.5-free,openrouter/google/gemma-3-27b-it:free" "$DEFAULT_FREE" "default free models are ranked by capability before provider order"
+assert_eq "2" "$(classify_models "$DEFAULT_FREE_NL" | grep -c ':free' || true)" "default model pool prefers non-OpenRouter free models"
+assert_eq "opencode/nemotron-3-super-free,opencode/minimax-m2.5-free" "$DEFAULT_FREE" "default free models exclude OpenRouter models"
 
 echo "=== Test: explicit selected model IDs ==="
 SELECTED_INPUT="openai/gpt-5.5,openai/gpt-5.3-spark"
@@ -57,7 +57,7 @@ assert_eq "2" "$(classify_models "$OPENCODE_GO_INPUT" | grep -c ':go' || true)" 
 echo "=== Test: default role model prefers Kimi/Ling 2.6 when available ==="
 ROLE_AVAILABLE="openai/gpt-5.5
 opencode-go/kimi-k2.6
-openrouter/other-model:free"
+nvidia/other-model"
 assert_eq "opencode-go/kimi-k2.6" "$(default_role_model "$ROLE_AVAILABLE")" "default role model prefers Kimi 2.6-compatible Go models"
 
 echo "=== Test: default role model does not auto-select paid Zen Kimi ==="
@@ -74,6 +74,11 @@ echo "=== Test: forbidden model IDs ==="
 if reject_forbidden_models "openai/gpt-5.5-fast" 2>/dev/null; then
   fail "gpt-5.5-fast must be rejected"
 fi
+
+echo "=== Test: OpenRouter is excluded from defaults ==="
+OPENROUTER_INPUT="openrouter/google/gemma-3-27b-it:free
+opencode/minimax-m2.5-free"
+assert_eq "opencode/minimax-m2.5-free" "$(default_free_models "$OPENROUTER_INPUT")" "OpenRouter models must not be selected by default"
 
 echo "=== Test: role selection is separate from worker selection ==="
 ROLE_ROUTING="$TMP_DIR/role-routing.json"

--- a/hooks/opencode/test-policy.sh
+++ b/hooks/opencode/test-policy.sh
@@ -1473,14 +1473,14 @@ chmod +x "$SETUP_REPO/bin/opencode" "$SETUP_REPO/bin/gh"
   printf '%s\n' "$setup_output" | grep -F 'opencode-autoship doctor' >/dev/null || fail "setup prints doctor next step"
   printf '%s\n' "$setup_output" | grep -F '/autoship-setup' >/dev/null || fail "setup prints setup next step"
   printf '%s\n' "$setup_output" | grep -F '/autoship' >/dev/null || fail "setup prints autoship next step"
-  jq -e '.models | length == 5' .autoship/model-routing.json >/dev/null || fail "setup writes all live free models by default"
+  jq -e '.models | length == 3' .autoship/model-routing.json >/dev/null || fail "setup writes non-OpenRouter live free models by default"
   jq -e '.maxConcurrentAgents == 20 and .max_agents == 20' .autoship/config.json >/dev/null || fail "setup writes default concurrency cap consumed by runtime"
   jq -e '.roles.planner == "opencode/nemotron-3-super-free" and .roles.coordinator == "opencode/nemotron-3-super-free" and .roles.orchestrator == "opencode/nemotron-3-super-free" and .roles.reviewer == "opencode/nemotron-3-super-free" and .roles.lead == "opencode/nemotron-3-super-free"' .autoship/model-routing.json >/dev/null || fail "setup configures live free-first role defaults"
   jq -e '.pools != null and .pools.default != null and .pools.frontend != null and .pools.backend != null and .pools.docs != null' .autoship/model-routing.json >/dev/null || fail "setup writes worker pools"
   jq -e 'all(.models[]; .cost == "free")' .autoship/model-routing.json >/dev/null || fail "default setup excludes paid worker models"
   jq -e 'all(.models[]; .id != "openai/gpt-5.5")' .autoship/model-routing.json >/dev/null || fail "planner model is not used as a default worker"
   jq -e '.models[0].id == "opencode/nemotron-3-super-free" and .defaultFallback == "opencode/nemotron-3-super-free"' .autoship/model-routing.json >/dev/null || fail "setup ranks strongest free worker first"
-  jq -e 'any(.models[]; .id == "openrouter/google/gemma-3-27b-it:free")' .autoship/model-routing.json >/dev/null || fail "setup includes OpenRouter free models from live OpenCode list"
+  jq -e 'all(.models[]; (.id | startswith("openrouter/") | not))' .autoship/model-routing.json >/dev/null || fail "setup excludes OpenRouter models from live OpenCode list"
   jq -e 'any(.models[]; .id == "zen/some-free-model:free")' .autoship/model-routing.json >/dev/null || fail "setup includes free models from any live OpenCode provider"
   jq '.models = [{"id":"manual/model","cost":"selected","strength":99,"max_task_types":["docs"]}] | .defaultFallback = "manual/model"' .autoship/model-routing.json >.autoship/model-routing.json.tmp && mv .autoship/model-routing.json.tmp .autoship/model-routing.json
   PATH="$SETUP_REPO/bin:$PATH" bash hooks/opencode/setup.sh >/dev/null
@@ -1488,10 +1488,10 @@ chmod +x "$SETUP_REPO/bin/opencode" "$SETUP_REPO/bin/gh"
   PATH="$SETUP_REPO/bin:$PATH" bash hooks/opencode/setup.sh --no-tui --max-agents=9 >/dev/null
   jq -e '.models[0].id == "manual/model"' .autoship/model-routing.json >/dev/null || fail "noninteractive setup preserves manual model-routing edits by default"
   PATH="$SETUP_REPO/bin:$PATH" bash hooks/opencode/setup.sh --no-tui --refresh-models >/dev/null
-  jq -e '.models | length == 5' .autoship/model-routing.json >/dev/null || fail "setup --refresh-models regenerates manual model routing when explicitly requested"
+  jq -e '.models | length == 3' .autoship/model-routing.json >/dev/null || fail "setup --refresh-models regenerates manual model routing when explicitly requested"
   jq '.models = [{"id":"manual/model","cost":"selected","strength":99,"max_task_types":["docs"]}] | .defaultFallback = "manual/model"' .autoship/model-routing.json >.autoship/model-routing.json.tmp && mv .autoship/model-routing.json.tmp .autoship/model-routing.json
   AUTOSHIP_REFRESH_MODELS=1 PATH="$SETUP_REPO/bin:$PATH" bash hooks/opencode/setup.sh >/dev/null
-  jq -e '.models | length == 5' .autoship/model-routing.json >/dev/null || fail "setup refreshes generated model routing when requested"
+  jq -e '.models | length == 3' .autoship/model-routing.json >/dev/null || fail "setup refreshes generated model routing when requested"
   AUTOSHIP_MODELS='opencode/gpt-5,opencode-go/qwen3.6-plus,openai/gpt-5.3-spark' PATH="$SETUP_REPO/bin:$PATH" bash hooks/opencode/setup.sh >/dev/null
   jq -e '.models[0].id == "opencode/gpt-5" and .models[0].cost == "selected" and .models[1].id == "opencode-go/qwen3.6-plus" and .models[2].id == "openai/gpt-5.3-spark"' .autoship/model-routing.json >/dev/null || fail "setup allows explicit selected non-free and Spark models from live list"
   if AUTOSHIP_MODELS='missing/model' PATH="$SETUP_REPO/bin:$PATH" bash hooks/opencode/setup.sh >/dev/null 2>&1; then
@@ -1911,7 +1911,7 @@ cp -R "$SCRIPT_DIR/../.." "$PACKAGE_REPO"
   for command in autoship autoship-setup autoship-status autoship-stop autoship-plan autoship-apply autoship-audit autoship-cancel autoship-clean autoship-dashboard autoship-retry; do
     jq -e --arg command "$command" '.command[$command].template == ("{file:commands/" + $command + ".md}\n\n$ARGUMENTS")' "$CONFIG_DIR/opencode.json" >/dev/null || fail "package installer registers /$command command"
   done
-  jq -e '.enabled_providers == ["kimi-for-coding", "nvidia", "openai", "opencode", "opencode-go", "openrouter"]' "$CONFIG_DIR/opencode.json" >/dev/null || fail "package installer writes provider allowlist"
+  jq -e '.enabled_providers == ["kimi-for-coding", "nvidia", "openai", "opencode", "opencode-go"]' "$CONFIG_DIR/opencode.json" >/dev/null || fail "package installer writes provider allowlist"
   jq -e '.disabled_providers == ["github-copilot"]' "$CONFIG_DIR/opencode.json" >/dev/null || fail "package installer disables github-copilot provider"
   test -d "$CONFIG_DIR/.autoship/hooks" || fail "package installer copies hooks"
   test -d "$CONFIG_DIR/.autoship/commands" || fail "package installer copies commands"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -49,7 +49,7 @@ const AUTOSHIP_COMMANDS: Record<string, Omit<CommandConfig, "template">> = {
   "autoship-retry": { description: "Retry a blocked or stuck AutoShip issue", agent: "build", subtask: false },
 };
 
-const ENABLED_PROVIDERS = ["kimi-for-coding", "nvidia", "openai", "opencode", "opencode-go", "openrouter"];
+const ENABLED_PROVIDERS = ["kimi-for-coding", "nvidia", "openai", "opencode", "opencode-go"];
 const DISABLED_PROVIDERS = ["github-copilot"];
 const LEGACY_PLUGIN_REGISTRATIONS = new Set([
   "opencode-autoship@latest",

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -12,7 +12,7 @@ AutoShip is the OpenCode plugin for solo maintainers who want their GitHub issue
 - Selects role models from live OpenCode inventory instead of requiring one fixed provider
 - Selects worker models from the live `opencode models` inventory
 - Defaults to ranked free worker models from the live OpenCode inventory and rotates compatible workers by issue number
-- Includes OpenCode Go models as allowed low-cost subscription fallbacks and allows explicitly selected Spark, Nvidia, OpenRouter, Zen, and other provider models when available
+- Includes OpenCode Go models as allowed low-cost subscription fallbacks and allows explicitly selected Spark, Nvidia, Zen, and other supported provider models when available
 - Runs up to 20 active workers by default
 
 ## Pages


### PR DESCRIPTION
## Summary
- Remove OpenRouter from the installed OpenCode provider allowlist.
- Exclude OpenRouter models from default AutoShip model discovery/routing.
- Update setup tests and docs to reflect the no-OpenRouter default policy.

## Verification
- bash hooks/opencode/test-model-parsing.sh
- bash hooks/opencode/check.sh --policy
- bash hooks/opencode/check.sh --syntax
- npm run build