### PR TITLE
fix(dispatch): warn workers not to use rtk for cargo commands

### DIFF
--- a/hooks/opencode/dispatch.sh
+++ b/hooks/opencode/dispatch.sh
@@ -254,6 +254,7 @@ $BODY
 - Work only in this worktree: $FULL_WORKSPACE_PATH
 - Implement the issue per its acceptance criteria.
 - Run relevant project checks before finishing.
+- **CRITICAL**: Do NOT use `rtk` for cargo, rustc, or test commands. `rtk` filters output and hides errors. Use plain `cargo check`, `cargo clippy`, `cargo test` instead.
 - Commit changes on branch autoship/issue-$ISSUE_NUM.
 - Write AUTOSHIP_RESULT.md in the worktree.
 - Write COMPLETE, BLOCKED, or STUCK to $FULL_WORKSPACE_PATH/status.


### PR DESCRIPTION
Prevents workers from using rtk cargo clippy/rtk cargo test which filters out errors and makes fixes impossible. Workers should use plain cargo commands.