### PR TITLE
fix(runner): harden headless Hermes execution

### DIFF
--- a/hooks/hermes/runner.sh
+++ b/hooks/hermes/runner.sh
@@ -159,49 +159,18 @@ Do NOT run cargo directly in WSL — it will fail due to missing MSVC linker (li
   printf 'RUNNING\n' >"$workspace_dir/status"
   autoship_state_set set-running "$ISSUE_KEY" agent="hermes" model="delegate_task"
 
-  # --- EXECUTE WORKER ---
-  # If inside a Hermes session, use delegate_task directly.
-  # Otherwise, fall back to hermes chat with the prompt file.
-  WORKER_RESULT="BLOCKED"
-  WORKER_REASON="no execution method available"
-
-  if [[ -n "${HERMES_SESSION_ID:-}" ]]; then
-    echo "Hermes session detected — executing via delegate_task..."
-    # delegate_task is a Hermes tool; we cannot call it from bash.
-    # Instead, write a ready marker and exit so the parent Hermes process
-    # can poll for DELEGATE_TASK_READY workspaces and invoke delegate_task.
-    printf 'DELEGATE_TASK_READY\n' >"$workspace_dir/status"
-    echo "Workspace ready for delegate_task: $ISSUE_KEY"
-    echo "Worktree: $worktree_path"
-    echo "Prompt: $prompt_file"
-    echo "Status: DELEGATE_TASK_READY"
-    echo ""
-    echo "Dispatch command:"
-    echo "  delegate_task --workdir \"$worktree_path\" --toolsets '[\"terminal\",\"file\",\"web\"]' --prompt \"\$(cat $prompt_file)\" --timeout 600"
-    exit 0
-  fi
-
-  # No Hermes session — try hermes chat CLI as a subprocess
-  if command -v hermes &>/dev/null; then
-    echo "Executing worker via hermes chat..."
-    printf 'RUNNING\n' >"$workspace_dir/status"
-
-    # Run hermes chat with the prompt file; capture exit code
-    HERMES_TIMEOUT="${HERMES_WORKER_TIMEOUT:-600}"
-    hermes chat --workdir "$worktree_path" --timeout "$HERMES_TIMEOUT" < "$prompt_file" > "$workspace_dir/hermes-worker.log" 2>&1
-    worker_exit=$?
-
-    if [[ $worker_exit -eq 0 ]]; then
-      WORKER_RESULT="COMPLETE"
-      WORKER_REASON="hermes chat completed successfully"
-    elif [[ $worker_exit -eq 124 ]]; then
-      WORKER_RESULT="STUCK"
-      WORKER_REASON="hermes chat timed out (exit 124)"
-    else
-      WORKER_RESULT="BLOCKED"
-      WORKER_REASON="hermes chat failed (exit $worker_exit)"
-    fi
-  fi
+  # delegate_task is a Hermes tool; this setup-only runner cannot call it from
+  # bash. Leave a ready marker so the parent Hermes process or operator can
+  # invoke delegate_task with the prepared worktree and prompt.
+  printf 'DELEGATE_TASK_READY\n' >"$workspace_dir/status"
+  echo "Workspace ready for delegate_task: $ISSUE_KEY"
+  echo "Worktree: $worktree_path"
+  echo "Prompt: $prompt_file"
+  echo "Status: DELEGATE_TASK_READY"
+  echo ""
+  echo "Dispatch command:"
+  echo "  delegate_task --workdir \"$worktree_path\" --toolsets '[\"terminal\",\"file\",\"web\"]' --prompt \"\$(cat $prompt_file)\" --timeout 600"
+  exit 0
 
   # --- POST-EXECUTION: detect result files if worker wrote them ---
   if [[ -f "$workspace_dir/HERMES_RESULT.md" ]]; then

--- a/hooks/hermes/runner.sh
+++ b/hooks/hermes/runner.sh
@@ -159,18 +159,58 @@ Do NOT run cargo directly in WSL — it will fail due to missing MSVC linker (li
   printf 'RUNNING\n' >"$workspace_dir/status"
   autoship_state_set set-running "$ISSUE_KEY" agent="hermes" model="delegate_task"
 
-  # delegate_task is a Hermes tool; this setup-only runner cannot call it from
-  # bash. Leave a ready marker so the parent Hermes process or operator can
-  # invoke delegate_task with the prepared worktree and prompt.
-  printf 'DELEGATE_TASK_READY\n' >"$workspace_dir/status"
-  echo "Workspace ready for delegate_task: $ISSUE_KEY"
-  echo "Worktree: $worktree_path"
-  echo "Prompt: $prompt_file"
-  echo "Status: DELEGATE_TASK_READY"
-  echo ""
-  echo "Dispatch command:"
-  echo "  delegate_task --workdir \"$worktree_path\" --toolsets '[\"terminal\",\"file\",\"web\"]' --prompt \"\$(cat $prompt_file)\" --timeout 600"
-  exit 0
+  # --- EXECUTE WORKER ---
+  # If inside a Hermes session, use delegate_task directly.
+  # Otherwise, fall back to hermes chat with the prompt file.
+  WORKER_RESULT="BLOCKED"
+  WORKER_REASON="no execution method available"
+
+  if [[ -n "${HERMES_SESSION_ID:-}" ]]; then
+    echo "Hermes session detected — executing via delegate_task..."
+    # delegate_task is a Hermes tool; we cannot call it from bash.
+    # Instead, write a ready marker and exit so the parent Hermes process
+    # can poll for DELEGATE_TASK_READY workspaces and invoke delegate_task.
+    printf 'DELEGATE_TASK_READY\n' >"$workspace_dir/status"
+    echo "Workspace ready for delegate_task: $ISSUE_KEY"
+    echo "Worktree: $worktree_path"
+    echo "Prompt: $prompt_file"
+    echo "Status: DELEGATE_TASK_READY"
+    echo ""
+    echo "Dispatch command:"
+    echo "  delegate_task --workdir \"$worktree_path\" --toolsets '[\"terminal\",\"file\",\"web\"]' --prompt \"\$(cat $prompt_file)\" --timeout 600"
+    exit 0
+  fi
+
+  # No Hermes session — try hermes chat CLI in headless mode
+  if command -v hermes &>/dev/null; then
+    echo "Executing worker via hermes chat (headless)..."
+    printf 'RUNNING\n' >"$workspace_dir/status"
+
+    # Use -q for single-query mode (reads prompt from file, non-interactive)
+    # Use -Q for quiet mode (no TTY/spinner, banner suppressed)
+    # Use --max-turns to prevent runaway sessions
+    HERMES_TIMEOUT="${HERMES_WORKER_TIMEOUT:-600}"
+    HERMES_MAX_TURNS="${HERMES_WORKER_MAX_TURNS:-90}"
+    hermes_cmd=(hermes chat --workdir "$worktree_path" -q "$(cat "$prompt_file")" -Q --max-turns "$HERMES_MAX_TURNS" -t terminal,file,web)
+    if command -v timeout >/dev/null 2>&1; then
+      hermes_cmd=(timeout "$HERMES_TIMEOUT" "${hermes_cmd[@]}")
+    elif command -v gtimeout >/dev/null 2>&1; then
+      hermes_cmd=(gtimeout "$HERMES_TIMEOUT" "${hermes_cmd[@]}")
+    fi
+    "${hermes_cmd[@]}" >"$workspace_dir/hermes-worker.log" 2>&1
+    worker_exit=$?
+
+    if [[ $worker_exit -eq 0 ]]; then
+      WORKER_RESULT="COMPLETE"
+      WORKER_REASON="hermes chat completed successfully"
+    elif [[ $worker_exit -eq 124 ]]; then
+      WORKER_RESULT="STUCK"
+      WORKER_REASON="hermes chat timed out (exit 124)"
+    else
+      WORKER_RESULT="BLOCKED"
+      WORKER_REASON="hermes chat failed (exit $worker_exit)"
+    fi
+  fi
 
   # --- POST-EXECUTION: detect result files if worker wrote them ---
   if [[ -f "$workspace_dir/HERMES_RESULT.md" ]]; then

--- a/hooks/opencode/test-policy.sh
+++ b/hooks/opencode/test-policy.sh
@@ -64,11 +64,14 @@ grep -F '"$HOOKS_DIR/hermes"/*.sh' "$SCRIPT_DIR/check.sh" >/dev/null \
   || fail "check.sh syntax check must include Hermes hooks"
 grep -F '"$HOOKS_DIR/hermes"/*.sh' "$SCRIPT_DIR/check.sh" | grep -F 'shellcheck' >/dev/null \
   || fail "check.sh shellcheck must include Hermes hooks"
+# Hermes runner must support both delegate_task mode (HERMES_SESSION_ID set)
+# and headless hermes chat mode (no session). The runner may execute workers
+# via hermes chat -q (non-interactive) when not in a Hermes session.
 grep -F 'DELEGATE_TASK_READY' "$REPO_ROOT/hooks/hermes/runner.sh" >/dev/null \
-  || fail "Hermes runner setup-only mode must mark workspaces ready for manual delegate_task dispatch"
-if grep -F 'hermes chat' "$REPO_ROOT/hooks/hermes/runner.sh" >/dev/null; then
-  fail "Hermes runner setup-only mode must not use hermes chat"
-fi
+  || fail "Hermes runner must mark workspaces ready for manual delegate_task dispatch"
+grep -F 'hermes chat' "$REPO_ROOT/hooks/hermes/runner.sh" >/dev/null \
+  || grep -F 'WORKER_RESULT' "$REPO_ROOT/hooks/hermes/runner.sh" >/dev/null \
+  || fail "Hermes runner must either execute workers via hermes chat or track completion status"
 if grep -F 'python3 -c "import os,time; st=os.stat(' "$REPO_ROOT/hooks/hermes/runner.sh" >/dev/null; then
   fail "Hermes runner must pass log paths to Python safely"
 fi


### PR DESCRIPTION
## Summary
- enable headless `hermes chat -q -Q` execution with completion status tracking
- wrap Hermes worker execution with `timeout`/`gtimeout` when available so stuck workers can report exit 124
- update policy checks for the supported Hermes runner behavior

## Verification
- `bash hooks/opencode/check.sh`
- `bash -n hooks/opencode/*.sh hooks/*.sh hooks/hermes/*.sh`
- `npm run typecheck`
- `npm run build`
- `npm run verify:pack`
- `npm audit --audit-level=moderate`
- `graphify update .`