### PR TITLE
fix(release): restore GitHub release sync

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          persist-credentials: false
+          persist-credentials: true
 
       - uses: actions/setup-node@v6
         with:
@@ -56,6 +56,7 @@ jobs:
             npx \
               --package semantic-release@25.0.3 \
               --package @semantic-release/changelog@6.0.3 \
+              --package @semantic-release/git@10.0.1 \
               --package @semantic-release/github@12.0.6 \
               --package @semantic-release/npm@13.1.5 \
               --package @semantic-release/exec@7.1.0 \
@@ -64,6 +65,7 @@ jobs:
             npx \
               --package semantic-release@25.0.3 \
               --package @semantic-release/changelog@6.0.3 \
+              --package @semantic-release/git@10.0.1 \
               --package @semantic-release/github@12.0.6 \
               --package @semantic-release/npm@13.1.5 \
               --package @semantic-release/exec@7.1.0 \

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ Thumbs.db
 .code-review-graph/
 graphify-out/
 .autoresearch/
+.archaeology/
+.tmp/
 AUTORESEARCH_FINDINGS.md
 autoresearch-memory.md
 __pycache__/

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -4,11 +4,19 @@
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
     "@semantic-release/changelog",
+    "@semantic-release/github",
     "@semantic-release/npm",
     [
       "@semantic-release/exec",
       {
         "prepareCmd": "node scripts/sync-version.mjs"
+      }
+    ],
+    [
+      "@semantic-release/git",
+      {
+        "assets": ["CHANGELOG.md", "VERSION", "package.json", "package-lock.json"],
+        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
     ]
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [2.12.1](https://github.com/Maleick/AutoShip/compare/v2.12.0...v2.12.1) (2026-05-09)
+
+### Bug Fixes
+
+* sync released package, local version markers, and GitHub release surfaces
+
 ## [2.9.3](https://github.com/Maleick/AutoShip/compare/v2.9.2...v2.9.3) (2026-05-08)
 
 

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -262,7 +262,9 @@ async function doctor() {
     }
     try {
         const assetVersion = (await readFile(join(autoshipDir, "VERSION"), "utf8")).trim();
-        if (assetVersion === VERSION) {
+        const normalizedAssetVersion = assetVersion.replace(/^v/, "");
+        const normalizedPackageVersion = VERSION.replace(/^v/, "");
+        if (normalizedAssetVersion === normalizedPackageVersion) {
             checks.push({ name: "asset-version", status: "PASS", message: `Installed assets match package ${VERSION}` });
         }
         else {

--- a/hooks/hermes/auto-prune.sh
+++ b/hooks/hermes/auto-prune.sh
@@ -2,8 +2,6 @@
 # AutoShip auto-prune — monitor disk usage and prune when thresholds exceeded
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-
 # Default thresholds (override via env vars)
 MAX_WORKTREE_SIZE_GB="${AUTOSHIP_MAX_WORKTREE_SIZE_GB:-2}"      # Max size per worktree
 MAX_TOTAL_WORKTREES_GB="${AUTOSHIP_MAX_TOTAL_WORKTREES_GB:-10}" # Max total for all worktrees
@@ -39,8 +37,8 @@ get_size_gb() {
     raw=$(du -sh "$dir" 2>/dev/null | awk '{print $1}')
     case "$raw" in
       *G) echo "${raw%G}" ;;
-      *M) echo "$(echo "${raw%M} * 0.001" | bc -l 2>/dev/null || echo "0")" ;;
-      *K) echo "$(echo "${raw%K} * 0.000001" | bc -l 2>/dev/null || echo "0")" ;;
+      *M) printf '%s\n' "$(printf '%s * 0.001\n' "${raw%M}" | bc -l 2>/dev/null || echo "0")" ;;
+      *K) printf '%s\n' "$(printf '%s * 0.000001\n' "${raw%K}" | bc -l 2>/dev/null || echo "0")" ;;
       *) echo "$raw" ;;
     esac
   else
@@ -56,7 +54,8 @@ prune_oversized_worktrees() {
   for wt in "$WORKTREE_BASE"/issue-*; do
     [[ -d "$wt" ]] || continue
     local issue_num
-    issue_num=$(basename "$wt" | sed 's/issue-//')
+    issue_num="${wt##*/}"
+    issue_num="${issue_num#issue-}"
     # Only process numeric issue directories
     if [[ ! "$issue_num" =~ ^[0-9]+$ ]]; then
       log "  Skipping non-numeric worktree: $wt"
@@ -64,13 +63,15 @@ prune_oversized_worktrees() {
     fi
 
     local size_gb
+    local is_oversize
     size_gb=$(get_size_gb "$wt")
-    if (($(echo "$size_gb > $MAX_WORKTREE_SIZE_GB" | bc -l 2>/dev/null || echo "0"))); then
+    is_oversize=$(printf '%s > %s\n' "$size_gb" "$MAX_WORKTREE_SIZE_GB" | bc -l 2>/dev/null || echo "0")
+    if [[ "$is_oversize" == "1" ]]; then
       log "Pruning oversized worktree: $wt (${size_gb}GB > ${MAX_WORKTREE_SIZE_GB}GB)"
 
       # Check if active (has RUNNING or QUEUED status)
-      local issue_num=$(basename "$wt" | sed 's/issue-//')
-      local ws_status=""
+      local ws_status
+      ws_status=""
       if [[ -f "$AUTOSHIP_DIR/workspaces/issue-$issue_num/status" ]]; then
         ws_status=$(cat "$AUTOSHIP_DIR/workspaces/issue-$issue_num/status" 2>/dev/null || echo "UNKNOWN")
       fi
@@ -87,7 +88,7 @@ prune_oversized_worktrees() {
   done
 
   log "Pruned $pruned oversized worktrees"
-  return $pruned
+  return "$pruned"
 }
 
 # Prune old workspaces
@@ -95,15 +96,20 @@ prune_old_workspaces() {
   log "Checking workspace age (limit: ${MAX_WORKSPACE_AGE_DAYS} days)..."
 
   local pruned=0
-  local cutoff_epoch=$(($(date +%s) - MAX_WORKSPACE_AGE_DAYS * 86400))
+  local cutoff_epoch
+  cutoff_epoch=$(($(date +%s) - MAX_WORKSPACE_AGE_DAYS * 86400))
 
   for ws in "$AUTOSHIP_DIR"/workspaces/issue-*; do
     [[ -d "$ws" ]] || continue
 
-    local mtime_epoch=$(stat -f%m "$ws" 2>/dev/null || stat -c%Y "$ws" 2>/dev/null || echo "0")
+    local mtime_epoch
+    local issue_num
+    local status
+    mtime_epoch=$(stat -f%m "$ws" 2>/dev/null || stat -c%Y "$ws" 2>/dev/null || echo "0")
     if [[ "$mtime_epoch" -lt "$cutoff_epoch" ]]; then
-      local issue_num=$(basename "$ws" | sed 's/issue-//')
-      local status=$(cat "$ws/status" 2>/dev/null || echo "UNKNOWN")
+      issue_num="${ws##*/}"
+      issue_num="${issue_num#issue-}"
+      status=$(cat "$ws/status" 2>/dev/null || echo "UNKNOWN")
 
       if [[ "$status" == "RUNNING" ]]; then
         log "  Skipping RUNNING workspace: issue-$issue_num"
@@ -117,12 +123,13 @@ prune_old_workspaces() {
   done
 
   log "Pruned $pruned old workspaces"
-  return $pruned
+  return "$pruned"
 }
 
 # Prune by total size
 prune_by_total_size() {
-  local total_gb=$(get_size_gb "$WORKTREE_BASE")
+  local total_gb
+  total_gb=$(get_size_gb "$WORKTREE_BASE")
 
   if ! threshold_exceeded "$total_gb" "$MAX_TOTAL_WORKTREES_GB" "Total worktrees"; then
     return 0
@@ -132,29 +139,36 @@ prune_by_total_size() {
 
   # Sort by modification time, oldest first
   local pruned=0
-  for wt in $(ls -1td "$WORKTREE_BASE"/issue-* 2>/dev/null | tail -r); do
-    [[ -d "$wt" ]] || continue
+  local sorted_worktrees
+  if sorted_worktrees=$(find "$WORKTREE_BASE" -maxdepth 1 -mindepth 1 -type d -name 'issue-*' -print0 \
+    | xargs -0 stat -f "%m %N" 2>/dev/null | sort -n | awk '{print $2}'); then
+    local wt
+    for wt in $sorted_worktrees; do
+      [[ -d "$wt" ]] || continue
 
-    local issue_num=$(basename "$wt" | sed 's/issue-//')
-    local status=""
-    if [[ -f "$AUTOSHIP_DIR/workspaces/issue-$issue_num/status" ]]; then
-      status=$(cat "$AUTOSHIP_DIR/workspaces/issue-$issue_num/status" 2>/dev/null)
-    fi
+      local issue_num status
+      issue_num="${wt##*/}"
+      issue_num="${issue_num#issue-}"
+      status=""
+      if [[ -f "$AUTOSHIP_DIR/workspaces/issue-$issue_num/status" ]]; then
+        status=$(cat "$AUTOSHIP_DIR/workspaces/issue-$issue_num/status" 2>/dev/null)
+      fi
 
-    if [[ "$status" == "RUNNING" ]]; then
-      continue
-    fi
+      if [[ "$status" == "RUNNING" ]]; then
+        continue
+      fi
 
-    log "Removing worktree to free space: $wt"
-    cd "$TARGET_REPO" && git worktree remove "$wt" --force 2>/dev/null || rm -rf "$wt" 2>/dev/null || true
-    ((pruned++)) || true
+      log "Removing worktree to free space: $wt"
+      cd "$TARGET_REPO" && git worktree remove "$wt" --force 2>/dev/null || rm -rf "$wt" 2>/dev/null || true
+      ((pruned++)) || true
 
-    # Check if we're under threshold now
-    total_gb=$(get_size_gb "$WORKTREE_BASE")
-    if ! threshold_exceeded "$total_gb" "$MAX_TOTAL_WORKTREES_GB" "Total worktrees"; then
-      break
-    fi
-  done
+      # Check if we're under threshold now
+      total_gb=$(get_size_gb "$WORKTREE_BASE")
+      if ! threshold_exceeded "$total_gb" "$MAX_TOTAL_WORKTREES_GB" "Total worktrees"; then
+        break
+      fi
+    done
+  fi
 
   log "Pruned $pruned worktrees to get under ${MAX_TOTAL_WORKTREES_GB}GB"
 }
@@ -162,7 +176,8 @@ prune_by_total_size() {
 # Prune by workspace count
 prune_by_workspace_count() {
   # Count actual directories, not files inside them
-  local count=$(find "$AUTOSHIP_DIR"/workspaces -maxdepth 1 -type d -name "issue-*" 2>/dev/null | wc -l | tr -d ' ')
+  local count
+  count=$(find "$AUTOSHIP_DIR"/workspaces -maxdepth 1 -type d -name "issue-*" 2>/dev/null | wc -l | tr -d ' ')
 
   if [[ "$count" -le "$MAX_WORKSPACE_COUNT" ]]; then
     return 0
@@ -170,25 +185,34 @@ prune_by_workspace_count() {
 
   log "Workspace count $count exceeds $MAX_WORKSPACE_COUNT, pruning oldest..."
 
-  local to_remove=$((count - MAX_WORKSPACE_COUNT))
+  local to_remove
   local removed=0
+  to_remove=$((count - MAX_WORKSPACE_COUNT))
 
   # Sort by mtime oldest first, only directories
-  for ws in $(find "$AUTOSHIP_DIR"/workspaces -maxdepth 1 -type d -name "issue-*" -print0 2>/dev/null | xargs -0 stat -f "%m %N" 2>/dev/null | sort -n | head -$to_remove | awk '{print $2}'); do
-    [[ -d "$ws" ]] || continue
+  local workspace_paths
+  if workspace_paths=$(find "$AUTOSHIP_DIR"/workspaces -maxdepth 1 -type d -name "issue-*" -print0 2>/dev/null \
+    | xargs -0 stat -f "%m %N" 2>/dev/null | sort -n | head -n "$to_remove" | cut -d' ' -f2-); then
+    local ws
+    for ws in $workspace_paths; do
+      [[ -d "$ws" ]] || continue
 
-    local issue_num=$(basename "$ws" | sed 's/issue-//')
-    local status=$(cat "$ws/status" 2>/dev/null || echo "UNKNOWN")
+      local issue_num
+      local status
+      issue_num="${ws##*/}"
+      issue_num="${issue_num#issue-}"
+      status=$(cat "$ws/status" 2>/dev/null || echo "UNKNOWN")
 
-    if [[ "$status" == "RUNNING" || "$status" == "QUEUED" ]]; then
-      log "Skipping active workspace: issue-$issue_num (${status})"
-      continue
-    fi
+      if [[ "$status" == "RUNNING" || "$status" == "QUEUED" ]]; then
+        log "Skipping active workspace: issue-$issue_num (${status})"
+        continue
+      fi
 
-    log "Removing workspace: issue-$issue_num (${status})"
-    rm -rf "$ws"
-    ((removed++)) || true
-  done
+      log "Removing workspace: issue-$issue_num (${status})"
+      rm -rf "$ws"
+      ((removed++)) || true
+    done
+  fi
 
   log "Removed $removed workspaces to get under $MAX_WORKSPACE_COUNT"
 }
@@ -215,8 +239,10 @@ main() {
   cd "$TARGET_REPO" && git worktree prune 2>/dev/null || true
 
   # Report current state
-  local current_total=$(get_size_gb "$WORKTREE_BASE")
-  local current_count=$(ls -1 "$AUTOSHIP_DIR"/workspaces/issue-* 2>/dev/null | wc -l | tr -d ' ')
+  local current_total
+  local current_count
+  current_total=$(get_size_gb "$WORKTREE_BASE")
+  current_count=$(find "$AUTOSHIP_DIR"/workspaces -maxdepth 1 -type d -name "issue-*" 2>/dev/null | wc -l | tr -d ' ')
 
   log "=== Auto-Prune Complete ==="
   log "Current state: ${current_total}GB total, $current_count workspaces"

--- a/hooks/hermes/auto-prune.sh
+++ b/hooks/hermes/auto-prune.sh
@@ -105,7 +105,7 @@ prune_old_workspaces() {
     local mtime_epoch
     local issue_num
     local status
-    mtime_epoch=$(stat -f%m "$ws" 2>/dev/null || stat -c%Y "$ws" 2>/dev/null || echo "0")
+    mtime_epoch=$(stat -c%Y "$ws" 2>/dev/null || stat -f%m "$ws" 2>/dev/null || echo "0")
     if [[ "$mtime_epoch" -lt "$cutoff_epoch" ]]; then
       issue_num="${ws##*/}"
       issue_num="${issue_num#issue-}"

--- a/hooks/hermes/runner.sh
+++ b/hooks/hermes/runner.sh
@@ -5,7 +5,12 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # Load shared utilities if available
+is_hermes_process_for_workspace() {
+  local workspace_dir="$1"
+  pgrep -af "[h]ermes" 2>/dev/null | grep -F "$workspace_dir" >/dev/null
+}
 if [[ -f "$SCRIPT_DIR/../lib/common.sh" ]]; then
+  # shellcheck disable=SC1091
   source "$SCRIPT_DIR/../lib/common.sh"
 else
   autoship_repo_root() {
@@ -29,7 +34,7 @@ if [[ -d "/opt/homebrew/opt/util-linux/bin" ]]; then
 fi
 
 REPO_ROOT=$(autoship_repo_root) || exit 1
-cd "$REPO_ROOT"
+cd "$REPO_ROOT" || exit 1
 
 log_age_minutes() {
   python3 - "$1" <<'PY'
@@ -85,7 +90,7 @@ if [[ -n "${1:-}" ]]; then
   autoship_state_set set-running "$ISSUE_KEY" agent="hermes/default"
 
   # Extract issue number from key
-  ISSUE_NUM=$(echo "$ISSUE_KEY" | sed 's/issue-//')
+  ISSUE_NUM="${ISSUE_KEY#issue-}"
 
   # Find the worktree path
   worktree_path=""
@@ -127,7 +132,7 @@ if [[ -n "${1:-}" ]]; then
 
   echo "Dispatching $ISSUE_KEY in $worktree_path"
 
-  cd "$worktree_path"
+  cd "$worktree_path" || exit 1
   export GH_TOKEN="${GH_TOKEN:-}"
   export HERMES_TARGET_REPO_PATH="${HERMES_TARGET_REPO_PATH:-$REPO_ROOT}"
 
@@ -184,10 +189,9 @@ Do NOT run cargo directly in WSL - it will fail due to missing MSVC linker (lib.
     printf '%s\n' "$$" >"$workspace_dir/runner.pid"
 
     HERMES_TIMEOUT="${HERMES_WORKER_TIMEOUT:-600}"
-    HERMES_MAX_TURNS="${HERMES_WORKER_MAX_TURNS:-90}"
     # Run delegate_task in the existing worktree directory.
     # Do NOT use --worktree - the workspace is already a git worktree.
-    hermes_cmd=(delegate_task --goal "$(cat "$prompt_file")" --toolsets terminal,file,web)
+    hermes_cmd=(delegate_task --goal "$(cat "$prompt_file")" --toolsets terminal file web)
     if command -v timeout >/dev/null 2>&1; then
       hermes_cmd=(timeout "$HERMES_TIMEOUT" "${hermes_cmd[@]}")
     elif command -v gtimeout >/dev/null 2>&1; then
@@ -228,7 +232,7 @@ Do NOT run cargo directly in WSL - it will fail due to missing MSVC linker (lib.
 
   # Also check for git commits as evidence of work done
   if [[ "$WORKER_RESULT" != "COMPLETE" && "$WORKER_RESULT" != "BLOCKED" ]]; then
-    commit_count=$(git -C "$worktree_path" rev-list --count autoship/issue-${ISSUE_NUM}...HEAD 2>/dev/null || echo 0)
+    commit_count=$(git -C "$worktree_path" rev-list --count autoship/issue-"${ISSUE_NUM}"...HEAD 2>/dev/null || echo 0)
     if [[ "$commit_count" -gt 0 ]]; then
       # Worker made commits but didn't finish workflow - mark STUCK for retry
       WORKER_RESULT="STUCK"
@@ -297,8 +301,7 @@ while IFS= read -r status_file; do
     if [[ "$log_age_min" =~ ^[0-9]+$ && "$log_age_min" -lt 30 ]]; then
       # Log is recent, but if there's NO active Hermes process, the log age
       # is just from a previous run that finished. Allow retry in that case.
-      active_hermes=$(ps aux 2>/dev/null | grep -E "[h]ermes" | grep -F "$workspace_dir" || true)
-      if [[ -n "$active_hermes" ]]; then
+      if is_hermes_process_for_workspace "$workspace_dir"; then
         retry_allowed=false
       fi
     fi
@@ -319,8 +322,7 @@ while IFS= read -r status_file; do
   # Check for an active Hermes process in the workspace (process-based validation)
   if [[ "$retry_allowed" == true ]]; then
     # Look for any Hermes process that has this workspace as its CWD
-    active_hermes=$(ps aux 2>/dev/null | grep -E "[h]ermes" | grep -F "$workspace_dir" || true)
-    if [[ -n "$active_hermes" ]]; then
+    if is_hermes_process_for_workspace "$workspace_dir"; then
       # Process is alive but status is STUCK - this is a false-positive STUCK.
       # Reset to RUNNING so the runner doesn't keep retrying it.
       printf 'RUNNING\n' >"$status_file"
@@ -335,8 +337,7 @@ while IFS= read -r status_file; do
     if [[ "$log_age_min" =~ ^[0-9]+$ && "$log_age_min" -lt 5 ]]; then
       # Even if log is <5min old, if there's no active hermes process, the log
       # is from a previous run that finished. Allow retry in that case.
-      active_hermes=$(ps aux 2>/dev/null | grep -E "[h]ermes" | grep -F "$workspace_dir" || true)
-      if [[ -n "$active_hermes" ]]; then
+      if is_hermes_process_for_workspace "$workspace_dir"; then
         retry_allowed=false
       fi
     fi
@@ -386,14 +387,6 @@ while IFS= read -r status_file; do
   workspace_dir=$(dirname "$status_file")
   issue_key=$(basename "$workspace_dir")
 
-  # Check if this is a Windows-target repo (has .cargo/config.toml with x86_64-pc-windows-msvc)
-  is_windows_repo=false
-  if [[ -f "$workspace_dir/.cargo/config.toml" ]]; then
-    if grep -q "x86_64-pc-windows-msvc" "$workspace_dir/.cargo/config.toml" 2>/dev/null; then
-      is_windows_repo=true
-    fi
-  fi
-
   # --- Prompt file discovery: look in workspace_dir and in the actual git worktree ---
   prompt_file=""
   if [[ -f "$workspace_dir/HERMES_PROMPT.md" ]]; then
@@ -405,7 +398,7 @@ while IFS= read -r status_file; do
   # and look there.  The workspace_dir may be a bare status container (issue-3059)
   # or a full worktree checkout (issue-3057).
   if [[ -z "$prompt_file" ]]; then
-    ISSUE_NUM=$(echo "$issue_key" | sed 's/issue-//')
+    ISSUE_NUM="${issue_key#issue-}"
     worktree_path=""
     HERMES_TARGET_REPO_PATH="${HERMES_TARGET_REPO_PATH:-$REPO_ROOT}"
     if [[ -n "$HERMES_TARGET_REPO_PATH" ]]; then

--- a/hooks/monitor-issues.sh
+++ b/hooks/monitor-issues.sh
@@ -55,8 +55,8 @@ _autoship_md_mtime() {
     echo "0"
     return
   fi
-  stat -f %m "$path" 2>/dev/null \
-    || stat -c %Y "$path" 2>/dev/null \
+  stat -c %Y "$path" 2>/dev/null \
+    || stat -f %m "$path" 2>/dev/null \
     || echo "0"
 }
 

--- a/hooks/opencode/create-pr.sh
+++ b/hooks/opencode/create-pr.sh
@@ -157,18 +157,20 @@ fi
   fi
   # Push branch if it exists locally but not on origin
   current_branch=$(git branch --show-current 2>/dev/null || true)
-  if [[ -n "$current_branch" ]]; then
+  if [[ -n "$current_branch" && "${AUTOSHIP_SKIP_BRANCH_PUSH:-false}" != "true" ]]; then
     if ! git ls-remote --exit-code --heads origin "$current_branch" >/dev/null 2>&1; then
       git push -u origin "$current_branch" >/dev/null 2>&1 || true
     fi
   fi
 )
 
-PR_URL=$(gh pr create \\
-  --title "$TITLE" \\
-  --body-file "$BODY_FILE" \\
-  --label autoship \\
-  --head "autoship/issue-$ISSUE_NUMBER")
+PR_URL=$(
+  gh pr create \
+    --title "$TITLE" \
+    --body-file "$BODY_FILE" \
+    --label autoship \
+    --head "autoship/issue-$ISSUE_NUMBER"
+)
 
 issue_meta=$(gh issue view "$ISSUE_NUMBER" --json labels,milestone 2>/dev/null || echo '{}')
 labels=$(jq -r '[.labels[].name? | select(. != "agent:ready")] | join(",")' <<<"$issue_meta" 2>/dev/null || true)

--- a/hooks/opencode/supervisor-loop.sh
+++ b/hooks/opencode/supervisor-loop.sh
@@ -230,16 +230,16 @@ auto_retry_stuck_workspaces() {
     [[ "$issue" =~ ^issue-[0-9]+$ ]] || continue
     status=$(status_of "$dir")
     [[ "$status" == "STUCK" ]] || continue
-    
+
     retry_count=0
     [[ -f "$dir/retry_count" ]] && retry_count=$(tr -d '[:space:]' <"$dir/retry_count")
     [[ "$retry_count" =~ ^[0-9]+$ ]] || retry_count=0
-    
+
     # Max retries per workspace
     if ((retry_count >= 3)); then
       continue
     fi
-    
+
     # Check cooldown since last stuck event or status change
     stuck_at_epoch=0
     if [[ -f "$dir/.autoship-event-STUCK.sent" ]]; then
@@ -247,14 +247,14 @@ auto_retry_stuck_workspaces() {
     elif [[ -f "$dir/status" ]]; then
       stuck_at_epoch=$(file_mtime_epoch "$dir/status")
     fi
-    
+
     if [[ "$stuck_at_epoch" =~ ^[0-9]+$ && "$stuck_at_epoch" -gt 0 ]]; then
       local elapsed=$((now - stuck_at_epoch))
       if ((elapsed < cooldown)); then
         continue
       fi
     fi
-    
+
     # Reset to QUEUED
     printf 'QUEUED\n' >"$dir/status"
     printf '%d\n' $((retry_count + 1)) >"$dir/retry_count"
@@ -271,6 +271,11 @@ run_hook_if_present() {
   elif [[ -f "$SCRIPT_DIR/$hook" ]]; then
     bash "$SCRIPT_DIR/$hook"
   fi
+}
+
+run_optional_hook_if_present() {
+  local hook="$1"
+  run_hook_if_present "$hook" || log_supervisor "optional hook failed hook=$hook"
 }
 
 dispatch_missing_queued_workspaces() {
@@ -331,6 +336,7 @@ supervisor_pass() {
   auto_retry_stuck_workspaces
   run_hook_if_present process-event-queue.sh
   run_hook_if_present reconcile-state.sh
+  run_optional_hook_if_present notify-discord.sh
   dispatch_missing_queued_workspaces
   run_hook_if_present runner.sh
   log_supervisor "pass finished"

--- a/hooks/opencode/supervisor-loop.sh
+++ b/hooks/opencode/supervisor-loop.sh
@@ -135,7 +135,7 @@ max_agents() {
 
 file_mtime_epoch() {
   local file="$1"
-  stat -f %m "$file" 2>/dev/null || stat -c %Y "$file" 2>/dev/null || printf '0\n'
+  stat -c %Y "$file" 2>/dev/null || stat -f %m "$file" 2>/dev/null || printf '0\n'
 }
 
 emit_report() {

--- a/hooks/opencode/test-policy.sh
+++ b/hooks/opencode/test-policy.sh
@@ -30,6 +30,29 @@ assert_file_contains() {
   grep -F "$text" "$file" >/dev/null || fail "$message"
 }
 
+copy_tracked_repo_fixture() {
+  local src="$1" dest="$2" file
+  mkdir -p "$dest"
+  while IFS= read -r file; do
+    [[ -n "$file" ]] || continue
+    mkdir -p "$dest/$(dirname "$file")"
+    cp "$src/$file" "$dest/$file"
+  done < <(git -C "$src" ls-files)
+}
+
+copy_package_fixture_without_local_artifacts() {
+  local src="$1" dest="$2" entry name
+  mkdir -p "$dest"
+  for entry in "$src"/* "$src"/.[!.]* "$src"/..?*; do
+    [[ -e "$entry" ]] || continue
+    name="$(basename "$entry")"
+    case "$name" in
+      . | .. | .git | .autoship | node_modules | .worktrees | .tmp | .archaeology) continue ;;
+    esac
+    cp -R "$entry" "$dest/"
+  done
+}
+
 assert_canonical_inventory() {
   local repo_root
   repo_root="$(cd "$SCRIPT_DIR/../.." && pwd)"
@@ -60,9 +83,9 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 if ! grep -E -A4 'actions/setup-node@v(4|6)' "$REPO_ROOT/.github/workflows/release.yml" | grep -Eq "node-version: ['\"]?(22|24)['\"]?"; then
   fail "release workflow must use Node 22 or 24 for semantic-release"
 fi
-grep -F '"$HOOKS_DIR/hermes"/*.sh' "$SCRIPT_DIR/check.sh" >/dev/null \
+grep -F "\"\$HOOKS_DIR/hermes\"/*.sh" "$SCRIPT_DIR/check.sh" >/dev/null \
   || fail "check.sh syntax check must include Hermes hooks"
-grep -F '"$HOOKS_DIR/hermes"/*.sh' "$SCRIPT_DIR/check.sh" | grep -F 'shellcheck' >/dev/null \
+grep -F "\"\$HOOKS_DIR/hermes\"/*.sh" "$SCRIPT_DIR/check.sh" | grep -F 'shellcheck' >/dev/null \
   || fail "check.sh shellcheck must include Hermes hooks"
 # Hermes runner must support both delegate_task mode (HERMES_SESSION_ID set)
 # and headless hermes chat mode (no session). The runner may execute workers
@@ -75,7 +98,7 @@ grep -F 'hermes chat' "$REPO_ROOT/hooks/hermes/runner.sh" >/dev/null \
 if grep -F 'hermes chat --worktree' "$REPO_ROOT/hooks/hermes/runner.sh" >/dev/null; then
   fail "Hermes runner must not pass --worktree when dispatch already prepared the target worktree"
 fi
-grep -F 'WORKSPACES_DIR="$AUTOSHIP_DIR/workspaces"' "$REPO_ROOT/hooks/hermes/runner.sh" >/dev/null \
+grep -F "WORKSPACES_DIR=\"\$AUTOSHIP_DIR/workspaces\"" "$REPO_ROOT/hooks/hermes/runner.sh" >/dev/null \
   || fail "Hermes runner must keep orchestration status under AutoShip workspaces"
 if grep -F 'python3 -c "import os,time; st=os.stat(' "$REPO_ROOT/hooks/hermes/runner.sh" >/dev/null; then
   fail "Hermes runner must pass log paths to Python safely"
@@ -83,10 +106,10 @@ fi
 if grep -F 'COMPLETE | BLOCKED | STUCK | unknown)' "$REPO_ROOT/hooks/hermes/cleanup-worktrees.sh" >/dev/null; then
   fail "Hermes cleanup must not delete retryable STUCK workspaces"
 fi
-if grep -F 'PLUGIN_URL="file://$PLUGIN_DEST"' "$REPO_ROOT/hooks/opencode/install.sh" >/dev/null; then
+if grep -F "PLUGIN_URL=\"file://\$PLUGIN_DEST\"" "$REPO_ROOT/hooks/opencode/install.sh" >/dev/null; then
   fail "source install must not register copied plugin with broken relative imports"
 fi
-if grep -F 'PLUGIN_URL="file://$REPO_ROOT/plugins/autoship.ts"' "$REPO_ROOT/hooks/opencode/install.sh" >/dev/null; then
+if grep -F "PLUGIN_URL=\"file://\$REPO_ROOT/plugins/autoship.ts\"" "$REPO_ROOT/hooks/opencode/install.sh" >/dev/null; then
   fail "source install must not register mutable checkout plugin paths"
 fi
 grep -F 'pathToFileURL' "$REPO_ROOT/hooks/opencode/install.sh" >/dev/null \
@@ -95,7 +118,7 @@ grep -F 'contains("autoship")) | not' "$REPO_ROOT/hooks/opencode/install.sh" >/d
   || fail "source install must remove legacy AutoShip file plugin registrations"
 grep -F '. != "opencode-autoship@latest"' "$REPO_ROOT/hooks/opencode/install.sh" >/dev/null \
   || fail "source install must remove legacy opencode-autoship@latest registrations"
-grep -F 'cp -R "$src/src" "$AUTOSHIP_HOME/src"' "$REPO_ROOT/hooks/opencode/sync-release.sh" >/dev/null \
+grep -F "cp -R \"\$src/src\" \"\$AUTOSHIP_HOME/src\"" "$REPO_ROOT/hooks/opencode/sync-release.sh" >/dev/null \
   || fail "source install must sync plugin source dependencies into config-owned assets"
 grep -F 'autoship:in-progress' "$REPO_ROOT/hooks/opencode/plan-issues.sh" >/dev/null \
   || fail "planner must skip AutoShip in-progress lifecycle labels"
@@ -111,9 +134,9 @@ grep -F 'resource-monitor.sh' "$REPO_ROOT/hooks/opencode/runner.sh" >/dev/null \
   || fail "runner must enforce resource monitor concurrency recommendations"
 grep -F 'runner.lock' "$REPO_ROOT/hooks/opencode/runner.sh" >/dev/null \
   || fail "runner must serialize queue scheduling with a lock"
-grep -F 'lockf -k "$LOCK_FILE"' "$REPO_ROOT/hooks/opencode/monitor-agents.sh" >/dev/null \
+grep -F "lockf -k \"\$LOCK_FILE\"" "$REPO_ROOT/hooks/opencode/monitor-agents.sh" >/dev/null \
   || fail "monitor must lock event queue writes on macOS"
-grep -F 'mktemp "$AUTOSHIP_DIR/event-queue.tmp.XXXXXX"' "$REPO_ROOT/hooks/opencode/monitor-agents.sh" >/dev/null \
+grep -F "mktemp \"\$AUTOSHIP_DIR/event-queue.tmp.XXXXXX\"" "$REPO_ROOT/hooks/opencode/monitor-agents.sh" >/dev/null \
   || fail "monitor must use unique event queue temp files"
 grep -F 'sanitize_issue_body' "$REPO_ROOT/hooks/opencode/dispatch.sh" >/dev/null \
   || fail "dispatcher must sanitize untrusted issue bodies"
@@ -129,7 +152,7 @@ grep -F 'exec 9>&-' "$REPO_ROOT/hooks/opencode/runner.sh" >/dev/null \
   || fail "runner workers must not inherit scheduler lock fd"
 grep -F 'tr -d' "$REPO_ROOT/hooks/opencode/monitor-agents.sh" | grep -F '\r\n' >/dev/null \
   || fail "monitor must normalize CRLF status reads"
-grep -F '&& mv "$tmp" "$EVENT_QUEUE"' "$REPO_ROOT/hooks/opencode/monitor-agents.sh" >/dev/null \
+grep -F "&& mv \"\$tmp\" \"\$EVENT_QUEUE\"" "$REPO_ROOT/hooks/opencode/monitor-agents.sh" >/dev/null \
   || fail "monitor must only replace event queue after successful jq write"
 grep -F 'env -i' "$REPO_ROOT/hooks/opencode/runner.sh" >/dev/null \
   || fail "runner must use an allowlisted worker environment"
@@ -226,8 +249,8 @@ cp "$REPO_ROOT/policies/textquest.json" "$TEXTQUEST_INSTALL/policies/textquest.j
 )
 
 test -f "$REPO_ROOT/commands/autoship-setup.md" || fail "canonical /autoship-setup command file is installed"
-grep -F '| `/autoship-setup` |' "$REPO_ROOT/README.md" >/dev/null || fail "README public command table includes /autoship-setup"
-grep -F '| `/autoship-setup` |' "$REPO_ROOT/commands/autoship.md" >/dev/null || fail "/autoship command table includes /autoship-setup"
+grep -F "| \`/autoship-setup\` |" "$REPO_ROOT/README.md" >/dev/null || fail "README public command table includes /autoship-setup"
+grep -F "| \`/autoship-setup\` |" "$REPO_ROOT/commands/autoship.md" >/dev/null || fail "/autoship command table includes /autoship-setup"
 
 ISSUES_FILE="$TMP_DIR/issues.json"
 cat >"$ISSUES_FILE" <<'JSON'
@@ -805,8 +828,7 @@ live_child_pid=$!
 _live_wait=0
 while [ "$_live_wait" -lt 50 ]; do
   kill -0 "$live_child_pid" 2>/dev/null \
-    && ps -axo command= 2>/dev/null \
-    | grep -F -q "$MONITOR_LIVE_CHILD_REPO/.autoship/workspaces/issue-999" \
+    && pgrep -f "$MONITOR_LIVE_CHILD_REPO/.autoship/workspaces/issue-999" >/dev/null \
     && break
   sleep 0.1
   _live_wait=$((_live_wait + 1))
@@ -942,12 +964,12 @@ test -f "$DISCORD_NOTIFY_REPO/.autoship/discord-notify-state.json" || fail "Disc
 rm -f "$DISCORD_NOTIFY_REPO/.autoship/discord-notify-state.json"
 (
   cd "$DISCORD_NOTIFY_REPO"
-  AUTOSHIP_DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/test/token" DISCORD_CAPTURE="$TMP_DIR/discord-failed-payload.json" DISCORD_CURL_EXIT=28 PATH="$DISCORD_NOTIFY_REPO/bin:$PATH" bash hooks/opencode/notify-discord.sh --force >/dev/null
+  AUTOSHIP_DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/test/token" DISCORD_CAPTURE="$TMP_DIR/discord-failed-payload.json" DISCORD_CURL_EXIT=28 PATH="$DISCORD_NOTIFY_REPO/bin:$PATH" bash hooks/opencode/notify-discord.sh --force >/dev/null || true
 )
 test ! -f "$DISCORD_NOTIFY_REPO/.autoship/discord-notify-state.json" || fail "Discord notifier does not checkpoint failed sends"
 (
   cd "$DISCORD_NOTIFY_REPO"
-  AUTOSHIP_DISCORD_WEBHOOK_URL="https://example.invalid/webhook" DISCORD_CAPTURE="$TMP_DIR/discord-invalid-payload.json" PATH="$DISCORD_NOTIFY_REPO/bin:$PATH" bash hooks/opencode/notify-discord.sh --force >/dev/null
+  AUTOSHIP_DISCORD_WEBHOOK_URL="https://example.invalid/webhook" DISCORD_CAPTURE="$TMP_DIR/discord-invalid-payload.json" PATH="$DISCORD_NOTIFY_REPO/bin:$PATH" bash hooks/opencode/notify-discord.sh --force >/dev/null || true
 )
 test ! -f "$DISCORD_NOTIFY_REPO/.autoship/discord-notify-state.json" || fail "Discord notifier does not checkpoint invalid webhook URLs"
 
@@ -1613,7 +1635,7 @@ printf '%s\n' "$formerly_blocked_line" | grep -F 'agent:ready' >/dev/null || fai
 SETUP_REPO="$TMP_DIR/setup-repo"
 mkdir -p "$SETUP_REPO/bin"
 mkdir -p "$SETUP_REPO/autoship"
-tar -C "$SCRIPT_DIR/../.." --exclude .git --exclude .autoship -cf - . | tar -C "$SETUP_REPO/autoship" -xf -
+copy_tracked_repo_fixture "$REPO_ROOT" "$SETUP_REPO/autoship"
 cat >"$SETUP_REPO/bin/opencode" <<'SH'
 #!/usr/bin/env bash
 if [[ "$1" == "models" ]]; then
@@ -2013,7 +2035,7 @@ chmod +x "$FIXTURE_REPO/bin/gh" "$FIXTURE_REPO/bin/opencode"
   printf 'live result\n' >"$live_workspace/AUTOSHIP_RESULT.md"
   printf 'runner log\n' >"$live_workspace/AUTOSHIP_RUNNER.log"
   printf 'COMPLETE\n' >"$live_workspace/status"
-  AUTOSHIP_ENABLE_PR_CREATE=true AUTOSHIP_GH_MUTATIONS_LOG="$FIXTURE_REPO/live-gh-mutations.log" PATH="$FIXTURE_REPO/bin:$PATH" bash hooks/opencode/create-pr.sh issue-191 "$live_workspace" >/dev/null
+  AUTOSHIP_ENABLE_PR_CREATE=true AUTOSHIP_SKIP_BRANCH_PUSH=true AUTOSHIP_GH_MUTATIONS_LOG="$FIXTURE_REPO/live-gh-mutations.log" PATH="$FIXTURE_REPO/bin:$PATH" bash hooks/opencode/create-pr.sh issue-191 "$live_workspace" >/dev/null
   git -C "$live_workspace" show --name-only --format= HEAD | grep -F 'implementation.txt' >/dev/null || fail "live PR path commits implementation changes"
   if git -C "$live_workspace" show --name-only --format= HEAD | grep -E 'AUTOSHIP_RESULT.md|AUTOSHIP_RUNNER.log|status' >/dev/null; then
     fail "live PR path must not commit AutoShip runtime artifacts"
@@ -2021,7 +2043,7 @@ chmod +x "$FIXTURE_REPO/bin/gh" "$FIXTURE_REPO/bin/opencode"
 )
 
 SYNC_REPO="$TMP_DIR/sync-release-repo"
-cp -R "$SCRIPT_DIR/../.." "$SYNC_REPO"
+copy_tracked_repo_fixture "$REPO_ROOT" "$SYNC_REPO"
 (
   cd "$SYNC_REPO"
   CONFIG_DIR="$TMP_DIR/sync-config"
@@ -2051,7 +2073,7 @@ cp -R "$SCRIPT_DIR/../.." "$SYNC_REPO"
 SELF_SYNC_CONFIG="$TMP_DIR/self-sync-config"
 SELF_AUTOSHIP_HOME="$SELF_SYNC_CONFIG/.autoship"
 mkdir -p "$SELF_SYNC_CONFIG"
-cp -R "$SCRIPT_DIR/../.." "$SELF_AUTOSHIP_HOME"
+copy_tracked_repo_fixture "$REPO_ROOT" "$SELF_AUTOSHIP_HOME"
 rm -rf "$SELF_AUTOSHIP_HOME/plugins"
 mkdir -p "$TMP_DIR/self-sync-plugin-target"
 printf 'external plugin\n' >"$TMP_DIR/self-sync-plugin-target/autoship.ts"
@@ -2062,7 +2084,7 @@ fi
 grep -F 'refusing to operate on symlinked path' "$TMP_DIR/self-sync-symlink.out" >/dev/null || fail "sync-release self-install reports symlinked plugin parent"
 
 PACKAGE_REPO="$TMP_DIR/package-repo"
-cp -R "$SCRIPT_DIR/../.." "$PACKAGE_REPO"
+copy_tracked_repo_fixture "$REPO_ROOT" "$PACKAGE_REPO"
 (
   cd "$PACKAGE_REPO"
   rm -rf .autoship node_modules dist
@@ -2114,7 +2136,7 @@ cp -R "$SCRIPT_DIR/../.." "$PACKAGE_REPO"
   fi
   grep -F 'Refusing to write symlinked OpenCode asset root' "$TMP_DIR/package-symlink-root.out" >/dev/null || fail "package installer reports symlinked .autoship root"
   ASSET_SYMLINK_REPO="$TMP_DIR/package-asset-symlink-repo"
-  cp -R . "$ASSET_SYMLINK_REPO"
+  copy_package_fixture_without_local_artifacts . "$ASSET_SYMLINK_REPO"
   rm -rf "$ASSET_SYMLINK_REPO/hooks"
   ln -s "$TMP_DIR" "$ASSET_SYMLINK_REPO/hooks"
   if OPENCODE_CONFIG_DIR="$TMP_DIR/package-asset-symlink-config" node "$ASSET_SYMLINK_REPO/dist/cli.js" install >"$TMP_DIR/package-symlink-src.out" 2>&1; then
@@ -2122,7 +2144,7 @@ cp -R "$SCRIPT_DIR/../.." "$PACKAGE_REPO"
   fi
   grep -F 'Refusing to copy symlinked package asset' "$TMP_DIR/package-symlink-src.out" >/dev/null || fail "package installer reports symlinked package asset"
   PACK_SYMLINK_REPO="$TMP_DIR/package-pack-symlink-repo"
-  cp -R . "$PACK_SYMLINK_REPO"
+  copy_package_fixture_without_local_artifacts . "$PACK_SYMLINK_REPO"
   rm "$PACK_SYMLINK_REPO/INSTALL.md"
   ln -s README.md "$PACK_SYMLINK_REPO/INSTALL.md"
   if (cd "$PACK_SYMLINK_REPO" && bash hooks/opencode/verify-package.sh >/dev/null 2>&1); then

--- a/hooks/opencode/validate-version-alignment.sh
+++ b/hooks/opencode/validate-version-alignment.sh
@@ -51,6 +51,10 @@ trim_file() {
   tr -d '[:space:]' <"$1"
 }
 
+normalize_version() {
+  printf '%s\n' "${1#v}"
+}
+
 record_mismatch() {
   failures+=("$1")
 }
@@ -71,8 +75,8 @@ else
   if [[ ! -f "$PACKAGE_FILE" ]]; then
     record_mismatch "package.json is missing"
   else
-    package_version="v$(jq -r '.version // empty' "$PACKAGE_FILE")"
-    if [[ "$package_version" != "$expected_version" ]]; then
+    package_version="$(jq -r '.version // empty' "$PACKAGE_FILE")"
+    if [[ "$(normalize_version "$package_version")" != "$(normalize_version "$expected_version")" ]]; then
       record_mismatch "package.json version $package_version does not match VERSION $expected_version"
     fi
   fi
@@ -93,7 +97,7 @@ else
       record_mismatch "installed asset marker $INSTALLED_VERSION_FILE is missing"
     else
       installed_version="$(trim_file "$INSTALLED_VERSION_FILE")"
-      if [[ "$installed_version" != "$expected_version" ]]; then
+      if [[ "$(normalize_version "$installed_version")" != "$(normalize_version "$expected_version")" ]]; then
         record_mismatch "installed asset marker $installed_version does not match VERSION $expected_version"
       fi
     fi
@@ -104,7 +108,7 @@ else
       record_mismatch "GitHub release tag marker $RELEASE_TAG_FILE is missing"
     else
       release_tag="$(trim_file "$RELEASE_TAG_FILE")"
-      if [[ "$release_tag" != "$expected_version" ]]; then
+      if [[ "$(normalize_version "$release_tag")" != "$(normalize_version "$expected_version")" ]]; then
         record_mismatch "GitHub release tag marker $release_tag does not match VERSION $expected_version"
       fi
     fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       "devDependencies": {
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/exec": "^7.1.0",
+        "@semantic-release/git": "^10.0.1",
         "@semantic-release/github": "^12.0.6",
         "@types/node": "^25.6.2",
         "typescript": "^6.0.3"
@@ -408,6 +409,155 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@semantic-release/git": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@semantic-release/git/-/git-10.0.1.tgz",
+      "integrity": "sha512-eWrx5KguUcU2wUPaO6sfvZI0wPafUKAMNC18aXY4EnNcrZL86dEmpNVnC9uMpGZkmZJ9EfCVJBQx4pV4EMGT1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@semantic-release/error": "^3.0.0",
+        "aggregate-error": "^3.0.0",
+        "debug": "^4.0.0",
+        "dir-glob": "^3.0.0",
+        "execa": "^5.0.0",
+        "lodash": "^4.17.4",
+        "micromatch": "^4.0.0",
+        "p-reduce": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.17"
+      },
+      "peerDependencies": {
+        "semantic-release": ">=18.0.0"
+      }
+    },
+    "node_modules/@semantic-release/git/node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/@semantic-release/git/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/git/node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/@semantic-release/git/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/git/node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@semantic-release/git/node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@semantic-release/git/node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/git/node_modules/p-reduce": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-2.1.0.tgz",
+      "integrity": "sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@semantic-release/git/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@semantic-release/git/node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@semantic-release/github": {
@@ -901,7 +1051,6 @@
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fill-range": "^7.1.1"
       },
@@ -1712,7 +1861,6 @@
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -2121,7 +2269,6 @@
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -2466,8 +2613,7 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -2475,7 +2621,6 @@
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"
@@ -4971,7 +5116,6 @@
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -5915,7 +6059,6 @@
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   "devDependencies": {
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/exec": "^7.1.0",
+    "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^12.0.6",
     "@types/node": "^25.6.2",
     "typescript": "^6.0.3"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -309,7 +309,9 @@ async function doctor() {
 
   try {
     const assetVersion = (await readFile(join(autoshipDir, "VERSION"), "utf8")).trim();
-    if (assetVersion === VERSION) {
+    const normalizedAssetVersion = assetVersion.replace(/^v/, "");
+    const normalizedPackageVersion = VERSION.replace(/^v/, "");
+    if (normalizedAssetVersion === normalizedPackageVersion) {
       checks.push({ name: "asset-version", status: "PASS", message: `Installed assets match package ${VERSION}` });
     } else {
       checks.push({ name: "asset-version", status: "FAIL", message: `Installed asset version ${assetVersion} does not match package ${VERSION}; run opencode-autoship install` });


### PR DESCRIPTION
## Summary
- Restores semantic-release GitHub release creation and release-artifact commits.
- Normalizes version comparisons so `2.12.1` and `v2.12.1` do not falsely fail doctor/version checks.
- Hardens policy/smoke fixtures and PR creation so local artifacts or fake remotes do not block the issue-to-PR loop.

## Test Plan
- `npm run typecheck`
- `npm run build`
- `npm run verify:pack`
- `bash hooks/opencode/check.sh`
- `bash -n hooks/opencode/*.sh hooks/*.sh hooks/hermes/*.sh`