### PR TITLE
fix: harden autoship supervisor monitoring

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,4 +44,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: "true"
-        run: npx semantic-release
+        run: >-
+          npx
+          --package semantic-release@25.0.3
+          --package @semantic-release/changelog@6.0.3
+          --package @semantic-release/git@10.0.1
+          --package @semantic-release/github@12.0.6
+          --package @semantic-release/npm@13.1.5
+          --package @semantic-release/exec@7.1.0
+          semantic-release

--- a/hooks/opencode/monitor-agents.sh
+++ b/hooks/opencode/monitor-agents.sh
@@ -163,21 +163,16 @@ is_worker_live() {
 }
 
 has_live_opencode_child() {
-  local dir="$1" key real_dir
-  key=$(basename "$dir")
+  local dir="$1" real_dir
   real_dir=$(cd "$dir" && pwd -P 2>/dev/null || printf '%s' "$dir")
+  [[ -n "$real_dir" ]] || return 1
   ps -axo command= 2>/dev/null | while IFS= read -r command; do
     case "$command" in
-      *opencode*" run "*) ;;
-      *) continue ;;
-    esac
-    case "$command" in
-      *"$real_dir"* | *"$key"*)
-        printf 'found\n'
-        break
+      *opencode*" run "*)
+        printf '%s\n' "$command"
         ;;
     esac
-  done | grep -q '^found$'
+  done | grep -F -q -- "$real_dir"
 }
 
 has_fresh_result() {

--- a/hooks/opencode/monitor-agents.sh
+++ b/hooks/opencode/monitor-agents.sh
@@ -162,6 +162,24 @@ is_worker_live() {
   kill -0 "$pid" 2>/dev/null
 }
 
+has_live_opencode_child() {
+  local dir="$1" key real_dir
+  key=$(basename "$dir")
+  real_dir=$(cd "$dir" && pwd -P 2>/dev/null || printf '%s' "$dir")
+  ps -axo command= 2>/dev/null | while IFS= read -r command; do
+    case "$command" in
+      *opencode*" run "*) ;;
+      *) continue ;;
+    esac
+    case "$command" in
+      *"$real_dir"* | *"$key"*)
+        printf 'found\n'
+        break
+        ;;
+    esac
+  done | grep -q '^found$'
+}
+
 has_fresh_result() {
   local dir="$1"
   local result_file
@@ -179,7 +197,9 @@ reconcile_exited_worker() {
   key=$(basename "$dir")
   local status_file="$dir/status"
 
-  is_worker_live "$dir" && return 0
+  if is_worker_live "$dir" || has_live_opencode_child "$dir"; then
+    return 0
+  fi
 
   if has_fresh_result "$dir"; then
     echo "COMPLETE" >"$status_file"

--- a/hooks/opencode/supervisor-loop.sh
+++ b/hooks/opencode/supervisor-loop.sh
@@ -20,13 +20,14 @@ WORKSPACES_DIR="$AUTOSHIP_DIR/workspaces"
 LOCK_FILE="$AUTOSHIP_DIR/supervisor-loop.lock"
 LOG_FILE="$AUTOSHIP_DIR/logs/supervisor-loop.log"
 INTERVAL_SECONDS="${AUTOSHIP_SUPERVISOR_INTERVAL_SECONDS:-30}"
+REPORT=false
 ONCE=false
 DAEMON=false
 ORIGINAL_ARGS=("$@")
 
 usage() {
   cat <<'EOF'
-Usage: supervisor-loop.sh [--once] [--daemon] [--interval SECONDS]
+Usage: supervisor-loop.sh [--once] [--daemon] [--interval SECONDS] [--report]
 
 Runs AutoShip supervision passes:
   monitor agents -> process event queue -> reconcile state -> runner refill
@@ -41,6 +42,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --daemon)
       DAEMON=true
+      shift
+      ;;
+    --report)
+      REPORT=true
       shift
       ;;
     --interval)
@@ -71,7 +76,10 @@ log_supervisor() {
 
 status_of() {
   local status_file="$1/status"
-  [[ -f "$status_file" ]] || return 1
+  [[ -f "$status_file" ]] || {
+    printf ''
+    return 0
+  }
   tr -d '[:space:]' <"$status_file" 2>/dev/null || true
 }
 
@@ -93,6 +101,97 @@ worker_is_live() {
   pid_matches_command "$pid" "$dir/worker.command"
 }
 
+has_live_opencode_child() {
+  local dir="$1" issue real_dir
+  issue=$(basename "$dir")
+  real_dir=$(cd "$dir" && pwd -P 2>/dev/null || printf '%s' "$dir")
+  ps -axo command= 2>/dev/null | while IFS= read -r command; do
+    case "$command" in
+      *opencode*" run "*) ;;
+      *) continue ;;
+    esac
+    case "$command" in
+      *"$real_dir"* | *"$issue"*)
+        printf 'found\n'
+        break
+        ;;
+    esac
+  done | grep -q '^found$'
+}
+
+workspace_has_live_worker() {
+  local dir="$1"
+  worker_is_live "$dir" || has_live_opencode_child "$dir"
+}
+
+max_agents() {
+  local max=""
+  if [[ -f "$AUTOSHIP_DIR/state.json" ]]; then
+    max=$(jq -r '.config.maxConcurrentAgents // .max_concurrent_agents // empty' "$AUTOSHIP_DIR/state.json" 2>/dev/null || true)
+  fi
+  if [[ -z "$max" && -f "$AUTOSHIP_DIR/config.json" ]]; then
+    max=$(jq -r '.maxConcurrentAgents // .max_agents // empty' "$AUTOSHIP_DIR/config.json" 2>/dev/null || true)
+  fi
+  [[ "$max" =~ ^[0-9]+$ ]] || max=20
+  printf '%s\n' "$max"
+}
+
+file_mtime_epoch() {
+  local file="$1"
+  stat -f %m "$file" 2>/dev/null || stat -c %Y "$file" 2>/dev/null || printf '0\n'
+}
+
+emit_report() {
+  [[ "$REPORT" == "true" ]] || return 0
+  [[ -d "$WORKSPACES_DIR" ]] || return 0
+  local max running queued complete_ready stale_running live_no_log now stale_after
+  max=$(max_agents)
+  running=0
+  queued=0
+  complete_ready=0
+  stale_running=0
+  live_no_log=0
+  now=$(date +%s)
+  stale_after="${AUTOSHIP_SUPERVISOR_STALE_LOG_SECONDS:-300}"
+  [[ "$stale_after" =~ ^[0-9]+$ ]] || stale_after=300
+
+  local dir issue status log_file mtime age
+  for dir in "$WORKSPACES_DIR"/*/; do
+    [[ -d "$dir" ]] || continue
+    issue=$(basename "$dir")
+    [[ "$issue" =~ ^issue-[0-9]+$ ]] || continue
+    status=$(status_of "$dir")
+    case "$status" in
+      RUNNING)
+        running=$((running + 1))
+        if workspace_has_live_worker "$dir"; then
+          log_file="$dir/AUTOSHIP_RUNNER.log"
+          if [[ -f "$log_file" ]]; then
+            mtime=$(file_mtime_epoch "$log_file")
+            [[ "$mtime" =~ ^[0-9]+$ ]] || mtime=0
+            age=$((now - mtime))
+            ((age > stale_after)) && live_no_log=$((live_no_log + 1))
+          else
+            live_no_log=$((live_no_log + 1))
+          fi
+        else
+          stale_running=$((stale_running + 1))
+        fi
+        ;;
+      QUEUED) queued=$((queued + 1)) ;;
+      COMPLETE) complete_ready=$((complete_ready + 1)) ;;
+    esac
+  done
+
+  local above_cap queued_eligible
+  above_cap=0
+  queued_eligible=0
+  ((running > max)) && above_cap=1
+  ((queued > 0 && running < max)) && queued_eligible=1
+  printf 'AUTOSHIP_MONITOR running=%s max=%s queued=%s complete_ready=%s stale_running=%s live_no_log=%s active_above_cap=%s queued_dispatch_eligible=%s\n' \
+    "$running" "$max" "$queued" "$complete_ready" "$stale_running" "$live_no_log" "$above_cap" "$queued_eligible"
+}
+
 has_fresh_result() {
   local dir="$1" result_file started_file="$1/started_at"
   for result_file in "$dir/AUTOSHIP_RESULT.md" "$dir/HERMES_RESULT.md"; do
@@ -111,7 +210,7 @@ clear_stale_running_workspaces() {
     [[ "$issue" =~ ^issue-[0-9]+$ ]] || continue
     status=$(status_of "$dir")
     [[ "$status" == "RUNNING" ]] || continue
-    if ! worker_is_live "$dir"; then
+    if ! workspace_has_live_worker "$dir"; then
       if has_fresh_result "$dir"; then
         printf 'COMPLETE\n' >"$dir/status"
         log_supervisor "marked stale running workspace complete issue=$issue"
@@ -135,6 +234,7 @@ run_hook_if_present() {
 supervisor_pass() {
   log_supervisor "pass started"
   run_hook_if_present monitor-agents.sh
+  emit_report
   clear_stale_running_workspaces
   run_hook_if_present process-event-queue.sh
   run_hook_if_present reconcile-state.sh

--- a/hooks/opencode/supervisor-loop.sh
+++ b/hooks/opencode/supervisor-loop.sh
@@ -102,20 +102,17 @@ worker_is_live() {
 }
 
 has_live_opencode_child() {
-  local dir="$1" issue real_dir
-  issue=$(basename "$dir")
+  local dir="$1" real_dir
   real_dir=$(cd "$dir" && pwd -P 2>/dev/null || printf '%s' "$dir")
   ps -axo command= 2>/dev/null | while IFS= read -r command; do
     case "$command" in
       *opencode*" run "*) ;;
       *) continue ;;
     esac
-    case "$command" in
-      *"$real_dir"* | *"$issue"*)
-        printf 'found\n'
-        break
-        ;;
-    esac
+    if printf '%s\n' "$command" | grep -F -- "$real_dir" >/dev/null 2>&1; then
+      printf 'found\n'
+      break
+    fi
   done | grep -q '^found$'
 }
 

--- a/hooks/opencode/test-policy.sh
+++ b/hooks/opencode/test-policy.sh
@@ -741,6 +741,16 @@ SH
 chmod +x "$MONITOR_LIVE_CHILD_REPO/bin/opencode"
 "$MONITOR_LIVE_CHILD_REPO/bin/opencode" run --model opencode/test-free "$MONITOR_LIVE_CHILD_REPO/.autoship/workspaces/issue-999" &
 live_child_pid=$!
+# Wait until the child is visible in ps to avoid a race on slow/loaded systems
+_live_wait=0
+while [ "$_live_wait" -lt 50 ]; do
+  kill -0 "$live_child_pid" 2>/dev/null \
+    && ps -axo command= 2>/dev/null \
+         | grep -F -q "$MONITOR_LIVE_CHILD_REPO/.autoship/workspaces/issue-999" \
+    && break
+  sleep 0.1
+  _live_wait=$((_live_wait + 1))
+done
 (
   cd "$MONITOR_LIVE_CHILD_REPO"
   bash hooks/opencode/monitor-agents.sh >/dev/null

--- a/hooks/opencode/test-policy.sh
+++ b/hooks/opencode/test-policy.sh
@@ -57,7 +57,7 @@ assert_canonical_inventory
 
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
-if ! grep -A4 'actions/setup-node@v4' "$REPO_ROOT/.github/workflows/release.yml" | grep -Eq "node-version: ['\"]?(22|24)['\"]?"; then
+if ! grep -E -A4 'actions/setup-node@v(4|6)' "$REPO_ROOT/.github/workflows/release.yml" | grep -Eq "node-version: ['\"]?(22|24)['\"]?"; then
   fail "release workflow must use Node 22 or 24 for semantic-release"
 fi
 grep -F '"$HOOKS_DIR/hermes"/*.sh' "$SCRIPT_DIR/check.sh" >/dev/null \
@@ -237,6 +237,7 @@ printf '{"policy":"textquest"}\n' >"$PACKAGE_VERIFY_REPO/policies/textquest.json
 printf 'agents\n' >"$PACKAGE_VERIFY_REPO/AGENTS.md"
 printf '1.0.0\n' >"$PACKAGE_VERIFY_REPO/VERSION"
 printf 'readme\n' >"$PACKAGE_VERIFY_REPO/README.md"
+printf 'changelog\n' >"$PACKAGE_VERIFY_REPO/CHANGELOG.md"
 printf 'install\n' >"$PACKAGE_VERIFY_REPO/INSTALL.md"
 printf 'license\n' >"$PACKAGE_VERIFY_REPO/LICENSE"
 printf 'install\n' >"$PACKAGE_VERIFY_REPO/.opencode/INSTALL.md"
@@ -719,6 +720,35 @@ printf '999999\n' >"$MONITOR_REPO/.autoship/workspaces/issue-997/worker.pid"
 )
 assert_eq "STUCK" "$(tr -d '[:space:]' <"$MONITOR_REPO/.autoship/workspaces/issue-997/status")" "monitor marks RUNNING workspace stuck when worker pid is no longer live"
 assert_eq "stuck" "$(jq -r '.issues["issue-997"].state' "$MONITOR_REPO/.autoship/state.json")" "monitor reconciles stale RUNNING workspace state"
+
+MONITOR_LIVE_CHILD_REPO="$TMP_DIR/monitor-live-child-repo"
+mkdir -p "$MONITOR_LIVE_CHILD_REPO/.autoship/workspaces/issue-999" "$MONITOR_LIVE_CHILD_REPO/hooks/opencode" "$MONITOR_LIVE_CHILD_REPO/hooks" "$MONITOR_LIVE_CHILD_REPO/bin"
+git init -q "$MONITOR_LIVE_CHILD_REPO"
+cp "$SCRIPT_DIR/monitor-agents.sh" "$MONITOR_LIVE_CHILD_REPO/hooks/opencode/monitor-agents.sh"
+cp "$SCRIPT_DIR/reconcile-state.sh" "$MONITOR_LIVE_CHILD_REPO/hooks/opencode/reconcile-state.sh"
+cp "$SCRIPT_DIR/../update-state.sh" "$MONITOR_LIVE_CHILD_REPO/hooks/update-state.sh"
+chmod +x "$MONITOR_LIVE_CHILD_REPO/hooks/opencode/monitor-agents.sh" "$MONITOR_LIVE_CHILD_REPO/hooks/opencode/reconcile-state.sh" "$MONITOR_LIVE_CHILD_REPO/hooks/update-state.sh"
+cat >"$MONITOR_LIVE_CHILD_REPO/.autoship/state.json" <<'JSON'
+{"repo":"owner/repo","issues":{"issue-999":{"state":"running"}},"stats":{},"config":{"maxConcurrentAgents":15}}
+JSON
+printf '[]\n' >"$MONITOR_LIVE_CHILD_REPO/.autoship/event-queue.json"
+printf 'RUNNING\n' >"$MONITOR_LIVE_CHILD_REPO/.autoship/workspaces/issue-999/status"
+printf '999999\n' >"$MONITOR_LIVE_CHILD_REPO/.autoship/workspaces/issue-999/worker.pid"
+cat >"$MONITOR_LIVE_CHILD_REPO/bin/opencode" <<'SH'
+#!/usr/bin/env bash
+sleep 30
+SH
+chmod +x "$MONITOR_LIVE_CHILD_REPO/bin/opencode"
+"$MONITOR_LIVE_CHILD_REPO/bin/opencode" run --model opencode/test-free "$MONITOR_LIVE_CHILD_REPO/.autoship/workspaces/issue-999" &
+live_child_pid=$!
+(
+  cd "$MONITOR_LIVE_CHILD_REPO"
+  bash hooks/opencode/monitor-agents.sh >/dev/null
+)
+kill "$live_child_pid" 2>/dev/null || true
+wait "$live_child_pid" 2>/dev/null || true
+assert_eq "RUNNING" "$(tr -d '[:space:]' <"$MONITOR_LIVE_CHILD_REPO/.autoship/workspaces/issue-999/status")" "monitor preserves RUNNING when stale wrapper pid has live opencode child for workspace"
+
 mkdir -p "$MONITOR_REPO/.autoship/workspaces/not-an-issue"
 printf 'COMPLETE\n' >"$MONITOR_REPO/.autoship/workspaces/not-an-issue/status"
 (
@@ -807,7 +837,7 @@ touch -t 202604240000 "$MONITOR_COMPLETE_REPO/.autoship/workspaces/issue-998/sta
 assert_eq "COMPLETE" "$(tr -d '[:space:]' <"$MONITOR_COMPLETE_REPO/.autoship/workspaces/issue-998/status")" "monitor marks dead worker complete when fresh result artifact exists"
 
 SUPERVISOR_REPO="$TMP_DIR/supervisor-repo"
-mkdir -p "$SUPERVISOR_REPO/.autoship/workspaces/issue-1101" "$SUPERVISOR_REPO/.autoship/workspaces/issue-1102" "$SUPERVISOR_REPO/.autoship/workspaces/issue-1103" "$SUPERVISOR_REPO/hooks/opencode" "$SUPERVISOR_REPO/hooks"
+mkdir -p "$SUPERVISOR_REPO/.autoship/workspaces/issue-1101" "$SUPERVISOR_REPO/.autoship/workspaces/issue-1102" "$SUPERVISOR_REPO/.autoship/workspaces/issue-1103" "$SUPERVISOR_REPO/.autoship/workspaces/issue-1104" "$SUPERVISOR_REPO/hooks/opencode" "$SUPERVISOR_REPO/hooks"
 git init -q "$SUPERVISOR_REPO"
 cp "$SCRIPT_DIR/supervisor-loop.sh" "$SUPERVISOR_REPO/hooks/opencode/supervisor-loop.sh"
 cat >"$SUPERVISOR_REPO/hooks/opencode/monitor-agents.sh" <<'SH'
@@ -845,6 +875,18 @@ assert_eq "STUCK" "$(tr -d '[:space:]' <"$SUPERVISOR_REPO/.autoship/workspaces/i
 assert_eq "COMPLETE" "$(tr -d '[:space:]' <"$SUPERVISOR_REPO/.autoship/workspaces/issue-1103/status")" "supervisor preserves fresh results from stale RUNNING workspace"
 assert_eq $'monitor\nevents\nreconcile\nrunner' "$(cat "$SUPERVISOR_REPO/.autoship/order.log")" "supervisor runs monitor, event processing, reconcile, and runner in order"
 test -s "$SUPERVISOR_REPO/.autoship/logs/supervisor-loop.log" || fail "supervisor writes a lifecycle log"
+supervisor_report=$(
+  cd "$SUPERVISOR_REPO"
+  bash hooks/opencode/supervisor-loop.sh --once --report
+)
+case "$supervisor_report" in
+  *"complete_ready=1"*) ;;
+  *) fail "supervisor report flags complete workspaces ready for verification" ;;
+esac
+case "$supervisor_report" in
+  *"queued_dispatch_eligible=1"*) ;;
+  *) fail "supervisor report flags queued dispatch eligibility below cap" ;;
+esac
 
 QUEUE_REPO="$TMP_DIR/queue-repo"
 mkdir -p "$QUEUE_REPO/.autoship" "$QUEUE_REPO/hooks/opencode" "$QUEUE_REPO/hooks"


### PR DESCRIPTION
## Summary
- Preserve RUNNING workspaces when the wrapper PID is stale but a matching `opencode run` child is still alive.
- Add `supervisor-loop.sh --report` check-ins for active cap pressure, stale RUNNING state, quiet live workers, completed work, and queued dispatch eligibility.
- Keep release policy verification green with setup-node v6 and explicit semantic-release plugin packages.

## Verification
- `bash -n hooks/opencode/monitor-agents.sh hooks/opencode/supervisor-loop.sh hooks/opencode/test-policy.sh`
- `bash hooks/opencode/test-policy.sh`