### PR TITLE
fix: harden release and TextQuest policy

### DIFF
--- a/.archaeology/FINAL_CATALOG.md
+++ b/.archaeology/FINAL_CATALOG.md
@@ -1,0 +1,20 @@
+# Final Catalog
+
+## Restored Findings
+
+- Removed the release workflow's direct protected-branch push path by dropping `@semantic-release/git` from semantic-release configuration and CI package loading.
+- Restored TextQuest policy auto-detection by treating `policyProfile: "default"` as the setup default, not as a hard override that disables repo detection.
+- Restored installed policy asset lookup by falling back from target repo `policies/` to the packaged AutoShip `policies/` directory.
+- Hardened monitor liveness detection by comparing both logical and physical workspace paths against a snapshot of `ps` output.
+
+## Verified Survey Results
+
+- No circular dependencies detected.
+- No exact duplication detected by the configured threshold.
+- No npm audit vulnerabilities detected.
+- TextQuest read-only AutoShip plan executed successfully and found no eligible ready issues at the time of the run.
+
+## Follow-Up Candidates
+
+- Consider adding a `knip` config that excludes publish artifacts and plugin assets to reduce false positives in future archaeology surveys.
+- Decide whether release commits/changelog updates should be handled by a separate release PR workflow rather than direct `main` commits.

--- a/.archaeology/expedition1-report.md
+++ b/.archaeology/expedition1-report.md
@@ -1,0 +1,14 @@
+# Expedition 1: Dead Code Excavation
+
+Mode: survey
+
+## Findings
+
+- `knip` reported `dist/cli.*`, `dist/index.*`, and `dist/types.*` as unused. These are build outputs used by package publishing and are not removal candidates.
+- `knip` reported `plugins/autoship.ts` as unused from static imports. This is installed as an OpenCode plugin asset, so static import analysis cannot prove it dead.
+- `semantic-release` appears as an unlisted binary in `.github/workflows/release.yml` because it is intentionally invoked through `npx --package` rather than a package dependency.
+
+## Action
+
+- No code removed.
+- Keep future dead-code tooling configured with package/runtime asset exclusions before using restore mode.

--- a/.archaeology/expedition3-report.md
+++ b/.archaeology/expedition3-report.md
@@ -1,0 +1,16 @@
+# Expedition 3: Circular Dependency Cartography
+
+Mode: survey
+
+## Command
+
+`npx --yes madge src hooks --extensions ts,js,sh --circular`
+
+## Result
+
+- Processed 94 files.
+- No circular dependency found.
+
+## Action
+
+- No dependency untangling required.

--- a/.archaeology/expedition6-report.md
+++ b/.archaeology/expedition6-report.md
@@ -1,0 +1,17 @@
+# Expedition 6: DRY Stratification
+
+Mode: survey
+
+## Command
+
+`npx --yes jscpd --silent --min-lines 12 --min-tokens 80 --reporters console src hooks scripts`
+
+## Result
+
+- 0 exact clones.
+- 0 duplicated lines.
+- 98 files scanned across 5 formats.
+
+## Action
+
+- No duplicate extraction required.

--- a/.archaeology/site_survey.md
+++ b/.archaeology/site_survey.md
@@ -1,0 +1,31 @@
+# Code Archaeology Site Survey
+
+Date: 2026-05-08
+Mode: survey with targeted restore for confirmed CI/TextQuest failures
+
+## Baseline
+
+- Branch: main
+- Head: 8e875011e0f2808c5ef2f5d83b9522bfca75dcba
+- Inventory: 202 tracked/source files excluding `.git`, `node_modules`, `dist`, `.autoship`, `.archaeology`, and `graphify-out`
+- Approximate lines: 22,745
+- Dominant strata: 102 shell scripts, 56 markdown docs, 12 JSON files, 4 TypeScript files
+
+## Survey Findings
+
+- CI release failure was reproducible from GitHub Actions logs: `@semantic-release/git` attempted `git push --tags ... HEAD:main`, rejected by protected branch rule `GH006`.
+- TextQuest policy test initially returned `default` because `.autoship/config.json` contains `policyProfile: "default"`, which suppressed AutoShip's TextQuest auto-detection.
+- Policy asset lookup resolved against the target repo, so installed/source AutoShip policy JSON was unavailable when hooks ran inside TextQuest.
+- Monitor liveness regression existed on macOS `/var` vs `/private/var` paths and strict `ps` pipeline matching.
+
+## Tool Survey
+
+- `knip --reporter compact`: reported generated `dist/*` files and `plugins/autoship.ts` as unused, plus `semantic-release` as an unlisted workflow binary. These are package/runtime artifacts, not safe removal candidates without packaging redesign.
+- `madge src hooks --extensions ts,js,sh --circular`: no circular dependencies found.
+- `jscpd --min-lines 12 --min-tokens 80 src hooks scripts`: 0 exact clones, 0 duplicated lines across 98 scanned files.
+- `npm audit --audit-level=moderate`: 0 vulnerabilities.
+
+## Preservation Notes
+
+- No dead-code removals were performed. Reported `dist/*` outputs are publish artifacts and intentionally included in `package.json` files.
+- Confirmed fixes were limited to CI release configuration, policy profile/asset resolution, and monitor liveness detection.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,6 @@ jobs:
           npx
           --package semantic-release@25.0.3
           --package @semantic-release/changelog@6.0.3
-          --package @semantic-release/git@10.0.1
           --package @semantic-release/github@12.0.6
           --package @semantic-release/npm@13.1.5
           --package @semantic-release/exec@7.1.0

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -10,13 +10,6 @@
       {
         "prepareCmd": "node scripts/sync-version.mjs"
       }
-    ],
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["CHANGELOG.md", "package.json", "package-lock.json", "VERSION"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-      }
     ]
   ]
 }

--- a/hooks/hermes/cronjob-script-helper.sh
+++ b/hooks/hermes/cronjob-script-helper.sh
@@ -9,24 +9,24 @@ AUTOSHIP_SCRIPTS_DIR="${AUTOSHIP_SCRIPTS_DIR:-$HOME/.hermes/scripts/autoship}"
 AUTOSHIP_TEMPLATE_DIR="${AUTOSHIP_TEMPLATE_DIR:-$REPO_ROOT/scripts/hermes/autoship}"
 
 usage() {
-    echo "Usage: $0 <name> <script_content_file>"
-    echo "  name: base name for the script (e.g. 'continuous-runner')"
-    echo "  script_content_file: path to file containing the bash script content"
-    echo ""
-    echo "Writes script to ~/.hermes/scripts/autoship/<name>.sh, chmod +x, returns relative path."
-    exit 1
+  echo "Usage: $0 <name> <script_content_file>"
+  echo "  name: base name for the script (e.g. 'continuous-runner')"
+  echo "  script_content_file: path to file containing the bash script content"
+  echo ""
+  echo "Writes script to ~/.hermes/scripts/autoship/<name>.sh, chmod +x, returns relative path."
+  exit 1
 }
 
 if [[ $# -lt 2 ]]; then
-    usage
+  usage
 fi
 
 name="$1"
 content_file="$2"
 
 if [[ ! -f "$content_file" ]]; then
-    echo "Error: content file not found: $content_file" >&2
-    exit 1
+  echo "Error: content file not found: $content_file" >&2
+  exit 1
 fi
 
 # Ensure scripts directory exists
@@ -36,17 +36,17 @@ script_path="$AUTOSHIP_SCRIPTS_DIR/${name}.sh"
 
 # If a template exists in the repo, use it as base; otherwise use provided content
 if [[ -f "$AUTOSHIP_TEMPLATE_DIR/${name}.sh" ]]; then
-    cat "$AUTOSHIP_TEMPLATE_DIR/${name}.sh" | sed 's/\r$//' > "$script_path"
+  cat "$AUTOSHIP_TEMPLATE_DIR/${name}.sh" | sed 's/\r$//' >"$script_path"
 else
-    cat "$content_file" | sed 's/\r$//' > "$script_path"
+  cat "$content_file" | sed 's/\r$//' >"$script_path"
 fi
 chmod +x "$script_path"
 
 # Verify syntax
 if ! bash -n "$script_path" 2>/dev/null; then
-    echo "Error: script has syntax errors: $script_path" >&2
-    rm -f "$script_path"
-    exit 1
+  echo "Error: script has syntax errors: $script_path" >&2
+  rm -f "$script_path"
+  exit 1
 fi
 
 # Return relative path from ~/.hermes/scripts/

--- a/hooks/hermes/runner.sh
+++ b/hooks/hermes/runner.sh
@@ -163,7 +163,7 @@ Do NOT run cargo directly in WSL — it will fail due to missing MSVC linker (li
   fi
 
   # Mark workspace as ready for manual dispatch
-  printf 'DELEGATE_TASK_READY\n' > "$workspace_dir/status"
+  printf 'DELEGATE_TASK_READY\n' >"$workspace_dir/status"
   autoship_state_set set-running "$ISSUE_KEY" agent="hermes" model="delegate_task"
 
   echo "Workspace ready for delegate_task: $ISSUE_KEY"

--- a/hooks/opencode/monitor-agents.sh
+++ b/hooks/opencode/monitor-agents.sh
@@ -163,16 +163,20 @@ is_worker_live() {
 }
 
 has_live_opencode_child() {
-  local dir="$1" real_dir
+  local dir="$1" real_dir logical_dir
+  logical_dir=$(cd "$dir" && pwd 2>/dev/null || printf '%s' "$dir")
   real_dir=$(cd "$dir" && pwd -P 2>/dev/null || printf '%s' "$dir")
-  [[ -n "$real_dir" ]] || return 1
-  ps -axo command= 2>/dev/null | while IFS= read -r command; do
+  [[ -n "$logical_dir$real_dir" ]] || return 1
+  local process_list command
+  process_list=$(ps -axo command= 2>/dev/null || true)
+  while IFS= read -r command; do
     case "$command" in
-      *opencode*" run "*)
-        printf '%s\n' "$command"
-        ;;
+      *opencode*) ;;
+      *) continue ;;
     esac
-  done | grep -F -q -- "$real_dir"
+    [[ "$command" == *"$logical_dir"* || "$command" == *"$real_dir"* ]] && return 0
+  done <<<"$process_list"
+  return 1
 }
 
 has_fresh_result() {

--- a/hooks/opencode/policy.sh
+++ b/hooks/opencode/policy.sh
@@ -3,16 +3,22 @@ set -euo pipefail
 
 COMMAND="${1:-}"
 KEY="${2:-}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 AUTOSHIP_DIR="$REPO_ROOT/.autoship"
 CONFIG_FILE="$AUTOSHIP_DIR/config.json"
 POLICY_DIR="$REPO_ROOT/policies"
+PACKAGED_POLICY_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)/policies"
+
+if [[ ! -f "$POLICY_DIR/default.json" && -f "$PACKAGED_POLICY_DIR/default.json" ]]; then
+  POLICY_DIR="$PACKAGED_POLICY_DIR"
+fi
 
 detect_profile() {
   if [[ -f "$CONFIG_FILE" ]]; then
     local configured
     configured=$(jq -r '.policyProfile // empty' "$CONFIG_FILE" 2>/dev/null || true)
-    [[ -n "$configured" ]] && {
+    [[ -n "$configured" && "$configured" != "default" ]] && {
       printf '%s\n' "$configured"
       return 0
     }

--- a/hooks/opencode/test-policy.sh
+++ b/hooks/opencode/test-policy.sh
@@ -165,6 +165,21 @@ cp "$REPO_ROOT/policies/default.json" "$POLICY_REPO/policies/default.json"
   assert_eq "8" "$(bash hooks/opencode/policy.sh value cargoConcurrencyCap)" "policy value falls back when config is non-object"
 )
 
+TEXTQUEST_REPO="$TMP_DIR/textquest-repo"
+TEXTQUEST_INSTALL="$TMP_DIR/textquest-install"
+git init -q "$TEXTQUEST_REPO"
+mkdir -p "$TEXTQUEST_REPO/.autoship" "$TEXTQUEST_REPO/textquest-web" "$TEXTQUEST_INSTALL/hooks/opencode" "$TEXTQUEST_INSTALL/policies"
+printf '[package]\nname = "textquest"\n' >"$TEXTQUEST_REPO/Cargo.toml"
+printf '{"policyProfile":"default"}\n' >"$TEXTQUEST_REPO/.autoship/config.json"
+cp "$SCRIPT_DIR/policy.sh" "$TEXTQUEST_INSTALL/hooks/opencode/policy.sh"
+cp "$REPO_ROOT/policies/default.json" "$TEXTQUEST_INSTALL/policies/default.json"
+cp "$REPO_ROOT/policies/textquest.json" "$TEXTQUEST_INSTALL/policies/textquest.json"
+(
+  cd "$TEXTQUEST_REPO"
+  assert_eq "textquest" "$(bash "$TEXTQUEST_INSTALL/hooks/opencode/policy.sh" profile)" "default policy profile must not disable TextQuest auto-detection"
+  assert_eq "textquest" "$(bash "$TEXTQUEST_INSTALL/hooks/opencode/policy.sh" json | jq -r '.profile')" "TextQuest policy loads from installed AutoShip assets"
+)
+
 test -f "$REPO_ROOT/commands/autoship-setup.md" || fail "canonical /autoship-setup command file is installed"
 grep -F '| `/autoship-setup` |' "$REPO_ROOT/README.md" >/dev/null || fail "README public command table includes /autoship-setup"
 grep -F '| `/autoship-setup` |' "$REPO_ROOT/commands/autoship.md" >/dev/null || fail "/autoship command table includes /autoship-setup"
@@ -475,8 +490,8 @@ chmod +x "$AUTOCOMMIT_REPO/bin/opencode"
   PATH="$AUTOCOMMIT_REPO/bin:$PATH" bash hooks/opencode/runner.sh >/dev/null
 )
 for _ in 1 2 3 4 5; do
-  [[ "$(tr -d '[:space:]' <"$AUTOCOMMIT_REPO/.autoship/workspaces/issue-253/status")" == "COMPLETE" ]] && \
-    [[ "$(git -C "$AUTOCOMMIT_REPO/.autoship/workspaces/issue-253" rev-list --count HEAD)" == "2" ]] && break
+  [[ "$(tr -d '[:space:]' <"$AUTOCOMMIT_REPO/.autoship/workspaces/issue-253/status")" == "COMPLETE" ]] \
+    && [[ "$(git -C "$AUTOCOMMIT_REPO/.autoship/workspaces/issue-253" rev-list --count HEAD)" == "2" ]] && break
   sleep 1
 done
 assert_eq "COMPLETE" "$(tr -d '[:space:]' <"$AUTOCOMMIT_REPO/.autoship/workspaces/issue-253/status")" "runner keeps complete status after auto-committing production changes"
@@ -746,7 +761,7 @@ _live_wait=0
 while [ "$_live_wait" -lt 50 ]; do
   kill -0 "$live_child_pid" 2>/dev/null \
     && ps -axo command= 2>/dev/null \
-         | grep -F -q "$MONITOR_LIVE_CHILD_REPO/.autoship/workspaces/issue-999" \
+    | grep -F -q "$MONITOR_LIVE_CHILD_REPO/.autoship/workspaces/issue-999" \
     && break
   sleep 0.1
   _live_wait=$((_live_wait + 1))


### PR DESCRIPTION
## Summary
- Stop semantic-release from pushing release commits directly to protected `main`.
- Restore TextQuest policy auto-detection when installed hooks run inside a target repo.
- Harden monitor liveness detection and record code archaeology survey findings.

## Verification
- `npm run typecheck`
- `npm run build`
- `npm run verify:pack`
- `npm audit --audit-level=moderate`
- `bash hooks/opencode/check.sh`
- `bash -n hooks/opencode/*.sh hooks/*.sh hooks/hermes/*.sh`
- TextQuest live policy profile/json check
- `graphify update .`

## Notes
- `hooks/hermes/dispatch.sh` has an unrelated local modification and is intentionally not included in this PR.