### PR TITLE
docs: update release and Discord guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2.12.2](https://github.com/Maleick/AutoShip/compare/v2.12.1...v2.12.2) (2026-05-09)
+
+### Bug Fixes
+
+* **release:** respect protected main ([#397](https://github.com/Maleick/AutoShip/issues/397)) ([7cf9350](https://github.com/Maleick/AutoShip/commit/7cf9350660329098b9772a89e0a85b1786e61a2c))
+* **release:** restore GitHub release sync ([#396](https://github.com/Maleick/AutoShip/issues/396)) ([6ce807f](https://github.com/Maleick/AutoShip/commit/6ce807f9a6a4416ee06269ef42f585febb785274))
+
 ## [2.12.1](https://github.com/Maleick/AutoShip/compare/v2.12.0...v2.12.1) (2026-05-09)
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -139,6 +139,16 @@ Hermes-specific configuration:
 
 AutoShip also loads committed policy profiles from `policies/`. Policies enrich worker prompts, configure Rust cargo safeguards, guide overlap-aware dispatch, and enforce repo-specific hazards such as self-hosted GitHub Actions runners.
 
+### Discord Status Notifications
+
+AutoShip still includes Discord status notifications for the OpenCode supervisor loop. Set `AUTOSHIP_DISCORD_WEBHOOK_URL` in the shell or service environment that starts AutoShip:
+
+```bash
+export AUTOSHIP_DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/..."
+```
+
+The notifier is optional and non-blocking. If the webhook is missing or invalid, AutoShip continues dispatching and running workers.
+
 ## Defaults
 
 - **OpenCode** max active workers: `20`

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,175 +1,68 @@
-# Package Publish Checklist
+# Release Checklist
 
-Use this checklist from a clean checkout on the release branch. Commands are written so an agent can copy each block, run it, and stop on the first failure.
-
-## Inputs
-
-Set the release version once. `VERSION` includes the `v` prefix; `PACKAGE_VERSION` is plain semver for `package.json`, `package-lock.json`, and npm.
-
-```bash
-export VERSION=vX.Y.Z
-export PACKAGE_VERSION=${VERSION#v}
-```
+AutoShip releases are automated from protected `main` with semantic-release. Release commits must still go through pull requests; the release workflow publishes npm and creates the GitHub Release after a qualifying commit lands on `main`.
 
 ## Preflight
 
-Verify required tools and repository state before editing release files.
+Run from a clean checkout:
 
 ```bash
-test -n "$VERSION"
-test -n "$PACKAGE_VERSION"
-command -v git
-command -v gh
-command -v node
-command -v npm
 git status --short
 gh auth status
+npm view opencode-autoship version dist-tags.latest
+gh release list --limit 5
 ```
 
-The `git status --short` output should be empty, unless the only changes are intentional release edits.
+## Change Requirements
 
-## Update Release Files
+Use conventional commits so semantic-release can decide the next version:
 
-Update `VERSION`, `package.json`, and `package-lock.json` together.
+- `fix(...)` creates a patch release.
+- `feat(...)` creates a minor release.
+- Breaking changes create a major release.
+- `chore(...)` alone does not create a release.
 
-```bash
-printf '%s\n' "$VERSION" > VERSION
-npm version "$PACKAGE_VERSION" --no-git-tag-version
-test "$(cat VERSION)" = "$VERSION"
-node -e "const pkg=require('./package.json'); if (pkg.version !== process.env.PACKAGE_VERSION) { throw new Error(pkg.version + ' !== ' + process.env.PACKAGE_VERSION); }"
-node -e "const lock=require('./package-lock.json'); if (lock.version !== process.env.PACKAGE_VERSION || lock.packages[''].version !== process.env.PACKAGE_VERSION) { throw new Error('package-lock.json version mismatch'); }"
-```
+Do not add `@semantic-release/git` or any step that pushes release-artifact commits directly to `main`. Branch protection requires changes through pull requests.
 
-Update `CHANGELOG.md` manually so the top entry is `## $VERSION` and summarizes user-visible release changes. Then verify the heading exists.
+## Verify Before PR
 
 ```bash
-grep -n "^## $VERSION$" CHANGELOG.md
-```
-
-## Verify Before Packing
-
-Run the repository checks required for AutoShip changes.
-
-```bash
-bash hooks/opencode/test-policy.sh
-bash -n hooks/opencode/*.sh hooks/*.sh
-bash hooks/opencode/smoke-test.sh
 npm run typecheck
+npm run build
+npm run verify:pack
+bash hooks/opencode/check.sh
+bash -n hooks/opencode/*.sh hooks/*.sh hooks/hermes/*.sh
 ```
 
-## Npm Pack Dry-Run
+## Merge Flow
 
-Inspect the exact package contents without publishing.
+1. Push a feature/fix branch.
+2. Open a PR against `main`.
+3. Wait for the AutoShip checks to pass.
+4. Merge through GitHub.
+5. Wait for the `Release` workflow on `main`.
 
-```bash
-npm pack --json --dry-run > /tmp/opencode-autoship-pack.json
-node - <<'NODE'
-const fs = require('node:fs');
-const pack = JSON.parse(fs.readFileSync('/tmp/opencode-autoship-pack.json', 'utf8'))[0];
-const files = new Set(pack.files.map((file) => file.path));
-const required = [
-  'dist/index.js',
-  'dist/cli.js',
-  'INSTALL.md',
-  '.opencode/INSTALL.md',
-  'hooks/opencode/install.sh',
-  'commands/autoship.md',
-  'skills/autoship-orchestrate/SKILL.md',
-  'AGENTS.md',
-  'VERSION',
-  'README.md',
-  'LICENSE',
-];
-const missing = required.filter((file) => !files.has(file));
-if (missing.length) {
-  throw new Error(`Missing package files: ${missing.join(', ')}`);
-}
-console.log(`Verified ${required.length} required package files in ${pack.filename}`);
-NODE
-```
+## Release Workflow
 
-## Commit And Tag
-
-Commit the release edits and create the tag only after all verification passes.
-
-```bash
-git status --short
-git add VERSION package.json package-lock.json CHANGELOG.md
-git commit -m "chore: release $VERSION"
-git tag -a "$VERSION" -m "$VERSION"
-```
-
-## Publish Package
-
-Publish the npm package from the same commit used for the tag. This is the canonical package for the long-term global install path documented as `npm install -g opencode-autoship`.
+The workflow in `.github/workflows/release.yml` runs:
 
 ```bash
 npm ci
-npm publish --access public
+npm run build
+npm run verify:pack
+semantic-release
 ```
 
-If npm prompts with a browser authentication URL, complete the npm CLI auth flow and rerun `npm publish --access public`. If npm publish fails for any other reason, do not move the tag. Fix the release commit, retag only if the failed tag has not been pushed, and rerun verification.
-
-Remove local publish artifacts after publishing if they were created only for the release:
-
-```bash
-test -f package.json && test -d hooks/opencode
-rm -rf node_modules dist
-```
-
-`bunx opencode-autoship install` is the one-time/no-global path. It resolves the same npm package but does not leave the CLI installed on PATH.
-
-GitHub Packages may be used as a secondary registry for provenance, but public docs should keep npm as the primary install path unless the package is renamed/scoped for GitHub Packages.
-
-## GitHub Release
-
-Push the release commit and tag, then create the GitHub release from the changelog entry.
-
-```bash
-awk -v version="$VERSION" '
-  $0 == "## " version { capture=1; print; next }
-  capture && /^## / { exit }
-  capture { print }
-' CHANGELOG.md > /tmp/opencode-autoship-release-notes.md
-test -s /tmp/opencode-autoship-release-notes.md
-git push origin HEAD
-git push origin "$VERSION"
-gh release create "$VERSION" --title "$VERSION" --notes-file /tmp/opencode-autoship-release-notes.md
-```
-
-## Install Verification
-
-Verify the published package installs and exposes the expected version in a disposable directory.
-
-```bash
-tmpdir=$(mktemp -d)
-cd "$tmpdir"
-npm init -y
-npm install "opencode-autoship@$PACKAGE_VERSION"
-node -e "const fs=require('node:fs'); const pkg=JSON.parse(fs.readFileSync('node_modules/opencode-autoship/package.json', 'utf8')); if (pkg.version !== process.env.PACKAGE_VERSION) { throw new Error(pkg.version + ' !== ' + process.env.PACKAGE_VERSION); }"
-npx opencode-autoship --help
-cd -
-rm -rf "$tmpdir"
-```
-
-Verify the package installer copies the packaged assets.
-
-```bash
-config_dir=$(mktemp -d)
-OPENCODE_CONFIG_DIR="$config_dir" npx "opencode-autoship@$PACKAGE_VERSION" install
-test "$(cat "$config_dir/.autoship/VERSION")" = "$VERSION"
-rm -rf "$config_dir"
-```
+Semantic-release publishes to npm with provenance and creates the GitHub Release through `@semantic-release/github`. The tracked `CHANGELOG.md`, `VERSION`, `package.json`, and `package-lock.json` may be updated manually by follow-up PRs when needed, but the canonical published release notes are the GitHub Release notes.
 
 ## Final Checks
 
-Confirm the tag, GitHub release, and npm package agree.
+Confirm the GitHub Release and npm package agree:
 
 ```bash
-git rev-parse "$VERSION"
-gh release view "$VERSION"
-npm view "opencode-autoship@$PACKAGE_VERSION" version
-npm view opencode-autoship dist-tags --json
+gh release list --limit 5
+npm view opencode-autoship version dist-tags.latest
+gh run list --limit 5 --json databaseId,workflowName,displayTitle,status,conclusion,url
 ```
 
-The release is complete when all final checks report `$VERSION` or `$PACKAGE_VERSION` as appropriate.
+The release is complete when the latest GitHub Release tag and npm `latest` version match, and the `Release` workflow completed successfully.

--- a/wiki/Configuration.md
+++ b/wiki/Configuration.md
@@ -153,3 +153,13 @@ bash hooks/opencode/setup.sh --no-tui --refresh-models
 ```
 
 Manual edits to `.autoship/model-routing.json` are preserved by default.
+
+## Discord Status Notifications
+
+Discord status notifications are optional and are still included for the OpenCode supervisor loop. Configure an incoming Discord webhook URL in the environment that starts AutoShip:
+
+```bash
+export AUTOSHIP_DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/..."
+```
+
+The webhook URL is intentionally environment-only so it is not copied into worker worktrees or committed runtime state. Notification failures are non-blocking; the supervisor logs them and continues dispatching work.


### PR DESCRIPTION
## Summary
- Add the published v2.12.2 release notes to the tracked changelog.
- Update release docs for protected-main semantic-release flow.
- Document optional Discord status webhook setup in README and wiki configuration.

## Test Plan
- `git diff --check`
- `bash hooks/opencode/check.sh --syntax`
- `bash hooks/opencode/check.sh --policy`