### PR TITLE
feat: persist Discord webhook in setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,11 +141,13 @@ AutoShip also loads committed policy profiles from `policies/`. Policies enrich 
 
 ### Discord Status Notifications
 
-AutoShip still includes Discord status notifications for the OpenCode supervisor loop. Set `AUTOSHIP_DISCORD_WEBHOOK_URL` in the shell or service environment that starts AutoShip:
+AutoShip still includes Discord status notifications for the OpenCode supervisor loop. `/autoship-setup` can persist the webhook to `~/.config/autoship/env` so it stays outside repo state:
 
 ```bash
-export AUTOSHIP_DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/..."
+bash hooks/opencode/setup.sh
 ```
+
+Paste the webhook at the silent `Discord webhook URL` prompt. Leave it blank to skip Discord notifications. The notifier reads the persisted file automatically; use `source ~/.config/autoship/env` only when running manual shell tests.
 
 The notifier is optional and non-blocking. If the webhook is missing or invalid, AutoShip continues dispatching and running workers.
 

--- a/docs/OPENCODE_INSTALL.md
+++ b/docs/OPENCODE_INSTALL.md
@@ -124,11 +124,13 @@ AutoShip maintains state in `.autoship/`:
 
 AutoShip can post status summaries to a Discord incoming webhook from the supervisor loop.
 
-Configure the webhook URL with an environment variable so the secret is not copied into worker worktrees:
+Configure the webhook URL through setup so the secret is written to the user env file instead of project state:
 
 ```bash
-export AUTOSHIP_DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/..."
+bash hooks/opencode/setup.sh
 ```
+
+Paste the webhook at the silent prompt. Leave it blank to skip Discord notifications. The notifier reads the persisted file automatically; use `source ~/.config/autoship/env` only when running manual shell tests.
 
 Optionally configure the summary interval in project config:
 

--- a/docs/superpowers/plans/2026-05-09-discord-webhook-setup.md
+++ b/docs/superpowers/plans/2026-05-09-discord-webhook-setup.md
@@ -1,0 +1,86 @@
+# Discord Webhook Setup Wizard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add safe Discord webhook persistence to the OpenCode setup wizard without storing secrets in repo state.
+
+**Architecture:** `hooks/opencode/setup.sh` remains the single setup entrypoint. It validates Discord webhook URLs, writes them only to `~/.config/autoship/env` with restricted permissions, and prints masked status. Policy tests verify both persistence and non-leakage.
+
+**Tech Stack:** Bash, jq, existing OpenCode policy test harness, Markdown docs.
+
+---
+
+### Task 1: Policy Test
+
+**Files:**
+- Modify: `hooks/opencode/test-policy.sh`
+
+- [ ] **Step 1: Add assertions to the existing setup fixture**
+
+Add setup runs that pass `AUTOSHIP_DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/123456789/test_token` and assert:
+
+```bash
+test -f "$XDG_CONFIG_HOME/autoship/env" || fail "setup writes user env file for Discord webhook"
+grep -F 'AUTOSHIP_DISCORD_WEBHOOK_URL=' "$XDG_CONFIG_HOME/autoship/env" >/dev/null || fail "setup persists Discord webhook env var"
+test "$(stat -f %Lp "$XDG_CONFIG_HOME/autoship/env" 2>/dev/null || stat -c %a "$XDG_CONFIG_HOME/autoship/env")" = "600" || fail "Discord env file is private"
+! grep -R "$setup_discord_url" .autoship >/dev/null 2>&1 || fail "setup must not write Discord webhook to project state"
+```
+
+- [ ] **Step 2: Run policy to verify failure before implementation**
+
+Run: `bash hooks/opencode/check.sh --policy`
+Expected: FAIL because setup does not yet write the user env file.
+
+### Task 2: Setup Implementation
+
+**Files:**
+- Modify: `hooks/opencode/setup.sh`
+- Modify: `hooks/opencode/notify-discord.sh`
+
+- [ ] **Step 1: Add options and helpers**
+
+Add `AUTOSHIP_DISCORD_WEBHOOK_URL`, URL validation, env-file path resolution, and private file writing. Do not add a CLI flag that accepts the webhook as an argument.
+
+- [ ] **Step 2: Add interactive prompt**
+
+When interactive, prompt `Discord webhook URL [leave blank to skip]:` with `read -rs` so the pasted webhook is not echoed.
+
+- [ ] **Step 3: Wire persistence**
+
+Persist valid webhook URLs to `${XDG_CONFIG_HOME:-$HOME/.config}/autoship/env`; never write them to `.autoship/config.json` or curl temp files.
+
+- [ ] **Step 4: Run policy to verify pass**
+
+Run: `bash hooks/opencode/check.sh --policy`
+Expected: PASS.
+
+### Task 3: Docs
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/OPENCODE_INSTALL.md`
+- Modify: `wiki/Configuration.md`
+
+- [ ] **Step 1: Document wizard setup**
+
+Explain that `/autoship-setup` can persist the webhook to `~/.config/autoship/env`, the prompt is silent, and the notifier reads the persisted file automatically.
+
+- [ ] **Step 2: Run verification**
+
+Run:
+
+```bash
+npm run typecheck
+npm run build
+npm run verify:pack
+bash hooks/opencode/check.sh
+bash -n hooks/opencode/*.sh hooks/*.sh hooks/hermes/*.sh
+```
+
+Expected: all commands pass.
+
+### Self-Review
+
+- Spec coverage: setup persistence, validation, non-leakage, docs, and verification are covered.
+- Placeholder scan: no placeholders remain.
+- Type consistency: Bash variable names use `AUTOSHIP_DISCORD_WEBHOOK_URL` consistently with the notifier.

--- a/hooks/opencode/notify-discord.sh
+++ b/hooks/opencode/notify-discord.sh
@@ -25,6 +25,13 @@ CHECKPOINT_FILE="$AUTOSHIP_DIR/discord-notify-state.json"
 
 [[ -f "$STATE_FILE" ]] || exit 0
 
+env_file="${XDG_CONFIG_HOME:-$HOME/.config}/autoship/env"
+if [[ -z "${AUTOSHIP_DISCORD_WEBHOOK_URL:-}" && -f "$env_file" ]]; then
+  persisted_webhook=$(grep -E '^(export[[:space:]]+)?AUTOSHIP_DISCORD_WEBHOOK_URL=' "$env_file" 2>/dev/null | tail -n 1 || true)
+  persisted_webhook="${persisted_webhook#export }"
+  AUTOSHIP_DISCORD_WEBHOOK_URL="${persisted_webhook#AUTOSHIP_DISCORD_WEBHOOK_URL=}"
+fi
+
 webhook_url="${AUTOSHIP_DISCORD_WEBHOOK_URL:-}"
 [[ -n "$webhook_url" ]] || exit 0
 case "$webhook_url" in
@@ -71,12 +78,9 @@ content=$(printf 'AutoShip status for %s\nRunning: %s / Queued: %s / Verifying: 
   "$repo" "$running" "$queued" "$verifying" "$completed" "$blocked" "$stuck")
 payload=$(jq -n --arg content "$content" '{content: $content, allowed_mentions: {parse: []}}')
 
-curl_config=$(mktemp "$AUTOSHIP_DIR/discord-curl.tmp.XXXXXX")
-chmod 600 "$curl_config"
-trap 'rm -f "$curl_config"' EXIT
-printf 'url = "%s"\n' "$webhook_url" >"$curl_config"
-
-if ! curl -fsS --connect-timeout 5 --max-time 10 -H 'Content-Type: application/json' --data "$payload" --config "$curl_config" >/dev/null; then
+if ! curl -fsS --connect-timeout 5 --max-time 10 -H 'Content-Type: application/json' --data "$payload" --config - >/dev/null <<EOF; then
+url = "$webhook_url"
+EOF
   echo "Discord notification failed" >&2
   exit 1
 fi

--- a/hooks/opencode/setup.sh
+++ b/hooks/opencode/setup.sh
@@ -15,6 +15,7 @@ ORCHESTRATOR_MODEL="${AUTOSHIP_ORCHESTRATOR_MODEL:-}"
 REVIEWER_MODEL="${AUTOSHIP_REVIEWER_MODEL:-}"
 LEAD_MODEL="${AUTOSHIP_LEAD_MODEL:-}"
 LABELS="${AUTOSHIP_LABELS:-agent:ready}"
+DISCORD_WEBHOOK_URL="${AUTOSHIP_DISCORD_WEBHOOK_URL:-}"
 
 NO_TUI=0
 POSITIONAL=()
@@ -58,9 +59,60 @@ ENVIRONMENT VARIABLES:
   AUTOSHIP_REVIEWER_MODEL  Reviewer model (default: same as planner)
   AUTOSHIP_LEAD_MODEL    Lead model (default: same as planner)
   AUTOSHIP_LABELS          Comma-separated labels (default: agent:ready)
+  AUTOSHIP_DISCORD_WEBHOOK_URL Discord webhook URL to persist to user env file
   GH_TOKEN                 GitHub token (for gh auth)
 EOF
   exit "${1:-0}"
+}
+
+autoship_user_config_dir() {
+  if [[ -n "${XDG_CONFIG_HOME:-}" ]]; then
+    printf '%s/autoship\n' "$XDG_CONFIG_HOME"
+    return 0
+  fi
+  printf '%s/.config/autoship\n' "$HOME"
+}
+
+valid_discord_webhook_url() {
+  local url="$1"
+  [[ "$url" != *$'\n'* && "$url" != *$'\r'* ]] || return 1
+  [[ "$url" =~ ^https://discord(app)?\.com/api/webhooks/[0-9]+/[A-Za-z0-9._~-]+$ ]]
+}
+
+persist_discord_webhook() {
+  local webhook_url="$1" config_dir env_file old_umask tmp_file
+  [[ -n "$webhook_url" ]] || return 0
+  if ! valid_discord_webhook_url "$webhook_url"; then
+    echo "Error: invalid Discord webhook URL" >&2
+    exit 1
+  fi
+  config_dir=$(autoship_user_config_dir)
+  env_file="$config_dir/env"
+  mkdir -p "$config_dir"
+  chmod 700 "$config_dir"
+  tmp_file=$(mktemp "$config_dir/env.tmp.XXXXXX")
+  old_umask=$(umask)
+  umask 077
+  if [[ -f "$env_file" ]]; then
+    grep -vE '^(export[[:space:]]+)?AUTOSHIP_DISCORD_WEBHOOK_URL=' "$env_file" >"$tmp_file" || true
+  fi
+  printf 'export AUTOSHIP_DISCORD_WEBHOOK_URL=%s\n' "$webhook_url" >>"$tmp_file"
+  mv "$tmp_file" "$env_file"
+  umask "$old_umask"
+  chmod 600 "$env_file"
+  echo "Discord webhook: configured ($env_file)"
+  echo "Load it before starting AutoShip: source $env_file"
+}
+
+configure_discord_webhook() {
+  if [[ -z "$DISCORD_WEBHOOK_URL" && "$NO_TUI" -eq 0 && -t 0 ]]; then
+    printf 'Discord webhook URL [leave blank to skip]: ' >&2
+    if IFS= read -rs prompted_discord_webhook; then
+      printf '\n' >&2
+      [[ -n "$prompted_discord_webhook" ]] && DISCORD_WEBHOOK_URL="$prompted_discord_webhook"
+    fi
+  fi
+  persist_discord_webhook "$DISCORD_WEBHOOK_URL"
 }
 
 parse_args() {
@@ -214,6 +266,7 @@ if [[ -f "$ROUTING_FILE" && -z "$SELECTED_MODELS" && "$REFRESH_MODELS" != "1" &&
     echo "AutoShip OpenCode setup already configured"
     echo "Model routing preserved: $ROUTING_FILE"
     echo "Set --refresh-models to regenerate from current opencode models."
+    configure_discord_webhook
     exit 0
   fi
 fi
@@ -273,6 +326,13 @@ if [[ "$NO_TUI" -eq 0 && -t 0 ]]; then
   if IFS= read -r prompted_reviewer; then
     [[ -n "$prompted_reviewer" ]] && REVIEWER_MODEL="$prompted_reviewer"
   fi
+  if [[ -z "$DISCORD_WEBHOOK_URL" ]]; then
+    printf 'Discord webhook URL [leave blank to skip]: ' >&2
+    if IFS= read -rs prompted_discord_webhook; then
+      printf '\n' >&2
+      [[ -n "$prompted_discord_webhook" ]] && DISCORD_WEBHOOK_URL="$prompted_discord_webhook"
+    fi
+  fi
 fi
 
 reject_forbidden_models "$SELECTED_MODELS,$PLANNER_MODEL,$COORDINATOR_MODEL,$ORCHESTRATOR_MODEL,$REVIEWER_MODEL,$LEAD_MODEL"
@@ -295,6 +355,8 @@ if [[ -n "$missing_role_models" ]]; then
   printf '%s\n' "$missing_role_models" >&2
   exit 1
 fi
+
+persist_discord_webhook "$DISCORD_WEBHOOK_URL"
 
 python3 - "$ROUTING_FILE" "$CONFIG_FILE" "$SELECTED_MODELS" "$MAX_AGENTS" "$PLANNER_MODEL" "$COORDINATOR_MODEL" "$ORCHESTRATOR_MODEL" "$REVIEWER_MODEL" "$LEAD_MODEL" "$LABELS" <<'PY'
 import json

--- a/hooks/opencode/test-policy.sh
+++ b/hooks/opencode/test-policy.sh
@@ -962,6 +962,16 @@ jq -e '.content | contains("Running: 1") and contains("Queued: 1") and contains(
 jq -e '.allowed_mentions.parse == []' "$TMP_DIR/discord-payload.json" >/dev/null || fail "Discord notifier disables mentions"
 test -f "$DISCORD_NOTIFY_REPO/.autoship/discord-notify-state.json" || fail "Discord notifier records checkpoint state"
 rm -f "$DISCORD_NOTIFY_REPO/.autoship/discord-notify-state.json"
+DISCORD_CONFIG_HOME="$TMP_DIR/discord-config-home"
+mkdir -p "$DISCORD_CONFIG_HOME/autoship"
+printf 'export AUTOSHIP_DISCORD_WEBHOOK_URL=%s\n' "https://discord.com/api/webhooks/test/token" >"$DISCORD_CONFIG_HOME/autoship/env"
+chmod 600 "$DISCORD_CONFIG_HOME/autoship/env"
+(
+  cd "$DISCORD_NOTIFY_REPO"
+  env -u AUTOSHIP_DISCORD_WEBHOOK_URL XDG_CONFIG_HOME="$DISCORD_CONFIG_HOME" DISCORD_CAPTURE="$TMP_DIR/discord-persisted-payload.json" PATH="$DISCORD_NOTIFY_REPO/bin:$PATH" bash hooks/opencode/notify-discord.sh --force >/dev/null
+)
+jq -e '.content | contains("AutoShip status for owner/repo")' "$TMP_DIR/discord-persisted-payload.json" >/dev/null || fail "Discord notifier loads persisted webhook env file"
+rm -f "$DISCORD_NOTIFY_REPO/.autoship/discord-notify-state.json"
 (
   cd "$DISCORD_NOTIFY_REPO"
   AUTOSHIP_DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/test/token" DISCORD_CAPTURE="$TMP_DIR/discord-failed-payload.json" DISCORD_CURL_EXIT=28 PATH="$DISCORD_NOTIFY_REPO/bin:$PATH" bash hooks/opencode/notify-discord.sh --force >/dev/null || true
@@ -1664,6 +1674,9 @@ SH
 chmod +x "$SETUP_REPO/bin/opencode" "$SETUP_REPO/bin/gh"
 (
   cd "$SETUP_REPO/autoship"
+  export HOME="$SETUP_REPO/home"
+  export XDG_CONFIG_HOME="$HOME/.config"
+  mkdir -p "$HOME"
   rm -f config/model-routing.json .autoship/model-routing.json .autoship/config.json
   setup_output=$(PATH="$SETUP_REPO/bin:$PATH" bash hooks/opencode/setup.sh)
   test -f .autoship/.onboarded || fail "setup writes onboarding marker"
@@ -1679,6 +1692,25 @@ chmod +x "$SETUP_REPO/bin/opencode" "$SETUP_REPO/bin/gh"
   jq -e '.models[0].id == "opencode/nemotron-3-super-free" and .defaultFallback == "opencode/nemotron-3-super-free"' .autoship/model-routing.json >/dev/null || fail "setup ranks strongest free worker first"
   jq -e 'all(.models[]; (.id | startswith("openrouter/") | not))' .autoship/model-routing.json >/dev/null || fail "setup excludes OpenRouter models from live OpenCode list"
   jq -e 'any(.models[]; .id == "zen/some-free-model:free")' .autoship/model-routing.json >/dev/null || fail "setup includes free models from any live OpenCode provider"
+  discord_env_file="$XDG_CONFIG_HOME/autoship/env"
+  rm -f "$discord_env_file"
+  mkdir -p "$(dirname "$discord_env_file")"
+  printf 'export AUTOSHIP_KEEP_ME=1\n' >"$discord_env_file"
+  setup_discord_url="https://discord.com/api/webhooks/123456789/test_token"
+  setup_discord_output=$(AUTOSHIP_DISCORD_WEBHOOK_URL="$setup_discord_url" PATH="$SETUP_REPO/bin:$PATH" bash hooks/opencode/setup.sh --no-tui --refresh-models)
+  test -f "$discord_env_file" || fail "setup writes user env file for Discord webhook"
+  grep -F 'AUTOSHIP_DISCORD_WEBHOOK_URL=' "$discord_env_file" >/dev/null || fail "setup persists Discord webhook env var"
+  grep -F 'AUTOSHIP_KEEP_ME=1' "$discord_env_file" >/dev/null || fail "setup preserves other user env settings"
+  printf '%s\n' "$setup_discord_output" | grep -F "$setup_discord_url" >/dev/null && fail "setup output must not leak Discord webhook URL"
+  env_mode=$(stat -f %Lp "$discord_env_file" 2>/dev/null || stat -c %a "$discord_env_file")
+  test "$env_mode" = "600" || fail "Discord env file is private"
+  ! grep -R "$setup_discord_url" .autoship >/dev/null 2>&1 || fail "setup must not write Discord webhook to project state"
+  if AUTOSHIP_DISCORD_WEBHOOK_URL="https://example.invalid/webhook" PATH="$SETUP_REPO/bin:$PATH" bash hooks/opencode/setup.sh --no-tui >/dev/null 2>&1; then
+    fail "setup rejects invalid Discord webhook URL"
+  fi
+  if AUTOSHIP_DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/not-enough" PATH="$SETUP_REPO/bin:$PATH" bash hooks/opencode/setup.sh --no-tui >/dev/null 2>&1; then
+    fail "setup rejects malformed Discord webhook URL"
+  fi
   jq '.models = [{"id":"manual/model","cost":"selected","strength":99,"max_task_types":["docs"]}] | .defaultFallback = "manual/model"' .autoship/model-routing.json >.autoship/model-routing.json.tmp && mv .autoship/model-routing.json.tmp .autoship/model-routing.json
   PATH="$SETUP_REPO/bin:$PATH" bash hooks/opencode/setup.sh >/dev/null
   jq -e '.models[0].id == "manual/model"' .autoship/model-routing.json >/dev/null || fail "setup preserves manual model-routing edits by default"

--- a/hooks/opencode/test-policy.sh
+++ b/hooks/opencode/test-policy.sh
@@ -1702,7 +1702,7 @@ chmod +x "$SETUP_REPO/bin/opencode" "$SETUP_REPO/bin/gh"
   grep -F 'AUTOSHIP_DISCORD_WEBHOOK_URL=' "$discord_env_file" >/dev/null || fail "setup persists Discord webhook env var"
   grep -F 'AUTOSHIP_KEEP_ME=1' "$discord_env_file" >/dev/null || fail "setup preserves other user env settings"
   printf '%s\n' "$setup_discord_output" | grep -F "$setup_discord_url" >/dev/null && fail "setup output must not leak Discord webhook URL"
-  env_mode=$(stat -f %Lp "$discord_env_file" 2>/dev/null || stat -c %a "$discord_env_file")
+  env_mode=$(stat -c %a "$discord_env_file" 2>/dev/null || stat -f %Lp "$discord_env_file")
   test "$env_mode" = "600" || fail "Discord env file is private"
   ! grep -R "$setup_discord_url" .autoship >/dev/null 2>&1 || fail "setup must not write Discord webhook to project state"
   if AUTOSHIP_DISCORD_WEBHOOK_URL="https://example.invalid/webhook" PATH="$SETUP_REPO/bin:$PATH" bash hooks/opencode/setup.sh --no-tui >/dev/null 2>&1; then

--- a/wiki/Configuration.md
+++ b/wiki/Configuration.md
@@ -156,10 +156,12 @@ Manual edits to `.autoship/model-routing.json` are preserved by default.
 
 ## Discord Status Notifications
 
-Discord status notifications are optional and are still included for the OpenCode supervisor loop. Configure an incoming Discord webhook URL in the environment that starts AutoShip:
+Discord status notifications are optional and are still included for the OpenCode supervisor loop. Configure an incoming Discord webhook URL through setup so it is persisted outside repo state:
 
 ```bash
-export AUTOSHIP_DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/..."
+bash hooks/opencode/setup.sh
 ```
+
+Paste the webhook at the silent `Discord webhook URL` prompt. Leave it blank to skip Discord notifications. The notifier reads the persisted file automatically; use `source ~/.config/autoship/env` only when running manual shell tests.
 
 The webhook URL is intentionally environment-only so it is not copied into worker worktrees or committed runtime state. Notification failures are non-blocking; the supervisor logs them and continues dispatching work.


### PR DESCRIPTION
## Summary
- Add silent Discord webhook setup persistence to the OpenCode setup wizard
- Load persisted webhook config in the notifier without sourcing arbitrary env files or writing webhook temp files
- Document wizard-based webhook setup and cover persistence/non-leakage in policy tests

## Verification
- npm run typecheck
- npm run build
- npm run verify:pack
- bash hooks/opencode/check.sh
- bash -n hooks/opencode/*.sh hooks/*.sh hooks/hermes/*.sh