### PR TITLE
docs(troubleshooting): add key learnings from dispatch fixes

### DIFF
--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -76,6 +76,68 @@ bash hooks/opencode/runner.sh
 
 The runner starts queued work up to the configured active cap.
 
+### opencode run exits with code 128 (signal kill)
+
+If you see workers exiting immediately with code 128, `opencode run` is hanging or being killed by the system. This happens when:
+
+- The OpenCode CLI session is stale or cannot start nested runs
+- The selected model is not available or quota is exhausted
+- Resource limits (memory/CPU) are being hit
+
+**Fix:** Use `hermes session create --agent` instead of `opencode run`. The runner auto-detects Hermes and uses it when available. To force Hermes mode:
+
+```bash
+export AUTOSHIP_RUNTIME=hermes
+bash hooks/opencode/runner.sh
+```
+
+### Model routing returns empty (no free models found)
+
+If `select-model.sh` returns empty and workers fail to start, check `config/model-routing.json`:
+
+```bash
+cat config/model-routing.json | jq '.models[] | select(.cost == "free")'
+```
+
+The `select-model.sh` script filters for models with `"cost": "free"`. If your primary model (e.g., `kimi-k2.6`) has `"cost": "selected"` or another value, it will not be picked.
+
+**Fix:** Edit `config/model-routing.json` and set the cost field to `"free"` for your desired models, then copy to `.autoship/`:
+
+```bash
+# Edit config/model-routing.json, then:
+cp config/model-routing.json .autoship/model-routing.json
+```
+
+### Subagent timeout (900s) on complex issues
+
+Hermes `delegate_task` has a 900-second (15-minute) timeout. Complex Rust builds or multi-file refactors may exceed this.
+
+**Fix:** The subagent will commit whatever progress it has made. Check the worktree, finish compilation fixes manually if needed, then commit and push:
+
+```bash
+cd .worktrees/issue-NNNN
+cargo test --no-run  # check if it compiles
+git add -A
+git commit -m "feat: partial implementation (issue #NNNN)"
+git push origin autoship/issue-NNNN
+gh pr create --title "..." --body "Closes #NNNN"
+```
+
+### Pre-existing compilation errors block all PRs
+
+If `cargo test --no-run` fails on `main`/`master`, all dispatched workers will also fail because they branch from the broken base.
+
+**Fix:** Fix compilation on `main` first, then dispatch workers:
+
+```bash
+cd ~/Projects/TextQuest
+cargo test --no-run  # identify errors
+# Fix errors...
+git add -A
+git commit -m "fix: resolve compilation errors"
+git push origin main
+```
+
 ## Status looks stale
 
 Run:


### PR DESCRIPTION
Adds troubleshooting documentation for four critical issues discovered during recent TextQuest burn-down:

## Key Learnings Added

1. **opencode run exits with code 128** — Documented root cause (stale session, resource limits) and fix (use `hermes session create --agent`)

2. **Model routing returns empty** — Documented that `select-model.sh` filters for `cost == "free"`, so models with `cost: "selected"` are silently skipped

3. **Subagent 900s timeout** — Documented recovery procedure: check worktree, finish manually, commit/push/PR

4. **Pre-existing compilation errors** — Documented that broken `main` branch blocks all PRs; fix main first before dispatching

These learnings came from closing 10 TextQuest issues (#978, #1102, #1111, #1121, #1140, #1141, #1147, #1148, #1258, #1260) over the past 24 hours.